### PR TITLE
fix: chunk_h return fs added sync

### DIFF
--- a/kernels/pto/chunk_h.cpp
+++ b/kernels/pto/chunk_h.cpp
@@ -872,6 +872,8 @@ AICORE void chunk_h_kernel(
       TASSIGN(fs_store, S_UB_HALF);
       TSTORE(fs_global, fs_store);
     }
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
   }
 #endif
 }

--- a/tests/test_single_kernels.py
+++ b/tests/test_single_kernels.py
@@ -329,10 +329,11 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
                 stream=stream, g_t=g_t, chunk_size=C,
                 cu_seqlens=cu, batch_size_override=N_seq, key_heads=HG)
     torch.npu.synchronize()
-    h_ref, v_ref, _ = ref_chunk_h(k.cpu(), w.cpu(), u.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
+    h_ref, v_ref, fs_ref = ref_chunk_h(k.cpu(), w.cpu(), u.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
     ok_h = stats_ok(s_out.float().cpu().view(tc_n, H, D, D), h_ref.float())
     ok_v = stats_ok(v_out.float().cpu(), v_ref.float())
-    return ok_h and ok_v
+    ok_fs = stats_ok(fs_out.float().cpu().view(N_seq, H, D, D), fs_ref.float())
+    return ok_h and ok_v and ok_fs
 
 
 def test_wy(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:


### PR DESCRIPTION
The final state from `chunk_h` was not tested with the reference

sync added because the kernel exited immediately after `TSTORE(fs_global, fs_store)` was issued to write to GM (so wait until MTE3 operation is done)