### PR TITLE
(hotfix) guard MEMORY_BASE #define

### DIFF
--- a/kernels/pto/include/kernel_utils.h
+++ b/kernels/pto/include/kernel_utils.h
@@ -8,7 +8,9 @@ for the full License text.
 */
 #pragma once
 
+#ifndef MEMORY_BASE
 #define MEMORY_BASE
+#endif
 #include <pto/pto-inst.hpp>
 #include <type_traits>
 


### PR DESCRIPTION
Fixes compilation warning when running `python tests/test_single_kernels.py --H-list 16,32,48,64`

```
In file included from /home/zouzias/github-repos/megagdn-pto/kernels/pto/tri_inverse.cpp:13:
In file included from /home/zouzias/github-repos/megagdn-pto/kernels/pto/tri_inverse_impl.cpp:15:
/home/zouzias/github-repos/megagdn-pto/kernels/pto/include/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.

```