### PR TITLE
Fix e2e triton crosscheck

### DIFF
--- a/kernels/triton_baseline/fla_vendor/SOURCES.md
+++ b/kernels/triton_baseline/fla_vendor/SOURCES.md
@@ -8,4 +8,6 @@ Also vendored (same tag) from [`vllm_ascend/ops/triton/triton_utils.py`](https:/
 
 Runtime still expects **`from vllm.triton_utils import tl, triton`** (vLLM’s Triton bindings for Ascend).
 
-**Local edits:** `solve_tril.py` — `extract_slice` / `insert_slice` import from `.ascend_triton_utils` instead of `vllm_ascend.ops.triton.triton_utils`.
+**Local edits:**
+`solve_tril.py` — `extract_slice` / `insert_slice` import from `.ascend_triton_utils` instead of `vllm_ascend.ops.triton.triton_utils`.
+`chunk.py` — only `chunk_gated_delta_rule_fwd` is kept (no distributed).

--- a/kernels/triton_baseline/fla_vendor/chunk.py
+++ b/kernels/triton_baseline/fla_vendor/chunk.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+# mypy: ignore-errors
+import warnings
+
+import torch
+from einops import rearrange
+# from vllm.distributed import get_pcp_group
+# from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
+
+from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
+# from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
+from .chunk_o import chunk_fwd_o
+# from .chunk_o_update import chunk_fwd_o_update
+from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from .cumsum import chunk_local_cumsum
+# from .l2norm import l2norm_fwd
+from .solve_tril import solve_tril
+from .utils import input_guard, prepare_final_chunk_indices
+from .wy_fast import recompute_w_u_fwd
+
+
+def chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.LongTensor | None = None,
+    prebuilt_meta=None,
+):
+    # forward_context = get_forward_context()
+    # num_decodes = 0
+    # attn_metadata = forward_context.attn_metadata
+    # if attn_metadata is not None and isinstance(attn_metadata, dict):
+    #     attn_metadata = next(iter(attn_metadata.values()), None)
+    # if attn_metadata is not None:
+    #     num_decodes = attn_metadata.num_decodes
+    chunk_size = 64
+    block_indices_cumsum = None if prebuilt_meta is None else prebuilt_meta.block_indices_cumsum
+    chunk_indices_chunk64 = None if prebuilt_meta is None else prebuilt_meta.chunk_indices_chunk64
+    chunk_offsets_chunk64 = None if prebuilt_meta is None else prebuilt_meta.chunk_offsets_chunk64
+    update_chunk_offsets_chunk64 = None if prebuilt_meta is None else prebuilt_meta.update_chunk_offsets_chunk64
+    final_chunk_indices_chunk64 = None if prebuilt_meta is None else prebuilt_meta.final_chunk_indices_chunk64
+    chunk_indices_large_block = None if prebuilt_meta is None else prebuilt_meta.chunk_indices_large_block
+    g = chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        block_indices=block_indices_cumsum,
+    )
+    # obtain WY representation. u is actually the new v.
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k,
+        beta=beta,
+        g_cumsum=g,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices_chunk64,
+        output_dtype=torch.float32,
+    )
+    A = solve_tril(
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_large_block=chunk_indices_large_block,
+        chunk_indices_bt=chunk_indices_chunk64,
+        output_dtype=k.dtype,
+    )
+    w, u = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g_cumsum=g,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices_chunk64,
+    )
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices_chunk64,
+        chunk_offsets=chunk_offsets_chunk64,
+    )
+
+    # if get_pcp_group().world_size > 1:
+    #     h_update = chunk_gated_delta_rule_fwd_hupdate(
+    #         k=k,
+    #         w=w,
+    #         u=u,
+    #         g=g,
+    #         cu_seqlens=cu_seqlens,
+    #         chunk_indices=chunk_indices_chunk64,
+    #         chunk_offsets=chunk_offsets_chunk64,
+    #         update_chunk_offsets=update_chunk_offsets_chunk64,
+    #         num_decodes=num_decodes,
+    #     )
+    #     all_final_state = get_pcp_group().all_gather(final_state.unsqueeze(0), 0)
+    #     final_chunk_indices = final_chunk_indices_chunk64
+    #     if final_chunk_indices is None:
+    #         final_chunk_indices = prepare_final_chunk_indices(cu_seqlens, chunk_size)
+    #     final_h_update = h_update[:, final_chunk_indices, :, :, :]
+    #     all_final_h_update = get_pcp_group().all_gather(final_h_update, 0)
+
+    #     updated_state = final_state.new_empty(get_pcp_group().world_size, *final_state.shape)
+    #     updated_state[0, ...] = all_final_state[0]
+    #     for i in range(1, get_pcp_group().world_size):
+    #         updated_final_state = all_final_state[i] + torch.matmul(
+    #             all_final_h_update[i, ...], updated_state[i - 1, ...]
+    #         )
+    #         updated_state[i, ...] = updated_final_state
+
+    #     final_state = updated_state[-1, ...]
+
+    #     if get_pcp_group().rank_in_group == 0:
+    #         updated_h_state = torch.zeros_like(final_state)
+    #     else:
+    #         updated_h_state = updated_state[get_pcp_group().rank_in_group - 1, ...]
+
+    #     h = chunk_fwd_o_update(
+    #         q=q,
+    #         v=v_new,
+    #         h=h,
+    #         h_update=h_update,
+    #         updated_h_state=updated_h_state,
+    #         cu_seqlens=cu_seqlens,
+    #     )
+
+    o = chunk_fwd_o(
+        q=q,
+        k=k,
+        v=v_new,
+        h=h,
+        g=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+    )
+
+    if SUPPRESS_LEVEL < 3:
+        return g, o, A, final_state, None, None, None
+    elif SUPPRESS_LEVEL >= 3:
+        return g, o, A, final_state, w, h, v_new
+
+
+# class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+#     @staticmethod
+#     @input_guard
+#     def forward(
+#         ctx,
+#         q: torch.Tensor,
+#         k: torch.Tensor,
+#         v: torch.Tensor,
+#         g: torch.Tensor,
+#         beta: torch.Tensor,
+#         scale: float,
+#         initial_state: torch.Tensor,
+#         output_final_state: bool,
+#         cu_seqlens: torch.LongTensor | None = None,
+#         prebuilt_meta=None,
+#         use_qk_l2norm_in_kernel: bool = False,
+#     ):
+#         if use_qk_l2norm_in_kernel:
+#             q = l2norm_fwd(q)
+#             k = l2norm_fwd(k)
+#         g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
+#             q=q,
+#             k=k,
+#             v=v,
+#             g=g,
+#             beta=beta,
+#             scale=scale,
+#             initial_state=initial_state,
+#             output_final_state=output_final_state,
+#             cu_seqlens=cu_seqlens,
+#             prebuilt_meta=prebuilt_meta,
+#         )
+#         ctx.scale = scale
+#         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+#         return o.to(q.dtype), final_state
+
+
+# @torch.compiler.disable
+# def chunk_gated_delta_rule(
+#     q: torch.Tensor,
+#     k: torch.Tensor,
+#     v: torch.Tensor,
+#     g: torch.Tensor,
+#     beta: torch.Tensor,
+#     scale: float = None,
+#     initial_state: torch.Tensor = None,
+#     output_final_state: bool = False,
+#     cu_seqlens: torch.LongTensor | None = None,
+#     prebuilt_meta=None,
+#     head_first: bool = False,
+#     use_qk_l2norm_in_kernel: bool = False,
+# ):
+#     r"""
+#     Args:
+#         q (torch.Tensor):
+#             queries of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+#         k (torch.Tensor):
+#             keys of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+#         v (torch.Tensor):
+#             values of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+#         g (torch.Tensor):
+#             (forget) gating tensor (in log space!) of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+#         beta (torch.Tensor):
+#             betas of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+#         scale (Optional[int]):
+#             Scale factor for the RetNet attention scores.
+#             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+#         initial_state (Optional[torch.Tensor]):
+#             Initial state of shape `[N, H, K, V]` for `N` input sequences.
+#             For equal-length input sequences, `N` equals the batch size `B`.
+#             Default: `None`.
+#         output_final_state (Optional[bool]):
+#             Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+#         cu_seqlens (torch.LongTensor):
+#             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+#             consistent with the FlashAttention API.
+#         head_first (Optional[bool]):
+#             Whether the inputs are in the head-first format, which is not supported for variable-length inputs.
+#             Default: `False`.
+
+#     Returns:
+#         o (torch.Tensor):
+#             Outputs of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+#         final_state (torch.Tensor):
+#             Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+
+#     Examples::
+#         >>> import torch
+#         >>> import torch.nn.functional as F
+#         >>> from einops import rearrange
+#         >>> from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+#         # inputs with equal lengths
+#         >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+#         >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+#         >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
+#         >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
+#         >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
+#         >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
+#         >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+#         >>> o, ht = chunk_gated_delta_rule(
+#             q, k, v, g, beta,
+#             initial_state=h0,
+#             output_final_state=True
+#         )
+#         # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+#         >>> q, k, v, beta, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, g))
+#         # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+#         >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+#         >>> o_var, ht_var = chunk_gated_delta_rule(
+#             q, k, v, g, beta,
+#             initial_state=h0,
+#             output_final_state=True,
+#             cu_seqlens=cu_seqlens
+#         )
+#     """
+#     assert q.dtype == k.dtype == v.dtype
+#     assert q.dtype != torch.float32, "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
+#     assert len(beta.shape) == 3, "beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
+
+#     if head_first:
+#         raise DeprecationWarning(
+#             "head_first is deprecated and will be removed in a future version. "
+#             "Please use head_first=False for now instead.",
+#             stacklevel=2,
+#         )
+#         q, k, v, beta, g = map(lambda x: rearrange(x, "b h t ... -> b t h ..."), (q, k, v, beta, g))
+#     if not head_first and q.shape[1] < q.shape[2]:
+#         warnings.warn(
+#             f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+#             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
+#             "when head_first=False was specified. "
+#             "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
+#             stacklevel=2,
+#         )
+#     if cu_seqlens is not None:
+#         if q.shape[0] != 1:
+#             raise ValueError(
+#                 f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+#                 f"Please flatten variable-length inputs before processing."
+#             )
+#         if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+#             raise ValueError(
+#                 f"The number of initial states is expected to be equal to the number of input sequences, "
+#                 f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
+#             )
+#     if scale is None:
+#         scale = k.shape[-1] ** -0.5
+#     o, final_state = ChunkGatedDeltaRuleFunction.apply(
+#         q,
+#         k,
+#         v,
+#         g,
+#         beta,
+#         scale,
+#         initial_state,
+#         output_final_state,
+#         cu_seqlens,
+#         prebuilt_meta,
+#         use_qk_l2norm_in_kernel,
+#     )
+#     if head_first:
+#         o = rearrange(o, "b t h ... -> b h t ...")
+#     return o, final_state

--- a/kernels/triton_baseline/fla_vendor/chunk.py
+++ b/kernels/triton_baseline/fla_vendor/chunk.py
@@ -12,19 +12,13 @@ import warnings
 
 import torch
 from einops import rearrange
-# from vllm.distributed import get_pcp_group
-# from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fla.ops.utils import SUPPRESS_LEVEL
 
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
-# from .chunk_delta_hupdate import chunk_gated_delta_rule_fwd_hupdate
 from .chunk_o import chunk_fwd_o
-# from .chunk_o_update import chunk_fwd_o_update
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
-# from .l2norm import l2norm_fwd
 from .solve_tril import solve_tril
-from .utils import input_guard, prepare_final_chunk_indices
 from .wy_fast import recompute_w_u_fwd
 
 
@@ -40,19 +34,10 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: torch.LongTensor | None = None,
     prebuilt_meta=None,
 ):
-    # forward_context = get_forward_context()
-    # num_decodes = 0
-    # attn_metadata = forward_context.attn_metadata
-    # if attn_metadata is not None and isinstance(attn_metadata, dict):
-    #     attn_metadata = next(iter(attn_metadata.values()), None)
-    # if attn_metadata is not None:
-    #     num_decodes = attn_metadata.num_decodes
     chunk_size = 64
     block_indices_cumsum = None if prebuilt_meta is None else prebuilt_meta.block_indices_cumsum
     chunk_indices_chunk64 = None if prebuilt_meta is None else prebuilt_meta.chunk_indices_chunk64
     chunk_offsets_chunk64 = None if prebuilt_meta is None else prebuilt_meta.chunk_offsets_chunk64
-    update_chunk_offsets_chunk64 = None if prebuilt_meta is None else prebuilt_meta.update_chunk_offsets_chunk64
-    final_chunk_indices_chunk64 = None if prebuilt_meta is None else prebuilt_meta.final_chunk_indices_chunk64
     chunk_indices_large_block = None if prebuilt_meta is None else prebuilt_meta.chunk_indices_large_block
     g = chunk_local_cumsum(
         g,
@@ -97,49 +82,6 @@ def chunk_gated_delta_rule_fwd(
         chunk_offsets=chunk_offsets_chunk64,
     )
 
-    # if get_pcp_group().world_size > 1:
-    #     h_update = chunk_gated_delta_rule_fwd_hupdate(
-    #         k=k,
-    #         w=w,
-    #         u=u,
-    #         g=g,
-    #         cu_seqlens=cu_seqlens,
-    #         chunk_indices=chunk_indices_chunk64,
-    #         chunk_offsets=chunk_offsets_chunk64,
-    #         update_chunk_offsets=update_chunk_offsets_chunk64,
-    #         num_decodes=num_decodes,
-    #     )
-    #     all_final_state = get_pcp_group().all_gather(final_state.unsqueeze(0), 0)
-    #     final_chunk_indices = final_chunk_indices_chunk64
-    #     if final_chunk_indices is None:
-    #         final_chunk_indices = prepare_final_chunk_indices(cu_seqlens, chunk_size)
-    #     final_h_update = h_update[:, final_chunk_indices, :, :, :]
-    #     all_final_h_update = get_pcp_group().all_gather(final_h_update, 0)
-
-    #     updated_state = final_state.new_empty(get_pcp_group().world_size, *final_state.shape)
-    #     updated_state[0, ...] = all_final_state[0]
-    #     for i in range(1, get_pcp_group().world_size):
-    #         updated_final_state = all_final_state[i] + torch.matmul(
-    #             all_final_h_update[i, ...], updated_state[i - 1, ...]
-    #         )
-    #         updated_state[i, ...] = updated_final_state
-
-    #     final_state = updated_state[-1, ...]
-
-    #     if get_pcp_group().rank_in_group == 0:
-    #         updated_h_state = torch.zeros_like(final_state)
-    #     else:
-    #         updated_h_state = updated_state[get_pcp_group().rank_in_group - 1, ...]
-
-    #     h = chunk_fwd_o_update(
-    #         q=q,
-    #         v=v_new,
-    #         h=h,
-    #         h_update=h_update,
-    #         updated_h_state=updated_h_state,
-    #         cu_seqlens=cu_seqlens,
-    #     )
-
     o = chunk_fwd_o(
         q=q,
         k=k,
@@ -154,168 +96,3 @@ def chunk_gated_delta_rule_fwd(
         return g, o, A, final_state, None, None, None
     elif SUPPRESS_LEVEL >= 3:
         return g, o, A, final_state, w, h, v_new
-
-
-# class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
-#     @staticmethod
-#     @input_guard
-#     def forward(
-#         ctx,
-#         q: torch.Tensor,
-#         k: torch.Tensor,
-#         v: torch.Tensor,
-#         g: torch.Tensor,
-#         beta: torch.Tensor,
-#         scale: float,
-#         initial_state: torch.Tensor,
-#         output_final_state: bool,
-#         cu_seqlens: torch.LongTensor | None = None,
-#         prebuilt_meta=None,
-#         use_qk_l2norm_in_kernel: bool = False,
-#     ):
-#         if use_qk_l2norm_in_kernel:
-#             q = l2norm_fwd(q)
-#             k = l2norm_fwd(k)
-#         g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
-#             q=q,
-#             k=k,
-#             v=v,
-#             g=g,
-#             beta=beta,
-#             scale=scale,
-#             initial_state=initial_state,
-#             output_final_state=output_final_state,
-#             cu_seqlens=cu_seqlens,
-#             prebuilt_meta=prebuilt_meta,
-#         )
-#         ctx.scale = scale
-#         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
-#         return o.to(q.dtype), final_state
-
-
-# @torch.compiler.disable
-# def chunk_gated_delta_rule(
-#     q: torch.Tensor,
-#     k: torch.Tensor,
-#     v: torch.Tensor,
-#     g: torch.Tensor,
-#     beta: torch.Tensor,
-#     scale: float = None,
-#     initial_state: torch.Tensor = None,
-#     output_final_state: bool = False,
-#     cu_seqlens: torch.LongTensor | None = None,
-#     prebuilt_meta=None,
-#     head_first: bool = False,
-#     use_qk_l2norm_in_kernel: bool = False,
-# ):
-#     r"""
-#     Args:
-#         q (torch.Tensor):
-#             queries of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
-#         k (torch.Tensor):
-#             keys of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
-#         v (torch.Tensor):
-#             values of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
-#         g (torch.Tensor):
-#             (forget) gating tensor (in log space!) of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
-#         beta (torch.Tensor):
-#             betas of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
-#         scale (Optional[int]):
-#             Scale factor for the RetNet attention scores.
-#             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
-#         initial_state (Optional[torch.Tensor]):
-#             Initial state of shape `[N, H, K, V]` for `N` input sequences.
-#             For equal-length input sequences, `N` equals the batch size `B`.
-#             Default: `None`.
-#         output_final_state (Optional[bool]):
-#             Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
-#         cu_seqlens (torch.LongTensor):
-#             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
-#             consistent with the FlashAttention API.
-#         head_first (Optional[bool]):
-#             Whether the inputs are in the head-first format, which is not supported for variable-length inputs.
-#             Default: `False`.
-
-#     Returns:
-#         o (torch.Tensor):
-#             Outputs of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
-#         final_state (torch.Tensor):
-#             Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
-
-#     Examples::
-#         >>> import torch
-#         >>> import torch.nn.functional as F
-#         >>> from einops import rearrange
-#         >>> from fla.ops.gated_delta_rule import chunk_gated_delta_rule
-#         # inputs with equal lengths
-#         >>> B, T, H, K, V = 4, 2048, 4, 512, 512
-#         >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
-#         >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
-#         >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
-#         >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
-#         >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
-#         >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
-#         >>> o, ht = chunk_gated_delta_rule(
-#             q, k, v, g, beta,
-#             initial_state=h0,
-#             output_final_state=True
-#         )
-#         # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
-#         >>> q, k, v, beta, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, g))
-#         # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
-#         >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
-#         >>> o_var, ht_var = chunk_gated_delta_rule(
-#             q, k, v, g, beta,
-#             initial_state=h0,
-#             output_final_state=True,
-#             cu_seqlens=cu_seqlens
-#         )
-#     """
-#     assert q.dtype == k.dtype == v.dtype
-#     assert q.dtype != torch.float32, "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
-#     assert len(beta.shape) == 3, "beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
-
-#     if head_first:
-#         raise DeprecationWarning(
-#             "head_first is deprecated and will be removed in a future version. "
-#             "Please use head_first=False for now instead.",
-#             stacklevel=2,
-#         )
-#         q, k, v, beta, g = map(lambda x: rearrange(x, "b h t ... -> b t h ..."), (q, k, v, beta, g))
-#     if not head_first and q.shape[1] < q.shape[2]:
-#         warnings.warn(
-#             f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
-#             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
-#             "when head_first=False was specified. "
-#             "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
-#             stacklevel=2,
-#         )
-#     if cu_seqlens is not None:
-#         if q.shape[0] != 1:
-#             raise ValueError(
-#                 f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
-#                 f"Please flatten variable-length inputs before processing."
-#             )
-#         if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
-#             raise ValueError(
-#                 f"The number of initial states is expected to be equal to the number of input sequences, "
-#                 f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
-#             )
-#     if scale is None:
-#         scale = k.shape[-1] ** -0.5
-#     o, final_state = ChunkGatedDeltaRuleFunction.apply(
-#         q,
-#         k,
-#         v,
-#         g,
-#         beta,
-#         scale,
-#         initial_state,
-#         output_final_state,
-#         cu_seqlens,
-#         prebuilt_meta,
-#         use_qk_l2norm_in_kernel,
-#     )
-#     if head_first:
-#         o = rearrange(o, "b t h ... -> b h t ...")
-#     return o, final_state

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -46,6 +46,7 @@ from megagdn_pto.kernel_libs import (
     transpose_gates,
 )
 from tests.test_single_kernels import (
+    ref_solve_tril,
     ref_chunk_h,
     ref_chunk_o,
     ref_cumsum,
@@ -63,32 +64,6 @@ D = 128
 MAX_RMSE_CROSS = 0.02
 MIN_R2_CROSS = 0.999
 MIN_PEARSON_CROSS = 0.999
-
-
-# ---------------------------------------------------------------------------
-# CPU reference for solve_tril
-# ---------------------------------------------------------------------------
-
-def ref_solve_tril(A: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
-    """CPU fp64 reference for the triangular inverse (solve_tril) stage.
-
-    For each chunk block of shape ``[v, v]`` (per head), computes
-    ``inv(A^T + I)^T`` which matches the ``fast_inverse`` kernel convention.
-    """
-    A64 = A.detach().cpu().double()
-    out = torch.zeros_like(A64)
-    for bos, eos in _seq_ranges(A.shape[1], cu_seqlens):
-        for chunk_start in range(bos, eos, cs):
-            v = min(cs, eos - chunk_start)
-            block = A64[:, chunk_start:chunk_start + v, :, :v]  # [1, v, H, v]
-            eye = torch.eye(v, dtype=torch.float64)
-            # inv(A^T + I)^T per head
-            # block: [1, v, H, v] — treat as [H, v, v] for batched inv
-            b = block[0].permute(1, 0, 2)  # [H, v, v]
-            b_t = b.transpose(1, 2) + eye.unsqueeze(0)  # [H, v, v]
-            inv_b = torch.linalg.inv(b_t).transpose(1, 2)  # [H, v, v]
-            out[0, chunk_start:chunk_start + v, :, :v] = inv_b.permute(1, 0, 2)
-    return out.to(dtype=A.dtype)
 
 
 # ---------------------------------------------------------------------------
@@ -182,40 +157,9 @@ def _triton_available() -> bool:
 
 def triton_pipeline(q, k, v, g_in, beta, cu_long, H, Hg, scale=1.0):
     """Full six-stage Triton pipeline (C=64, bf16)."""
-    from fla_vendor.chunk_delta_h import chunk_gated_delta_rule_fwd_h
-    from fla_vendor.chunk_o import chunk_fwd_o
-    from fla_vendor.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
-    from fla_vendor.cumsum import chunk_local_cumsum
-    from fla_vendor.solve_tril import solve_tril as triton_solve_tril
-    from fla_vendor.utils import prepare_chunk_indices, prepare_chunk_offsets
-    from fla_vendor.wy_fast import recompute_w_u_fwd
+    from fla_vendor.chunk import chunk_gated_delta_rule_fwd
 
-    chunk_indices = prepare_chunk_indices(cu_long, C_TRITON)
-    chunk_offsets = prepare_chunk_offsets(cu_long, C_TRITON)
-
-    q_bf = q.bfloat16()
-    k_bf = k.bfloat16()
-    v_bf = v.bfloat16()
-    beta_bf = beta.bfloat16()
-    g_f32 = g_in.float()
-
-    g_cs = chunk_local_cumsum(g_f32, cu_seqlens=cu_long, chunk_size=C_TRITON,
-                               chunk_indices=chunk_indices)
-    A_tri = chunk_scaled_dot_kkt_fwd(k=k_bf, beta=beta_bf, g_cumsum=g_cs,
-                                     cu_seqlens=cu_long, chunk_indices=chunk_indices,
-                                     chunk_size=C_TRITON, output_dtype=torch.float32)
-    A_inv_tri = triton_solve_tril(A_tri.half(), cu_seqlens=cu_long)
-    w_tri, u_tri = recompute_w_u_fwd(k=k_bf, v=v_bf, beta=beta_bf, g_cumsum=g_cs,
-                                     A=A_inv_tri.bfloat16(), cu_seqlens=cu_long,
-                                     chunk_indices=chunk_indices)
-    h_tri, v_new_tri, _ = chunk_gated_delta_rule_fwd_h(
-        k=k_bf, w=w_tri, u=u_tri, g=g_f32,
-        initial_state=None, output_final_state=False,
-        cu_seqlens=cu_long, chunk_indices=chunk_indices, chunk_offsets=chunk_offsets,
-        chunk_size=C_TRITON,
-    )
-    o_tri = chunk_fwd_o(q=q_bf, k=k_bf, v=v_new_tri, h=h_tri, g=g_f32,
-                        scale=scale, cu_seqlens=cu_long, chunk_size=C_TRITON)
+    _, o_tri, _, _, _, _, _ = chunk_gated_delta_rule_fwd(q, k, v, g_in, beta, scale, None, None, cu_long)
     torch.npu.synchronize()
     return o_tri.float()
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -55,6 +55,7 @@ from tests.test_single_kernels import (
     _seq_ranges,
     stats_ok,
 )
+from megagdn_pto.mega_kernel import run_mega_kernel
 
 C_PTO = 128
 C_TRITON = 64
@@ -229,7 +230,17 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
         g_in.cpu(), beta.cpu().float(), cu_cpu, H, Hg, scale,
     )
 
+    # PTO mega kernel
+    o_mega = run_mega_kernel(
+        q, k, v, g_in, beta, cu32,
+        stream=torch.npu.current_stream()._as_parameter_,
+        chunk_size=C_PTO,
+        scale=scale,
+        key_heads=Hg,
+    )
+
     ok_pto = stats_ok(o_pto.float().cpu(), o_cpu)
+    ok_mega = stats_ok(o_mega.float().cpu(), o_cpu)
 
     ok_cross = True
     if triton_ok:
@@ -241,7 +252,7 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
             print(f"    [Triton skipped: {str(e).split(chr(10))[0][:80]}]")
             ok_cross = True  # not a failure, triton may not support all shapes
 
-    return ok_pto and ok_cross, label, ok_pto, ok_cross
+    return ok_pto and ok_cross and ok_mega, label, ok_pto, ok_cross, ok_mega
 
 
 def main() -> None:
@@ -269,13 +280,13 @@ def main() -> None:
         assert H % Hg == 0
         print(f"\n{'='*60}\nH={H}  Hg={Hg}\n{'='*60}")
         for T_or_cu, T_total in TEST_SHAPES:
-            ok, label, ok_pto, ok_cross = run_one(
+            ok, label, ok_pto, ok_cross, ok_mega = run_one(
                 T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok)
             if not ok:
                 all_pass = False
             cross_str = f"  cross={'PASS' if ok_cross else 'FAIL'}" if triton_ok else ""
             status = "PASS" if ok else "FAIL"
-            print(f"  {status}  {label}  pto_vs_cpu={'PASS' if ok_pto else 'FAIL'}{cross_str}")
+            print(f"  {status}  {label}  pto_vs_cpu={'PASS' if ok_pto else 'FAIL'}  mega_vs_cpu={'PASS' if ok_mega else 'FAIL'}{cross_str}")
 
     print(f"\n{'ALL PASS' if all_pass else 'SOME FAILED'}")
     sys.exit(0 if all_pass else 1)


### PR DESCRIPTION
Using the triton layer from https://github.com/vllm-project/vllm-ascend/tree/v0.18.0rc1/vllm_ascend/ops/triton/fla, fixes the triton crosschecks.

Log:
```
Device: npu:0  Hg=16  D=128  C_PTO=128  C_TRITON=64
Triton cross-check: enabled

============================================================
H=32  Hg=16
============================================================
In file included from /workspace/megagdn-pto/kernels/pto/tri_inverse.cpp:13:
In file included from /workspace/megagdn-pto/kernels/pto/tri_inverse_impl.cpp:15:
/workspace/megagdn-pto/kernels/pto/include/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.
In file included from /workspace/megagdn-pto/kernels/pto/tri_inverse.cpp:13:
In file included from /workspace/megagdn-pto/kernels/pto/tri_inverse_impl.cpp:15:
/workspace/megagdn-pto/kernels/pto/include/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.
INFO 05-04 09:29:55 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 05-04 09:29:55 [__init__.py:46] - ascend -> vllm_ascend:register
INFO 05-04 09:29:55 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-04 09:29:55 [__init__.py:239] Platform plugin ascend is activated
[WARNING] Please DO NOT tune args ['num_warps', 'num_stages']!
  PASS  T=256  pto_vs_cpu=PASS  cross=PASS
  PASS  T=512  pto_vs_cpu=PASS  cross=PASS
  PASS  T=1024  pto_vs_cpu=PASS  cross=PASS
  PASS  varlen [0, 256, 512]  pto_vs_cpu=PASS  cross=PASS
  PASS  varlen [0, 128, 384, 768]  pto_vs_cpu=PASS  cross=PASS
  PASS  varlen [0, 384, 512]  pto_vs_cpu=PASS  cross=PASS
  PASS  varlen [0, 128, 256, 512]  pto_vs_cpu=PASS  cross=PASS

ALL PASS
```

