### PR TITLE
Extend tests

### DIFF
--- a/tests/ref_gdn.py
+++ b/tests/ref_gdn.py
@@ -216,3 +216,17 @@ class RefGDN:
                     o[0, s:e, h, :] = inter + (qk * gate * causal.to(self.dtype)) @ vc
             ci_base += nc
         return o
+
+    def run_full_pipeline(
+        self, q, k, v, g_in, beta, cu_seqlens_list, H, Hg, scale=1.0, C=128
+    ):
+        """Complete CPU fp32 reference for the GDN pipeline."""
+        cu = cu_seqlens_list
+        g_sum = self.cumsum(g_in, C, cu)
+        A = self.kkt(k, beta, g_sum, C, cu)
+        A_inv = self.solve_tril(A, C, cu)
+        w, u = self.wy_fast(k, v, beta, A_inv, g_sum, C, cu)
+        _, v_new, _ = self.chunk_h(k, w, u, g_sum, C, cu)
+        h_states, v_new, _ = self.chunk_h(k, w, u, g_sum, C, cu)
+        o = self.chunk_o(q, k, v_new, h_states, g_sum, C, cu)
+        return o * scale

--- a/tests/ref_gdn.py
+++ b/tests/ref_gdn.py
@@ -1,0 +1,218 @@
+import numpy as np
+import torch
+from megagdn_pto.kernel_libs import total_chunks
+
+# ---------------------------------------------------------------------------
+# CPU Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _safe_exp(x: torch.Tensor) -> torch.Tensor:
+    return torch.where(x <= 0, torch.exp(x), torch.zeros_like(x))
+
+
+def _seq_ranges(T: int, cu_seqlens=None) -> list[tuple[int, int]]:
+    if cu_seqlens is None:
+        return [(0, T)]
+    cu = cu_seqlens.tolist() if hasattr(cu_seqlens, "tolist") else cu_seqlens
+    return [(cu[i], cu[i + 1]) for i in range(len(cu) - 1)]
+
+
+class RefGDN:
+    def __init__(self, dtype: torch.dtype):
+        self.dtype = dtype
+
+    def cumsum(self, g: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
+        """Chunk-local cumulative sum of gates (fp32)."""
+        B, T, H = g.shape
+        gf = g.to(self.dtype)
+        out = torch.zeros_like(gf, dtype=self.dtype)
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                out[:, s:e, :] = gf[:, s:e, :].cumsum(dim=1)
+        return out
+
+    def solve_tril(self, A: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
+        """CPU reference for solve_tril: computes (I + A)^{-1} per chunk submatrix.
+
+        A is strictly lower triangular [B, T, H, cs] (PTO convention).
+        The inverse is computed always with numpy at double-precision, which internally
+        uses LAPACK.
+        """
+        B, T, H, _ = A.shape
+        out = torch.zeros(B, T, H, cs, dtype=self.dtype)
+        Af = A.to(self.dtype)
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                v = e - s
+                for h in range(H):
+                    Ac = Af[0, s:e, h, :v]  # [v, v], strictly lower triangular
+                    M = np.linalg.inv((np.identity(v) + Ac.numpy()).astype(np.double))
+                    inv = torch.from_numpy(M)
+                    out[0, s:e, h, :v] = inv.to(self.dtype)
+        return out
+
+    def kkt(
+        self,
+        k: torch.Tensor,
+        beta: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ) -> torch.Tensor:
+        """CPU reference for scaled_dot_kkt (GQA: k has Hg heads, beta/g have H heads)."""
+        B, T, Hg, Dd = k.shape
+        H = beta.shape[2]
+        grp = H // Hg
+        out = torch.zeros(B, T, H, cs, dtype=self.dtype)
+        kf, bf, gf = k.to(self.dtype), beta.to(self.dtype), g_cumsum.to(self.dtype)
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                v = e - s
+                for h in range(H):
+                    hg = h // grp
+                    kc, gc = kf[0, s:e, hg, :], gf[0, s:e, h]
+                    blk = (
+                        (kc @ kc.T)
+                        * _safe_exp(gc[:, None] - gc[None, :])
+                        * bf[0, s:e, h, None]
+                    )
+                    mask = torch.arange(v)[:, None] > torch.arange(v)[None, :]
+                    out[0, s:e, h, :v] = blk * mask.to(self.dtype)
+        return out
+
+    def chunk_h(
+        self,
+        k: torch.Tensor,
+        w: torch.Tensor,
+        u: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ):
+        """CPU reference for chunk_h: states S, v_new, final states."""
+        B, T, Hg, Dd = k.shape
+        H = w.shape[2]
+        grp = H // Hg
+        kf, wf, uf, gf = (
+            k.to(self.dtype),
+            w.to(self.dtype),
+            u.to(self.dtype),
+            g_cumsum.to(self.dtype),
+        )
+        ranges = _seq_ranges(T, cu_seqlens)
+        tc = total_chunks(
+            len(ranges), T, cs, torch.tensor(cu_seqlens) if cu_seqlens else None
+        )
+        h_out = torch.zeros(tc, H, Dd, Dd, dtype=self.dtype)
+        v_new = torch.zeros_like(uf)
+        final = torch.zeros(len(ranges), H, Dd, Dd, dtype=self.dtype)
+        ci_base = 0
+        for si, (bos, eos) in enumerate(ranges):
+            nc = (eos - bos + cs - 1) // cs
+            for h in range(H):
+                hg = h // grp
+                S = torch.zeros(Dd, Dd, dtype=self.dtype)
+                for ci in range(nc):
+                    s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
+                    gc = gf[0, s:e, h]
+                    gl = gc[e - s - 1]
+                    h_out[ci_base + ci, h] = S.clone()
+                    vc = uf[0, s:e, h, :] - wf[0, s:e, h, :] @ S
+                    v_new[0, s:e, h, :] = vc
+                    kv = kf[0, s:e, hg, :].T @ (vc * torch.exp(gl - gc)[:, None])
+                    S = torch.exp(gl) * S + kv
+                final[si, h] = S
+            ci_base += nc
+        return h_out, v_new, final
+
+    def wy_fast(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+        A_inv: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ):
+        """CPU reference for wy_fast."""
+        B, T, Hg, Kd = k.shape
+        H = v.shape[2]
+        grp = H // Hg
+        w = torch.zeros(B, T, H, Kd, dtype=self.dtype)
+        u = torch.zeros(B, T, H, v.shape[-1], dtype=self.dtype)
+        kf, vf, bf, Af, gf = (
+            k.to(dtype=self.dtype),
+            v.to(dtype=self.dtype),
+            beta.to(dtype=self.dtype),
+            A_inv.to(dtype=self.dtype),
+            g_cumsum.to(dtype=self.dtype),
+        )
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                valid = e - s
+                for h in range(H):
+                    hg = h // grp
+                    Ab = Af[0, s:e, h, :valid]
+                    gc = gf[0, s:e, h]
+                    vb = vf[0, s:e, h, :] * bf[0, s:e, h, None]
+                    kb = (
+                        kf[0, s:e, hg, :] * bf[0, s:e, h, None] * torch.exp(gc)[:, None]
+                    )
+                    u[0, s:e, h, :] = Ab @ vb
+                    w[0, s:e, h, :] = Ab @ kb
+        return w, u
+
+    def chunk_o(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v_new: torch.Tensor,
+        h_states: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ) -> torch.Tensor:
+        """CPU reference for chunk_o (PTO gating convention: min(Δg, 0))."""
+        B, T, Hg, Dd = q.shape
+        H = v_new.shape[2]
+        grp = H // Hg
+        qf, kf, vf, hf, gf = (
+            q.to(self.dtype),
+            k.to(self.dtype),
+            v_new.to(self.dtype),
+            h_states.to(self.dtype),
+            g_cumsum.to(self.dtype),
+        )
+        o = torch.zeros(B, T, H, Dd, dtype=self.dtype)
+        ranges = _seq_ranges(T, cu_seqlens)
+        ci_base = 0
+        for bos, eos in ranges:
+            nc = (eos - bos + cs - 1) // cs
+            for h in range(H):
+                hg = h // grp
+                for ci in range(nc):
+                    s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
+                    vlen = e - s
+                    qc, kc, vc, gc = (
+                        qf[0, s:e, hg, :],
+                        kf[0, s:e, hg, :],
+                        vf[0, s:e, h, :],
+                        gf[0, s:e, h],
+                    )
+                    inter = (qc @ hf[ci_base + ci, h]) * torch.exp(gc)[:, None]
+                    qk = qc @ kc.T
+                    causal = torch.arange(vlen)[:, None] >= torch.arange(vlen)[None, :]
+                    gate = torch.exp(
+                        torch.minimum(
+                            gc[:, None] - gc[None, :], torch.zeros(vlen, vlen)
+                        )
+                    )
+                    o[0, s:e, h, :] = inter + (qk * gate * causal.to(self.dtype)) @ vc
+            ci_base += nc
+        return o

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -52,15 +52,15 @@ from tests.test_single_kernels import (
     ref_cumsum,
     ref_kkt,
     ref_wy,
+    _seq_ranges,
+    stats_ok,
 )
-from tests.utils import NumericalAccuracy
 from megagdn_pto.mega_kernel import run_mega_kernel
 
 C_PTO = 128
 C_TRITON = 64
 D = 128
 
-ACCURACY = NumericalAccuracy()
 # Cross-backend agreement thresholds (tighter than vs-CPU)
 MAX_RMSE_CROSS = 0.02
 MIN_R2_CROSS = 0.999
@@ -310,8 +310,8 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
         key_heads=Hg,
     )
 
-    ok_pto = ACCURACY.stats_ok(o_pto.float().cpu(), o_cpu)
-    ok_mega = ACCURACY.stats_ok(o_mega.float().cpu(), o_cpu)
+    ok_pto = stats_ok(o_pto.float().cpu(), o_cpu)
+    ok_mega = stats_ok(o_mega.float().cpu(), o_cpu)
 
     ok_cross = True
     if triton_ok:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -37,6 +37,7 @@ if _TRITON_BASELINE not in sys.path:
 from megagdn_pto.fast_inverse import load_tri_inverse, solve_tril
 from megagdn_pto.kernel_libs import (
     BLOCK_DIM,
+    run_chunk_cumsum,
     run_chunk_h,
     run_chunk_o,
     run_scaled_dot_kkt,
@@ -45,17 +46,9 @@ from megagdn_pto.kernel_libs import (
     transpose_beta,
     transpose_gates,
 )
-from tests.test_single_kernels import (
-    ref_solve_tril,
-    ref_chunk_h,
-    ref_chunk_o,
-    ref_cumsum,
-    ref_kkt,
-    ref_wy,
-    _seq_ranges,
-    stats_ok,
-)
+from tests.ref_gdn import RefGDN
 from megagdn_pto.mega_kernel import run_mega_kernel
+from tests.utils import NumericalAccuracy
 
 C_PTO = 128
 C_TRITON = 64
@@ -66,26 +59,7 @@ MAX_RMSE_CROSS = 0.02
 MIN_R2_CROSS = 0.999
 MIN_PEARSON_CROSS = 0.999
 
-
-# ---------------------------------------------------------------------------
-# Full CPU reference pipeline
-# ---------------------------------------------------------------------------
-
-
-def cpu_pipeline(q, k, v, g_in, beta, cu_seqlens_list, H, Hg, scale=1.0):
-    """Complete CPU fp32 reference for the GDN pipeline."""
-    cu = cu_seqlens_list
-    g_sum = ref_cumsum(g_in, C_PTO, cu)
-    A = ref_kkt(k, beta, g_sum, C_PTO, cu)
-    A_inv = ref_solve_tril(A.float(), C_PTO, cu).to(torch.float32)
-    w, u = ref_wy(k, v, beta, A_inv, g_sum, C_PTO, cu)
-    _, v_new, _ = ref_chunk_h(k, w.float(), u.float(), g_sum, C_PTO, cu)
-    N_seq = 1 if cu is None else len(cu) - 1
-    tc = total_chunks(N_seq, q.shape[1], C_PTO, torch.tensor(cu) if cu else None)
-    _, _, h_states_list = ref_chunk_h(k, w.float(), u.float(), g_sum, C_PTO, cu)
-    h_states, v_new, _ = ref_chunk_h(k, w.float(), u.float(), g_sum, C_PTO, cu)
-    o = ref_chunk_o(q, k, v_new.float(), h_states, g_sum, C_PTO, cu)
-    return (o * scale).float()
+ACCURACY = NumericalAccuracy()
 
 
 # ---------------------------------------------------------------------------
@@ -104,8 +78,16 @@ def pto_pipeline(q, k, v, g_in, beta, cu32, H, Hg, scale=1.0, tri_inv_func=None)
     if tri_inv_func is None:
         tri_inv_func = load_tri_inverse()
 
-    # 1. Cumsum (CPU reference, exact match with PTO)
-    g_sum = ref_cumsum(g_in.cpu(), C_PTO, cu_cpu).to(dev)
+    # 1. Cumsum
+    g_sum = torch.empty_like(g_in)
+    run_chunk_cumsum(
+        g_in,
+        g_sum,
+        stream=stream,
+        chunk_size=C_PTO,
+        cu_seqlens=cu32,
+        batch_size_override=N_seq,
+    )
     g_t = transpose_gates(g_sum)
     beta_t = transpose_beta(beta)
 
@@ -284,12 +266,13 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
     o_pto = pto_pipeline(q, k, v, g_in, beta, cu32, H, Hg, scale, tri_inv_func)
 
     # CPU reference pipeline
-    o_cpu = cpu_pipeline(
-        q.cpu().float(),
-        k.cpu().float(),
-        v.cpu().float(),
+    cpu_ref_gdn = RefGDN(torch.double)
+    o_cpu = cpu_ref_gdn.run_full_pipeline(
+        q.cpu(),
+        k.cpu(),
+        v.cpu(),
         g_in.cpu(),
-        beta.cpu().float(),
+        beta.cpu(),
         cu_cpu,
         H,
         Hg,
@@ -310,8 +293,8 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
         key_heads=Hg,
     )
 
-    ok_pto = stats_ok(o_pto.float().cpu(), o_cpu)
-    ok_mega = stats_ok(o_mega.float().cpu(), o_cpu)
+    ok_pto = ACCURACY.stats_ok(o_pto.double().cpu(), o_cpu.double())
+    ok_mega = ACCURACY.stats_ok(o_mega.double().cpu(), o_cpu.double())
 
     ok_cross = True
     if triton_ok:
@@ -323,7 +306,7 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
             print(f"    [Triton skipped: {str(e).split(chr(10))[0][:80]}]")
             ok_cross = True  # not a failure, triton may not support all shapes
 
-    return ok_pto and ok_cross and ok_mega, label, ok_pto, ok_cross, ok_mega
+    return (ok_pto and ok_cross and ok_mega), label, ok_pto, ok_cross, ok_mega
 
 
 def main() -> None:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -52,15 +52,15 @@ from tests.test_single_kernels import (
     ref_cumsum,
     ref_kkt,
     ref_wy,
-    _seq_ranges,
-    stats_ok,
 )
+from tests.utils import NumericalAccuracy
 from megagdn_pto.mega_kernel import run_mega_kernel
 
 C_PTO = 128
 C_TRITON = 64
 D = 128
 
+ACCURACY = NumericalAccuracy()
 # Cross-backend agreement thresholds (tighter than vs-CPU)
 MAX_RMSE_CROSS = 0.02
 MIN_R2_CROSS = 0.999
@@ -71,6 +71,7 @@ MIN_PEARSON_CROSS = 0.999
 # Full CPU reference pipeline
 # ---------------------------------------------------------------------------
 
+
 def cpu_pipeline(q, k, v, g_in, beta, cu_seqlens_list, H, Hg, scale=1.0):
     """Complete CPU fp32 reference for the GDN pipeline."""
     cu = cu_seqlens_list
@@ -80,8 +81,7 @@ def cpu_pipeline(q, k, v, g_in, beta, cu_seqlens_list, H, Hg, scale=1.0):
     w, u = ref_wy(k, v, beta, A_inv, g_sum, C_PTO, cu)
     _, v_new, _ = ref_chunk_h(k, w.float(), u.float(), g_sum, C_PTO, cu)
     N_seq = 1 if cu is None else len(cu) - 1
-    tc = total_chunks(N_seq, q.shape[1], C_PTO,
-                      torch.tensor(cu) if cu else None)
+    tc = total_chunks(N_seq, q.shape[1], C_PTO, torch.tensor(cu) if cu else None)
     _, _, h_states_list = ref_chunk_h(k, w.float(), u.float(), g_sum, C_PTO, cu)
     h_states, v_new, _ = ref_chunk_h(k, w.float(), u.float(), g_sum, C_PTO, cu)
     o = ref_chunk_o(q, k, v_new.float(), h_states, g_sum, C_PTO, cu)
@@ -91,6 +91,7 @@ def cpu_pipeline(q, k, v, g_in, beta, cu_seqlens_list, H, Hg, scale=1.0):
 # ---------------------------------------------------------------------------
 # PTO pipeline
 # ---------------------------------------------------------------------------
+
 
 def pto_pipeline(q, k, v, g_in, beta, cu32, H, Hg, scale=1.0, tri_inv_func=None):
     """Full six-stage PTO pipeline on NPU."""
@@ -111,9 +112,20 @@ def pto_pipeline(q, k, v, g_in, beta, cu32, H, Hg, scale=1.0, tri_inv_func=None)
     # 2. scaled_dot_kkt
     msk_lower = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=-1).float()
     A = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float16)
-    run_scaled_dot_kkt(k, beta, g_sum, msk_lower, A,
-                       stream=stream, g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
-                       cu_seqlens=cu32, batch_size_override=N_seq, key_heads=Hg)
+    run_scaled_dot_kkt(
+        k,
+        beta,
+        g_sum,
+        msk_lower,
+        A,
+        stream=stream,
+        g_t=g_t,
+        beta_t=beta_t,
+        chunk_size=C_PTO,
+        cu_seqlens=cu32,
+        batch_size_override=N_seq,
+        key_heads=Hg,
+    )
 
     # 3. solve_tril
     A_inv = solve_tril(A, cu32, C_PTO, H, tri_inv_func)
@@ -121,25 +133,62 @@ def pto_pipeline(q, k, v, g_in, beta, cu32, H, Hg, scale=1.0, tri_inv_func=None)
     # 4. wy_fast
     w = torch.empty_like(v)
     u = torch.empty_like(v)
-    run_wy_fast(k, v, beta, g_sum, A_inv, w, u,
-                stream=stream, g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
-                cu_seqlens=cu32, batch_size_override=N_seq, key_heads=Hg)
+    run_wy_fast(
+        k,
+        v,
+        beta,
+        g_sum,
+        A_inv,
+        w,
+        u,
+        stream=stream,
+        g_t=g_t,
+        beta_t=beta_t,
+        chunk_size=C_PTO,
+        cu_seqlens=cu32,
+        batch_size_override=N_seq,
+        key_heads=Hg,
+    )
 
     # 5. chunk_h
     tc_n = total_chunks(N_seq, T, C_PTO, cu32)
     s = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
     v_new = torch.empty_like(v)
     fs = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
-    run_chunk_h(k, w, u, g_sum, s, v_new, fs,
-                stream=stream, g_t=g_t, chunk_size=C_PTO,
-                cu_seqlens=cu32, batch_size_override=N_seq, key_heads=Hg)
+    run_chunk_h(
+        k,
+        w,
+        u,
+        g_sum,
+        s,
+        v_new,
+        fs,
+        stream=stream,
+        g_t=g_t,
+        chunk_size=C_PTO,
+        cu_seqlens=cu32,
+        batch_size_override=N_seq,
+        key_heads=Hg,
+    )
 
     # 6. chunk_o
     msk_full = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
     o = torch.empty_like(v)
-    run_chunk_o(q, k, v_new, s, g_sum, msk_full, o,
-                stream=stream, g_t=g_t, chunk_size=C_PTO,
-                cu_seqlens=cu32, batch_size_override=N_seq, key_heads=Hg)
+    run_chunk_o(
+        q,
+        k,
+        v_new,
+        s,
+        g_sum,
+        msk_full,
+        o,
+        stream=stream,
+        g_t=g_t,
+        chunk_size=C_PTO,
+        cu_seqlens=cu32,
+        batch_size_override=N_seq,
+        key_heads=Hg,
+    )
 
     return (o * scale).to(q.dtype)
 
@@ -148,9 +197,11 @@ def pto_pipeline(q, k, v, g_in, beta, cu32, H, Hg, scale=1.0, tri_inv_func=None)
 # Triton pipeline
 # ---------------------------------------------------------------------------
 
+
 def _triton_available() -> bool:
     try:
         from fla_vendor.chunk_delta_h import chunk_gated_delta_rule_fwd_h  # noqa
+
         return True
     except Exception:
         return False
@@ -160,7 +211,9 @@ def triton_pipeline(q, k, v, g_in, beta, cu_long, H, Hg, scale=1.0):
     """Full six-stage Triton pipeline (C=64, bf16)."""
     from fla_vendor.chunk import chunk_gated_delta_rule_fwd
 
-    _, o_tri, _, _, _, _, _ = chunk_gated_delta_rule_fwd(q, k, v, g_in, beta, scale, None, None, cu_long)
+    _, o_tri, _, _, _, _, _ = chunk_gated_delta_rule_fwd(
+        q, k, v, g_in, beta, scale, None, None, cu_long
+    )
     torch.npu.synchronize()
     return o_tri.float()
 
@@ -168,6 +221,7 @@ def triton_pipeline(q, k, v, g_in, beta, cu_long, H, Hg, scale=1.0):
 # ---------------------------------------------------------------------------
 # Cross-backend check
 # ---------------------------------------------------------------------------
+
 
 def _r2(ref, pred):
     r = ref.numpy().ravel().astype(np.float64)
@@ -209,14 +263,19 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
 
     torch.manual_seed(0)
     torch.npu.manual_seed(0)
-    q = F.normalize(torch.randn(1, T, Hg, D, device=dev, dtype=torch.float16), dim=-1, p=2)
-    k = F.normalize(torch.randn(1, T, Hg, D, device=dev, dtype=torch.float16), dim=-1, p=2)
+    q = F.normalize(
+        torch.randn(1, T, Hg, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
+    k = F.normalize(
+        torch.randn(1, T, Hg, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
     v = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
     g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
 
     cu32 = (
-        torch.tensor(cu_list, dtype=torch.int32, device=dev) if cu_list
+        torch.tensor(cu_list, dtype=torch.int32, device=dev)
+        if cu_list
         else torch.tensor([0, T], dtype=torch.int32, device=dev)
     )
     cu_cpu = cu32.cpu().tolist() if cu_list else None
@@ -226,21 +285,33 @@ def run_one(T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok):
 
     # CPU reference pipeline
     o_cpu = cpu_pipeline(
-        q.cpu().float(), k.cpu().float(), v.cpu().float(),
-        g_in.cpu(), beta.cpu().float(), cu_cpu, H, Hg, scale,
+        q.cpu().float(),
+        k.cpu().float(),
+        v.cpu().float(),
+        g_in.cpu(),
+        beta.cpu().float(),
+        cu_cpu,
+        H,
+        Hg,
+        scale,
     )
 
     # PTO mega kernel
     o_mega = run_mega_kernel(
-        q, k, v, g_in, beta, cu32,
+        q,
+        k,
+        v,
+        g_in,
+        beta,
+        cu32,
         stream=torch.npu.current_stream()._as_parameter_,
         chunk_size=C_PTO,
         scale=scale,
         key_heads=Hg,
     )
 
-    ok_pto = stats_ok(o_pto.float().cpu(), o_cpu)
-    ok_mega = stats_ok(o_mega.float().cpu(), o_cpu)
+    ok_pto = ACCURACY.stats_ok(o_pto.float().cpu(), o_cpu)
+    ok_mega = ACCURACY.stats_ok(o_mega.float().cpu(), o_cpu)
 
     ok_cross = True
     if triton_ok:
@@ -268,7 +339,7 @@ def main() -> None:
     dev = torch.device(args.device)
     heads = [int(x) for x in args.H_list.split(",")] if args.H_list else [args.H]
     Hg = args.hg
-    scale = D ** -0.5
+    scale = D**-0.5
     triton_ok = not args.no_triton and _triton_available()
     tri_inv_func = load_tri_inverse()
 
@@ -281,12 +352,15 @@ def main() -> None:
         print(f"\n{'='*60}\nH={H}  Hg={Hg}\n{'='*60}")
         for T_or_cu, T_total in TEST_SHAPES:
             ok, label, ok_pto, ok_cross, ok_mega = run_one(
-                T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok)
+                T_or_cu, T_total, H, Hg, dev, scale, tri_inv_func, triton_ok
+            )
             if not ok:
                 all_pass = False
             cross_str = f"  cross={'PASS' if ok_cross else 'FAIL'}" if triton_ok else ""
             status = "PASS" if ok else "FAIL"
-            print(f"  {status}  {label}  pto_vs_cpu={'PASS' if ok_pto else 'FAIL'}  mega_vs_cpu={'PASS' if ok_mega else 'FAIL'}{cross_str}")
+            print(
+                f"  {status}  {label}  pto_vs_cpu={'PASS' if ok_pto else 'FAIL'}  mega_vs_cpu={'PASS' if ok_mega else 'FAIL'}{cross_str}"
+            )
 
     print(f"\n{'ALL PASS' if all_pass else 'SOME FAILED'}")
     sys.exit(0 if all_pass else 1)

--- a/tests/test_single_kernels.py
+++ b/tests/test_single_kernels.py
@@ -50,6 +50,10 @@ D = 128  # head dimension
 # ---------------------------------------------------------------------------
 
 
+def _safe_exp(x: torch.Tensor) -> torch.Tensor:
+    return torch.where(x <= 0, torch.exp(x), torch.zeros_like(x))
+
+
 def _seq_ranges(T: int, cu_seqlens=None) -> list[tuple[int, int]]:
     if cu_seqlens is None:
         return [(0, T)]
@@ -57,180 +61,201 @@ def _seq_ranges(T: int, cu_seqlens=None) -> list[tuple[int, int]]:
     return [(cu[i], cu[i + 1]) for i in range(len(cu) - 1)]
 
 
-def ref_cumsum(g: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
-    """Chunk-local cumulative sum of gates (fp32)."""
-    B, T, H = g.shape
-    out = torch.zeros_like(g, dtype=torch.float32)
-    for bos, eos in _seq_ranges(T, cu_seqlens):
-        for j in range(0, eos - bos, cs):
-            s, e = bos + j, min(bos + j + cs, eos)
-            out[:, s:e, :] = g.float()[:, s:e, :].cumsum(dim=1)
-    return out
+class RefGDN:
+    def __init__(self, dtype: torch.dtype):
+        self.dtype = dtype
 
+    def cumsum(self, g: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
+        """Chunk-local cumulative sum of gates (fp32)."""
+        B, T, H = g.shape
+        gf = g.to(self.dtype)
+        out = torch.zeros_like(gf, dtype=self.dtype)
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                out[:, s:e, :] = gf[:, s:e, :].cumsum(dim=1)
+        return out
 
-def _safe_exp(x: torch.Tensor) -> torch.Tensor:
-    return torch.where(x <= 0, torch.exp(x), torch.zeros_like(x))
+    def solve_tril(self, A: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
+        """CPU reference for solve_tril: computes (I + A)^{-1} per chunk submatrix.
 
+        A is strictly lower triangular [B, T, H, cs] (PTO convention).
+        """
+        B, T, H, _ = A.shape
+        out = torch.zeros(B, T, H, cs, dtype=self.dtype)
+        Af = A.to(self.dtype)
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                v = e - s
+                for h in range(H):
+                    Ac = Af[0, s:e, h, :v]  # [v, v], strictly lower triangular
+                    inv = torch.linalg.inv(torch.eye(v) + Ac)
+                    out[0, s:e, h, :v] = inv
+        return out
 
-def ref_solve_tril(A: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
-    """CPU reference for solve_tril: computes (I + A)^{-1} per chunk submatrix.
+    def kkt(
+        self,
+        k: torch.Tensor,
+        beta: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ) -> torch.Tensor:
+        """CPU reference for scaled_dot_kkt (GQA: k has Hg heads, beta/g have H heads)."""
+        B, T, Hg, Dd = k.shape
+        H = beta.shape[2]
+        grp = H // Hg
+        out = torch.zeros(B, T, H, cs, dtype=self.dtype)
+        kf, bf, gf = k.to(self.dtype), beta.to(self.dtype), g_cumsum.to(self.dtype)
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                v = e - s
+                for h in range(H):
+                    hg = h // grp
+                    kc, gc = kf[0, s:e, hg, :], gf[0, s:e, h]
+                    blk = (
+                        (kc @ kc.T)
+                        * _safe_exp(gc[:, None] - gc[None, :])
+                        * bf[0, s:e, h, None]
+                    )
+                    mask = torch.arange(v)[:, None] > torch.arange(v)[None, :]
+                    out[0, s:e, h, :v] = blk * mask.to(self.dtype)
+        return out
 
-    A is strictly lower triangular [B, T, H, cs] (PTO convention).
-    """
-    B, T, H, _ = A.shape
-    out = torch.zeros(B, T, H, cs, dtype=torch.float32)
-    Af = A.float()
-    for bos, eos in _seq_ranges(T, cu_seqlens):
-        for j in range(0, eos - bos, cs):
-            s, e = bos + j, min(bos + j + cs, eos)
-            v = e - s
-            for h in range(H):
-                Ac = Af[0, s:e, h, :v]  # [v, v], strictly lower triangular
-                inv = torch.linalg.inv(torch.eye(v) + Ac)
-                out[0, s:e, h, :v] = inv
-    return out
-
-
-def ref_kkt(
-    k: torch.Tensor,
-    beta: torch.Tensor,
-    g_cumsum: torch.Tensor,
-    cs: int,
-    cu_seqlens=None,
-) -> torch.Tensor:
-    """CPU reference for scaled_dot_kkt (GQA: k has Hg heads, beta/g have H heads)."""
-    B, T, Hg, Dd = k.shape
-    H = beta.shape[2]
-    grp = H // Hg
-    out = torch.zeros(B, T, H, cs, dtype=torch.float32)
-    kf, bf, gf = k.float(), beta.float(), g_cumsum.float()
-    for bos, eos in _seq_ranges(T, cu_seqlens):
-        for j in range(0, eos - bos, cs):
-            s, e = bos + j, min(bos + j + cs, eos)
-            v = e - s
-            for h in range(H):
-                hg = h // grp
-                kc, gc = kf[0, s:e, hg, :], gf[0, s:e, h]
-                blk = (
-                    (kc @ kc.T)
-                    * _safe_exp(gc[:, None] - gc[None, :])
-                    * bf[0, s:e, h, None]
-                )
-                mask = torch.arange(v)[:, None] > torch.arange(v)[None, :]
-                out[0, s:e, h, :v] = blk * mask.float()
-    return out
-
-
-def ref_chunk_h(
-    k: torch.Tensor,
-    w: torch.Tensor,
-    u: torch.Tensor,
-    g_cumsum: torch.Tensor,
-    cs: int,
-    cu_seqlens=None,
-):
-    """CPU reference for chunk_h: states S, v_new, final states."""
-    B, T, Hg, Dd = k.shape
-    H = w.shape[2]
-    grp = H // Hg
-    kf, wf, uf, gf = k.float(), w.float(), u.float(), g_cumsum.float()
-    ranges = _seq_ranges(T, cu_seqlens)
-    tc = total_chunks(
-        len(ranges), T, cs, torch.tensor(cu_seqlens) if cu_seqlens else None
-    )
-    h_out = torch.zeros(tc, H, Dd, Dd, dtype=torch.float32)
-    v_new = torch.zeros_like(uf)
-    final = torch.zeros(len(ranges), H, Dd, Dd, dtype=torch.float32)
-    ci_base = 0
-    for si, (bos, eos) in enumerate(ranges):
-        nc = (eos - bos + cs - 1) // cs
-        for h in range(H):
-            hg = h // grp
-            S = torch.zeros(Dd, Dd, dtype=torch.float32)
-            for ci in range(nc):
-                s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
-                gc = gf[0, s:e, h]
-                gl = gc[e - s - 1]
-                h_out[ci_base + ci, h] = S.clone()
-                vc = uf[0, s:e, h, :] - wf[0, s:e, h, :] @ S
-                v_new[0, s:e, h, :] = vc
-                kv = kf[0, s:e, hg, :].T @ (vc * torch.exp(gl - gc)[:, None])
-                S = torch.exp(gl) * S + kv
-            final[si, h] = S
-        ci_base += nc
-    return h_out, v_new, final
-
-
-def ref_wy(
-    k: torch.Tensor,
-    v: torch.Tensor,
-    beta: torch.Tensor,
-    A: torch.Tensor,
-    g_cumsum: torch.Tensor,
-    cs: int,
-    cu_seqlens=None,
-):
-    """CPU reference for wy_fast."""
-    B, T, Hg, Kd = k.shape
-    H = v.shape[2]
-    grp = H // Hg
-    w = torch.zeros(B, T, H, Kd, dtype=torch.float32)
-    u = torch.zeros(B, T, H, v.shape[-1], dtype=torch.float32)
-    kf, vf, bf, Af, gf = k.float(), v.float(), beta.float(), A.float(), g_cumsum.float()
-    for bos, eos in _seq_ranges(T, cu_seqlens):
-        for j in range(0, eos - bos, cs):
-            s, e = bos + j, min(bos + j + cs, eos)
-            valid = e - s
+    def chunk_h(
+        self,
+        k: torch.Tensor,
+        w: torch.Tensor,
+        u: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ):
+        """CPU reference for chunk_h: states S, v_new, final states."""
+        B, T, Hg, Dd = k.shape
+        H = w.shape[2]
+        grp = H // Hg
+        kf, wf, uf, gf = (
+            k.to(self.dtype),
+            w.to(self.dtype),
+            u.to(self.dtype),
+            g_cumsum.to(self.dtype),
+        )
+        ranges = _seq_ranges(T, cu_seqlens)
+        tc = total_chunks(
+            len(ranges), T, cs, torch.tensor(cu_seqlens) if cu_seqlens else None
+        )
+        h_out = torch.zeros(tc, H, Dd, Dd, dtype=self.dtype)
+        v_new = torch.zeros_like(uf)
+        final = torch.zeros(len(ranges), H, Dd, Dd, dtype=self.dtype)
+        ci_base = 0
+        for si, (bos, eos) in enumerate(ranges):
+            nc = (eos - bos + cs - 1) // cs
             for h in range(H):
                 hg = h // grp
-                Ab = Af[0, s:e, h, :valid]
-                gc = gf[0, s:e, h]
-                vb = vf[0, s:e, h, :] * bf[0, s:e, h, None]
-                kb = kf[0, s:e, hg, :] * bf[0, s:e, h, None] * torch.exp(gc)[:, None]
-                u[0, s:e, h, :] = Ab @ vb
-                w[0, s:e, h, :] = Ab @ kb
-    return w.to(k.dtype), u.to(v.dtype)
+                S = torch.zeros(Dd, Dd, dtype=self.dtype)
+                for ci in range(nc):
+                    s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
+                    gc = gf[0, s:e, h]
+                    gl = gc[e - s - 1]
+                    h_out[ci_base + ci, h] = S.clone()
+                    vc = uf[0, s:e, h, :] - wf[0, s:e, h, :] @ S
+                    v_new[0, s:e, h, :] = vc
+                    kv = kf[0, s:e, hg, :].T @ (vc * torch.exp(gl - gc)[:, None])
+                    S = torch.exp(gl) * S + kv
+                final[si, h] = S
+            ci_base += nc
+        return h_out, v_new, final
 
+    def wy(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+        A: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ):
+        """CPU reference for wy_fast."""
+        B, T, Hg, Kd = k.shape
+        H = v.shape[2]
+        grp = H // Hg
+        w = torch.zeros(B, T, H, Kd, dtype=self.dtype)
+        u = torch.zeros(B, T, H, v.shape[-1], dtype=self.dtype)
+        kf, vf, bf, Af, gf = (
+            k.float(),
+            v.float(),
+            beta.float(),
+            A.float(),
+            g_cumsum.float(),
+        )
+        for bos, eos in _seq_ranges(T, cu_seqlens):
+            for j in range(0, eos - bos, cs):
+                s, e = bos + j, min(bos + j + cs, eos)
+                valid = e - s
+                for h in range(H):
+                    hg = h // grp
+                    Ab = Af[0, s:e, h, :valid]
+                    gc = gf[0, s:e, h]
+                    vb = vf[0, s:e, h, :] * bf[0, s:e, h, None]
+                    kb = (
+                        kf[0, s:e, hg, :] * bf[0, s:e, h, None] * torch.exp(gc)[:, None]
+                    )
+                    u[0, s:e, h, :] = Ab @ vb
+                    w[0, s:e, h, :] = Ab @ kb
+        return w.to(k.dtype), u.to(v.dtype)
 
-def ref_chunk_o(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v_new: torch.Tensor,
-    h_states: torch.Tensor,
-    g_cumsum: torch.Tensor,
-    cs: int,
-    cu_seqlens=None,
-) -> torch.Tensor:
-    """CPU reference for chunk_o (PTO gating convention: min(Δg, 0))."""
-    B, T, Hg, Dd = q.shape
-    H = v_new.shape[2]
-    grp = H // Hg
-    qf, kf, vf, gf = q.float(), k.float(), v_new.float(), g_cumsum.float()
-    o = torch.zeros(B, T, H, Dd, dtype=torch.float32)
-    ranges = _seq_ranges(T, cu_seqlens)
-    ci_base = 0
-    for bos, eos in ranges:
-        nc = (eos - bos + cs - 1) // cs
-        for h in range(H):
-            hg = h // grp
-            for ci in range(nc):
-                s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
-                vlen = e - s
-                qc, kc, vc, gc = (
-                    qf[0, s:e, hg, :],
-                    kf[0, s:e, hg, :],
-                    vf[0, s:e, h, :],
-                    gf[0, s:e, h],
-                )
-                inter = (qc @ h_states[ci_base + ci, h]) * torch.exp(gc)[:, None]
-                qk = qc @ kc.T
-                causal = torch.arange(vlen)[:, None] >= torch.arange(vlen)[None, :]
-                gate = torch.exp(
-                    torch.minimum(gc[:, None] - gc[None, :], torch.zeros(vlen, vlen))
-                )
-                o[0, s:e, h, :] = inter + (qk * gate * causal.float()) @ vc
-        ci_base += nc
-    return o
+    def chunk_o(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v_new: torch.Tensor,
+        h_states: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        cs: int,
+        cu_seqlens=None,
+    ) -> torch.Tensor:
+        """CPU reference for chunk_o (PTO gating convention: min(Δg, 0))."""
+        B, T, Hg, Dd = q.shape
+        H = v_new.shape[2]
+        grp = H // Hg
+        qf, kf, vf, hf, gf = (
+            q.to(self.dtype),
+            k.to(self.dtype),
+            v_new.to(self.dtype),
+            h_states.to(self.dtype),
+            g_cumsum.to(self.dtype),
+        )
+        o = torch.zeros(B, T, H, Dd, dtype=self.dtype)
+        ranges = _seq_ranges(T, cu_seqlens)
+        ci_base = 0
+        for bos, eos in ranges:
+            nc = (eos - bos + cs - 1) // cs
+            for h in range(H):
+                hg = h // grp
+                for ci in range(nc):
+                    s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
+                    vlen = e - s
+                    qc, kc, vc, gc = (
+                        qf[0, s:e, hg, :],
+                        kf[0, s:e, hg, :],
+                        vf[0, s:e, h, :],
+                        gf[0, s:e, h],
+                    )
+                    inter = (qc @ hf[ci_base + ci, h]) * torch.exp(gc)[:, None]
+                    qk = qc @ kc.T
+                    causal = torch.arange(vlen)[:, None] >= torch.arange(vlen)[None, :]
+                    gate = torch.exp(
+                        torch.minimum(
+                            gc[:, None] - gc[None, :], torch.zeros(vlen, vlen)
+                        )
+                    )
+                    o[0, s:e, h, :] = inter + (qk * gate * causal.to(self.dtype)) @ vc
+            ci_base += nc
+        return o
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +268,10 @@ class TestCase:
     label: str
     cu_seqlens_list: list[int] | None
     T: int
+    dtype: torch.dtype = torch.double
+
+    def __post_init__(self):
+        self.ref_gdn = RefGDN(self.dtype)
 
 
 def _cu_from_seqlens(seqlens: list[int]) -> list[int]:
@@ -307,6 +336,8 @@ def build_test_cases() -> list[TestCase]:
 
 def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
+    ref_cumsum = tc.ref_gdn.cumsum
+    ref_kkt = tc.ref_gdn.kkt
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -340,11 +371,16 @@ def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     torch.npu.synchronize()
     ref = ref_kkt(k.cpu(), beta.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
-    return ACCURACY.stats_ok(A_out.float().cpu(), ref)
+    A_out_cpu = A_out.cpu()
+    torch.npu.synchronize()
+    print(f"max A_out: {A_out_cpu.abs().max().item()}")
+    return ACCURACY.stats_ok(A_out.cpu().to(tc.dtype), ref.to(tc.dtype))
 
 
 def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
+    ref_cumsum = tc.ref_gdn.cumsum
+    ref_chunk_h = tc.ref_gdn.chunk_h
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -384,13 +420,17 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     h_ref, v_ref, _ = ref_chunk_h(
         k.cpu(), w.cpu(), u.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list
     )
-    ok_h = ACCURACY.stats_ok(s_out.float().cpu().view(tc_n, H, D, D), h_ref.float())
-    ok_v = ACCURACY.stats_ok(v_out.float().cpu(), v_ref.float())
+    ok_h = ACCURACY.stats_ok(
+        s_out.cpu().to(tc.dtype).view(tc_n, H, D, D), h_ref.to(tc.dtype)
+    )
+    ok_v = ACCURACY.stats_ok(v_out.cpu().to(tc.dtype), v_ref.to(tc.dtype))
     return ok_h and ok_v
 
 
 def test_wy(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
+    ref_cumsum = tc.ref_gdn.cumsum
+    ref_wy = tc.ref_gdn.wy
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -430,13 +470,15 @@ def test_wy(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     w_ref, u_ref = ref_wy(
         k.cpu(), v.cpu(), beta.cpu(), A.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list
     )
-    return ACCURACY.stats_ok(w_out.float().cpu(), w_ref.float()) and ACCURACY.stats_ok(
-        u_out.float().cpu(), u_ref.float()
-    )
+    return ACCURACY.stats_ok(
+        w_out.cpu().to(tc.dtype), w_ref.to(tc.dtype)
+    ) and ACCURACY.stats_ok(u_out.cpu().to(tc.dtype), u_ref.to(tc.dtype))
 
 
 def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
+    ref_cumsum = tc.ref_gdn.cumsum
+    ref_chunk_o = tc.ref_gdn.chunk_o
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -494,15 +536,16 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         key_heads=HG,
     )
     torch.npu.synchronize()
-    s_re = s_out.float().cpu().view(tc_n, H, D, D)
+    s_re = s_out.cpu().to(tc.dtype).view(tc_n, H, D, D)
     o_ref = ref_chunk_o(
         q.cpu(), k.cpu(), v_out.cpu(), s_re, g_sum.cpu(), C, tc.cu_seqlens_list
     )
-    return ACCURACY.stats_ok(o_out.float().cpu(), o_ref.float())
+    return ACCURACY.stats_ok(o_out.cpu().to(tc.dtype), o_ref.to(tc.dtype))
 
 
 def test_cumsum(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
+    ref_cumsum = tc.ref_gdn.cumsum
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -518,11 +561,12 @@ def test_cumsum(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     torch.npu.synchronize()
     ref = ref_cumsum(g.cpu(), C, tc.cu_seqlens_list)
-    return ACCURACY.stats_ok(g_sum.cpu(), ref)
+    return ACCURACY.stats_ok(g_sum.cpu().to(tc.dtype), ref.to(tc.dtype))
 
 
 def test_solve_tril(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
+    ref_solve_tril = tc.ref_gdn.solve_tril
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -547,7 +591,7 @@ def test_solve_tril(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     A_inv = solve_tril(A, cu, C, H, tri_inv)
     torch.npu.synchronize()
     ref = ref_solve_tril(A.cpu(), C, tc.cu_seqlens_list)
-    return ACCURACY.stats_ok(A_inv.float().cpu(), ref)
+    return ACCURACY.stats_ok(A_inv.cpu().to(tc.dtype), ref.to(tc.dtype))
 
 
 _STAGES = {

--- a/tests/test_single_kernels.py
+++ b/tests/test_single_kernels.py
@@ -378,56 +378,6 @@ def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     return ACCURACY.stats_ok(A_out.cpu().to(tc.dtype), ref.to(tc.dtype), chunk_size=C)
 
 
-def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
-    T = tc.T
-    ref_cumsum = tc.ref_gdn.cumsum
-    ref_chunk_h = tc.ref_gdn.chunk_h
-    cu = (
-        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
-        if tc.cu_seqlens_list
-        else None
-    )
-    N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
-    torch.manual_seed(42)
-    k = F.normalize(
-        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
-    )
-    w = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
-    u = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
-    g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(g_in.dtype).to(dev)
-    g_t = transpose_gates(g_sum)
-    stream = torch.npu.current_stream()._as_parameter_
-    tc_n = total_chunks(N_seq, T, C, cu)
-    s_out = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
-    v_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
-    fs_out = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
-    run_chunk_h(
-        k,
-        w,
-        u,
-        g_sum,
-        s_out,
-        v_out,
-        fs_out,
-        stream=stream,
-        g_t=g_t,
-        chunk_size=C,
-        cu_seqlens=cu,
-        batch_size_override=N_seq,
-        key_heads=HG,
-    )
-    torch.npu.synchronize()
-    h_ref, v_ref, _ = ref_chunk_h(
-        k.cpu(), w.cpu(), u.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list
-    )
-    ok_h = ACCURACY.stats_ok(
-        s_out.cpu().to(tc.dtype).view(tc_n, H, D, D), h_ref.to(tc.dtype), chunk_size=C
-    )
-    ok_v = ACCURACY.stats_ok(v_out.cpu().to(tc.dtype), v_ref.to(tc.dtype), chunk_size=C)
-    return ok_h and ok_v
-
-
 def test_wy_fast(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
     ref_cumsum = tc.ref_gdn.cumsum
@@ -482,39 +432,47 @@ def test_wy_fast(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     ) and ACCURACY.stats_ok(u_out.cpu().to(tc.dtype), u_ref.to(tc.dtype), chunk_size=C)
 
 
-def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
+def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
     ref_cumsum = tc.ref_gdn.cumsum
-    ref_chunk_o = tc.ref_gdn.chunk_o
+    ref_wy_fast = tc.ref_gdn.wy_fast
+    ref_solve_tril = tc.ref_gdn.solve_tril
+    ref_kkt = tc.ref_gdn.kkt
+    ref_chunk_h = tc.ref_gdn.chunk_h
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
         else None
     )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
+
     torch.manual_seed(42)
-    k = F.normalize(
-        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    _, k, v, beta, g_in = generate_random_inputs(T, H, HG, D)
+    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
+    A = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+    A_inv = ref_solve_tril(A, C, tc.cu_seqlens_list)
+    w, u = ref_wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
+    stream = torch.npu.current_stream()._as_parameter_
+
+    k_npu, g_sum_npu, w_npu, u_npu = (
+        k.to(torch.float16).npu(),
+        g_sum.to(torch.float32).npu(),
+        w.to(torch.float16).npu(),
+        u.to(torch.float16).npu(),
     )
-    q = F.normalize(
-        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
-    )
-    w = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
-    u = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
-    g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(g_in.dtype).to(dev)
-    g_t = transpose_gates(g_sum)
+    g_t = transpose_gates(g_sum_npu)
+
     stream = torch.npu.current_stream()._as_parameter_
     tc_n = total_chunks(N_seq, T, C, cu)
-    s_out = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
+    h_out = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
     v_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
     fs_out = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
     run_chunk_h(
-        k,
-        w,
-        u,
-        g_sum,
-        s_out,
+        k_npu,
+        w_npu,
+        u_npu,
+        g_sum_npu,
+        h_out,
         v_out,
         fs_out,
         stream=stream,
@@ -525,15 +483,68 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         key_heads=HG,
     )
     torch.npu.synchronize()
-    msk = torch.tril(torch.ones(C, C, device=dev), diagonal=0).float()
+    h_ref, v_ref, _ = ref_chunk_h(
+        k, w.to(torch.float16), u.to(torch.float16), g_sum, C, tc.cu_seqlens_list
+    )
+    ok_h = ACCURACY.stats_ok(
+        h_out.cpu().to(tc.dtype).view(tc_n, H, D, D), h_ref.to(tc.dtype), chunk_size=C
+    )
+    ok_v = ACCURACY.stats_ok(v_out.cpu().to(tc.dtype), v_ref.to(tc.dtype), chunk_size=C)
+    return ok_h and ok_v
+
+
+def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
+    T = tc.T
+    ref_cumsum = tc.ref_gdn.cumsum
+    ref_wy_fast = tc.ref_gdn.wy_fast
+    ref_solve_tril = tc.ref_gdn.solve_tril
+    ref_kkt = tc.ref_gdn.kkt
+    ref_chunk_h = tc.ref_gdn.chunk_h
+    ref_chunk_o = tc.ref_gdn.chunk_o
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
+    N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
+
+    torch.manual_seed(42)
+    q, k, v, beta, g_in = generate_random_inputs(T, H, HG, D)
+    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
+    A = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+    A_inv = ref_solve_tril(A, C, tc.cu_seqlens_list)
+    w, u = ref_wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
+    h_states, v_new, _ = ref_chunk_h(k, w, u, g_sum, C, tc.cu_seqlens_list)
+
+    stream = torch.npu.current_stream()._as_parameter_
+
+    q_npu, k_npu, g_sum_npu, v_new_npu, h_states_npu = (
+        q.to(torch.float16).npu(),
+        k.to(torch.float16).npu(),
+        g_sum.to(torch.float32).npu(),
+        v_new.to(torch.float16).npu(),
+        h_states.to(torch.float16).npu(),
+    )
+
+    o_ref = ref_chunk_o(
+        q_npu.cpu(),
+        k_npu.cpu(),
+        v_new_npu.cpu(),
+        h_states_npu.cpu(),
+        g_sum_npu.cpu(),
+        C,
+        tc.cu_seqlens_list,
+    )
+    mask_npu = torch.tril(torch.ones(C, C, device=dev), diagonal=0).float()
     o_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
+    g_t = transpose_gates(g_sum_npu)
     run_chunk_o(
-        q,
-        k,
-        v_out,
-        s_out,
-        g_sum,
-        msk,
+        q_npu,
+        k_npu,
+        v_new_npu,
+        h_states_npu,
+        g_sum_npu,
+        mask_npu,
         o_out,
         stream=stream,
         g_t=g_t,
@@ -543,10 +554,7 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         key_heads=HG,
     )
     torch.npu.synchronize()
-    s_re = s_out.cpu().to(tc.dtype).view(tc_n, H, D, D)
-    o_ref = ref_chunk_o(
-        q.cpu(), k.cpu(), v_out.cpu(), s_re, g_sum.cpu(), C, tc.cu_seqlens_list
-    )
+
     return ACCURACY.stats_ok(o_out.cpu().to(tc.dtype), o_ref.to(tc.dtype), chunk_size=C)
 
 

--- a/tests/test_single_kernels.py
+++ b/tests/test_single_kernels.py
@@ -22,13 +22,10 @@ import sys
 import time
 from dataclasses import dataclass
 
-import numpy as np
 import torch
-import torch.nn.functional as F
 
 from megagdn_pto.fast_inverse import load_tri_inverse, solve_tril
 from megagdn_pto.kernel_libs import (
-    BLOCK_DIM,
     run_chunk_cumsum,
     run_chunk_h,
     run_chunk_o,
@@ -39,226 +36,14 @@ from megagdn_pto.kernel_libs import (
     transpose_gates,
 )
 from tests.utils import NumericalAccuracy, generate_random_inputs
+from tests.ref_gdn import RefGDN
 
 ACCURACY = NumericalAccuracy()
 
 C = 128  # PTO chunk size
 D = 128  # head dimension
 
-# ---------------------------------------------------------------------------
-# CPU Reference implementations
-# ---------------------------------------------------------------------------
-
-
-def _safe_exp(x: torch.Tensor) -> torch.Tensor:
-    return torch.where(x <= 0, torch.exp(x), torch.zeros_like(x))
-
-
-def _seq_ranges(T: int, cu_seqlens=None) -> list[tuple[int, int]]:
-    if cu_seqlens is None:
-        return [(0, T)]
-    cu = cu_seqlens.tolist() if hasattr(cu_seqlens, "tolist") else cu_seqlens
-    return [(cu[i], cu[i + 1]) for i in range(len(cu) - 1)]
-
-
-class RefGDN:
-    def __init__(self, dtype: torch.dtype):
-        self.dtype = dtype
-
-    def cumsum(self, g: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
-        """Chunk-local cumulative sum of gates (fp32)."""
-        B, T, H = g.shape
-        gf = g.to(self.dtype)
-        out = torch.zeros_like(gf, dtype=self.dtype)
-        for bos, eos in _seq_ranges(T, cu_seqlens):
-            for j in range(0, eos - bos, cs):
-                s, e = bos + j, min(bos + j + cs, eos)
-                out[:, s:e, :] = gf[:, s:e, :].cumsum(dim=1)
-        return out
-
-    def solve_tril(self, A: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
-        """CPU reference for solve_tril: computes (I + A)^{-1} per chunk submatrix.
-
-        A is strictly lower triangular [B, T, H, cs] (PTO convention).
-        """
-        B, T, H, _ = A.shape
-        out = torch.zeros(B, T, H, cs, dtype=self.dtype)
-        Af = A.to(self.dtype)
-        for bos, eos in _seq_ranges(T, cu_seqlens):
-            for j in range(0, eos - bos, cs):
-                s, e = bos + j, min(bos + j + cs, eos)
-                v = e - s
-                for h in range(H):
-                    Ac = Af[0, s:e, h, :v]  # [v, v], strictly lower triangular
-                    # inv = torch.linalg.inv(torch.eye(v) + Ac)
-                    M = np.linalg.inv((np.identity(v) + Ac.numpy()).astype(np.double))
-                    inv = torch.from_numpy(M)
-                    out[0, s:e, h, :v] = inv.to(self.dtype)
-        return out
-
-    def kkt(
-        self,
-        k: torch.Tensor,
-        beta: torch.Tensor,
-        g_cumsum: torch.Tensor,
-        cs: int,
-        cu_seqlens=None,
-    ) -> torch.Tensor:
-        """CPU reference for scaled_dot_kkt (GQA: k has Hg heads, beta/g have H heads)."""
-        B, T, Hg, Dd = k.shape
-        H = beta.shape[2]
-        grp = H // Hg
-        out = torch.zeros(B, T, H, cs, dtype=self.dtype)
-        kf, bf, gf = k.to(self.dtype), beta.to(self.dtype), g_cumsum.to(self.dtype)
-        for bos, eos in _seq_ranges(T, cu_seqlens):
-            for j in range(0, eos - bos, cs):
-                s, e = bos + j, min(bos + j + cs, eos)
-                v = e - s
-                for h in range(H):
-                    hg = h // grp
-                    kc, gc = kf[0, s:e, hg, :], gf[0, s:e, h]
-                    blk = (
-                        (kc @ kc.T)
-                        * _safe_exp(gc[:, None] - gc[None, :])
-                        * bf[0, s:e, h, None]
-                    )
-                    mask = torch.arange(v)[:, None] > torch.arange(v)[None, :]
-                    out[0, s:e, h, :v] = blk * mask.to(self.dtype)
-        return out
-
-    def chunk_h(
-        self,
-        k: torch.Tensor,
-        w: torch.Tensor,
-        u: torch.Tensor,
-        g_cumsum: torch.Tensor,
-        cs: int,
-        cu_seqlens=None,
-    ):
-        """CPU reference for chunk_h: states S, v_new, final states."""
-        B, T, Hg, Dd = k.shape
-        H = w.shape[2]
-        grp = H // Hg
-        kf, wf, uf, gf = (
-            k.to(self.dtype),
-            w.to(self.dtype),
-            u.to(self.dtype),
-            g_cumsum.to(self.dtype),
-        )
-        ranges = _seq_ranges(T, cu_seqlens)
-        tc = total_chunks(
-            len(ranges), T, cs, torch.tensor(cu_seqlens) if cu_seqlens else None
-        )
-        h_out = torch.zeros(tc, H, Dd, Dd, dtype=self.dtype)
-        v_new = torch.zeros_like(uf)
-        final = torch.zeros(len(ranges), H, Dd, Dd, dtype=self.dtype)
-        ci_base = 0
-        for si, (bos, eos) in enumerate(ranges):
-            nc = (eos - bos + cs - 1) // cs
-            for h in range(H):
-                hg = h // grp
-                S = torch.zeros(Dd, Dd, dtype=self.dtype)
-                for ci in range(nc):
-                    s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
-                    gc = gf[0, s:e, h]
-                    gl = gc[e - s - 1]
-                    h_out[ci_base + ci, h] = S.clone()
-                    vc = uf[0, s:e, h, :] - wf[0, s:e, h, :] @ S
-                    v_new[0, s:e, h, :] = vc
-                    kv = kf[0, s:e, hg, :].T @ (vc * torch.exp(gl - gc)[:, None])
-                    S = torch.exp(gl) * S + kv
-                final[si, h] = S
-            ci_base += nc
-        return h_out, v_new, final
-
-    def wy_fast(
-        self,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        beta: torch.Tensor,
-        A_inv: torch.Tensor,
-        g_cumsum: torch.Tensor,
-        cs: int,
-        cu_seqlens=None,
-    ):
-        """CPU reference for wy_fast."""
-        B, T, Hg, Kd = k.shape
-        H = v.shape[2]
-        grp = H // Hg
-        w = torch.zeros(B, T, H, Kd, dtype=self.dtype)
-        u = torch.zeros(B, T, H, v.shape[-1], dtype=self.dtype)
-        kf, vf, bf, Af, gf = (
-            k.to(dtype=self.dtype),
-            v.to(dtype=self.dtype),
-            beta.to(dtype=self.dtype),
-            A_inv.to(dtype=self.dtype),
-            g_cumsum.to(dtype=self.dtype),
-        )
-        for bos, eos in _seq_ranges(T, cu_seqlens):
-            for j in range(0, eos - bos, cs):
-                s, e = bos + j, min(bos + j + cs, eos)
-                valid = e - s
-                for h in range(H):
-                    hg = h // grp
-                    Ab = Af[0, s:e, h, :valid]
-                    gc = gf[0, s:e, h]
-                    vb = vf[0, s:e, h, :] * bf[0, s:e, h, None]
-                    kb = (
-                        kf[0, s:e, hg, :] * bf[0, s:e, h, None] * torch.exp(gc)[:, None]
-                    )
-                    u[0, s:e, h, :] = Ab @ vb
-                    w[0, s:e, h, :] = Ab @ kb
-        return w, u
-
-    def chunk_o(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v_new: torch.Tensor,
-        h_states: torch.Tensor,
-        g_cumsum: torch.Tensor,
-        cs: int,
-        cu_seqlens=None,
-    ) -> torch.Tensor:
-        """CPU reference for chunk_o (PTO gating convention: min(Δg, 0))."""
-        B, T, Hg, Dd = q.shape
-        H = v_new.shape[2]
-        grp = H // Hg
-        qf, kf, vf, hf, gf = (
-            q.to(self.dtype),
-            k.to(self.dtype),
-            v_new.to(self.dtype),
-            h_states.to(self.dtype),
-            g_cumsum.to(self.dtype),
-        )
-        o = torch.zeros(B, T, H, Dd, dtype=self.dtype)
-        ranges = _seq_ranges(T, cu_seqlens)
-        ci_base = 0
-        for bos, eos in ranges:
-            nc = (eos - bos + cs - 1) // cs
-            for h in range(H):
-                hg = h // grp
-                for ci in range(nc):
-                    s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
-                    vlen = e - s
-                    qc, kc, vc, gc = (
-                        qf[0, s:e, hg, :],
-                        kf[0, s:e, hg, :],
-                        vf[0, s:e, h, :],
-                        gf[0, s:e, h],
-                    )
-                    inter = (qc @ hf[ci_base + ci, h]) * torch.exp(gc)[:, None]
-                    qk = qc @ kc.T
-                    causal = torch.arange(vlen)[:, None] >= torch.arange(vlen)[None, :]
-                    gate = torch.exp(
-                        torch.minimum(
-                            gc[:, None] - gc[None, :], torch.zeros(vlen, vlen)
-                        )
-                    )
-                    o[0, s:e, h, :] = inter + (qk * gate * causal.to(self.dtype)) @ vc
-            ci_base += nc
-        return o
-
+torch.manual_seed(42)
 
 # ---------------------------------------------------------------------------
 # Test cases
@@ -338,31 +123,31 @@ def build_test_cases() -> list[TestCase]:
 
 def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    ref_cumsum = tc.ref_gdn.cumsum
-    ref_kkt = tc.ref_gdn.kkt
+
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
         else None
     )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
-    torch.manual_seed(42)
-    k = F.normalize(
-        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    _, k, _, beta, g_in = generate_random_inputs(T, H, HG, D)
+
+    g_sum = tc.ref_gdn.cumsum(g_in, C, tc.cu_seqlens_list).to(g_in.dtype)
+    k_npu, beta_npu, g_sum_npu = (
+        k.to(torch.float16).to(dev),
+        beta.to(torch.float16).to(dev),
+        g_sum.to(torch.float32).to(dev),
     )
-    beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
-    g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(g_in.dtype).to(dev)
-    g_t, beta_t = transpose_gates(g_sum), transpose_beta(beta)
-    msk = torch.tril(torch.ones(C, C, device=dev), diagonal=-1).float()
+    g_t, beta_t = transpose_gates(g_sum_npu), transpose_beta(beta_npu)
+    mask = torch.tril(torch.ones(C, C, device=dev, dtype=torch.float32), diagonal=-1)
     A_out = torch.zeros(1, T, H, C, device=dev, dtype=torch.float16)
     stream = torch.npu.current_stream()._as_parameter_
     torch.npu.synchronize()
     run_scaled_dot_kkt(
-        k,
-        beta,
-        g_sum,
-        msk,
+        k_npu,
+        beta_npu,
+        g_sum_npu,
+        mask,
         A_out,
         stream=stream,
         g_t=g_t,
@@ -373,17 +158,34 @@ def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         key_heads=HG,
     )
     torch.npu.synchronize()
-    ref = ref_kkt(k.cpu(), beta.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
+    ref = tc.ref_gdn.kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
 
     return ACCURACY.stats_ok(A_out.cpu().to(tc.dtype), ref.to(tc.dtype), chunk_size=C)
 
 
+def test_solve_tril(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
+    T = tc.T
+
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
+    _, k, _, beta, g_in = generate_random_inputs(T, H, HG, D)
+    g_sum = tc.ref_gdn.cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(tc.dtype)
+    A_raw = tc.ref_gdn.kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+
+    A_dev = A_raw.to(torch.float16).to(dev)
+    tri_inv = load_tri_inverse()
+    A_inv = solve_tril(A_dev, cu, C, H, tri_inv)
+    torch.npu.synchronize()
+    ref = tc.ref_gdn.solve_tril(A_dev.cpu(), C, tc.cu_seqlens_list)
+    return ACCURACY.stats_ok(A_inv.cpu().to(tc.dtype), ref.to(tc.dtype), chunk_size=C)
+
+
 def test_wy_fast(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    ref_cumsum = tc.ref_gdn.cumsum
-    ref_wy_fast = tc.ref_gdn.wy_fast
-    ref_solve_tril = tc.ref_gdn.solve_tril
-    ref_kkt = tc.ref_gdn.kkt
+
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -391,11 +193,10 @@ def test_wy_fast(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
 
-    torch.manual_seed(42)
     _, k, v, beta, g_in = generate_random_inputs(T, H, HG, D)
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
-    A = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
-    A_inv = ref_solve_tril(A, C, tc.cu_seqlens_list)
+    g_sum = tc.ref_gdn.cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
+    A = tc.ref_gdn.kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+    A_inv = tc.ref_gdn.solve_tril(A, C, tc.cu_seqlens_list)
     stream = torch.npu.current_stream()._as_parameter_
 
     k_npu, v_npu, beta_npu, g_sum_npu, A_inv_npu = (
@@ -426,7 +227,7 @@ def test_wy_fast(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         key_heads=HG,
     )
     torch.npu.synchronize()
-    w_ref, u_ref = ref_wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
+    w_ref, u_ref = tc.ref_gdn.wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
     return ACCURACY.stats_ok(
         w_out.cpu().to(tc.dtype), w_ref.to(tc.dtype), chunk_size=C
     ) and ACCURACY.stats_ok(u_out.cpu().to(tc.dtype), u_ref.to(tc.dtype), chunk_size=C)
@@ -434,11 +235,7 @@ def test_wy_fast(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
 
 def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    ref_cumsum = tc.ref_gdn.cumsum
-    ref_wy_fast = tc.ref_gdn.wy_fast
-    ref_solve_tril = tc.ref_gdn.solve_tril
-    ref_kkt = tc.ref_gdn.kkt
-    ref_chunk_h = tc.ref_gdn.chunk_h
+
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -446,12 +243,11 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
 
-    torch.manual_seed(42)
     _, k, v, beta, g_in = generate_random_inputs(T, H, HG, D)
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
-    A = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
-    A_inv = ref_solve_tril(A, C, tc.cu_seqlens_list)
-    w, u = ref_wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
+    g_sum = tc.ref_gdn.cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
+    A = tc.ref_gdn.kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+    A_inv = tc.ref_gdn.solve_tril(A, C, tc.cu_seqlens_list)
+    w, u = tc.ref_gdn.wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
     stream = torch.npu.current_stream()._as_parameter_
 
     k_npu, g_sum_npu, w_npu, u_npu = (
@@ -462,7 +258,6 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     g_t = transpose_gates(g_sum_npu)
 
-    stream = torch.npu.current_stream()._as_parameter_
     tc_n = total_chunks(N_seq, T, C, cu)
     h_out = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
     v_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
@@ -483,7 +278,7 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         key_heads=HG,
     )
     torch.npu.synchronize()
-    h_ref, v_ref, _ = ref_chunk_h(
+    h_ref, v_ref, _ = tc.ref_gdn.chunk_h(
         k, w.to(torch.float16), u.to(torch.float16), g_sum, C, tc.cu_seqlens_list
     )
     ok_h = ACCURACY.stats_ok(
@@ -495,12 +290,7 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
 
 def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    ref_cumsum = tc.ref_gdn.cumsum
-    ref_wy_fast = tc.ref_gdn.wy_fast
-    ref_solve_tril = tc.ref_gdn.solve_tril
-    ref_kkt = tc.ref_gdn.kkt
-    ref_chunk_h = tc.ref_gdn.chunk_h
-    ref_chunk_o = tc.ref_gdn.chunk_o
+
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
@@ -508,13 +298,12 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
 
-    torch.manual_seed(42)
     q, k, v, beta, g_in = generate_random_inputs(T, H, HG, D)
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
-    A = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
-    A_inv = ref_solve_tril(A, C, tc.cu_seqlens_list)
-    w, u = ref_wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
-    h_states, v_new, _ = ref_chunk_h(k, w, u, g_sum, C, tc.cu_seqlens_list)
+    g_sum = tc.ref_gdn.cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
+    A = tc.ref_gdn.kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+    A_inv = tc.ref_gdn.solve_tril(A, C, tc.cu_seqlens_list)
+    w, u = tc.ref_gdn.wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
+    h_states, v_new, _ = tc.ref_gdn.chunk_h(k, w, u, g_sum, C, tc.cu_seqlens_list)
 
     stream = torch.npu.current_stream()._as_parameter_
 
@@ -526,7 +315,7 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         h_states.to(torch.float16).npu(),
     )
 
-    o_ref = ref_chunk_o(
+    o_ref = tc.ref_gdn.chunk_o(
         q_npu.cpu(),
         k_npu.cpu(),
         v_new_npu.cpu(),
@@ -560,14 +349,14 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
 
 def test_cumsum(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    ref_cumsum = tc.ref_gdn.cumsum
+
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
         else None
     )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
-    torch.manual_seed(42)
+
     g = torch.randn(1, T, H, device=dev, dtype=torch.float32)
     g_sum = torch.empty_like(g)
     stream = torch.npu.current_stream()._as_parameter_
@@ -575,33 +364,8 @@ def test_cumsum(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         g, g_sum, stream=stream, chunk_size=C, cu_seqlens=cu, batch_size_override=N_seq
     )
     torch.npu.synchronize()
-    ref = ref_cumsum(g.cpu(), C, tc.cu_seqlens_list)
+    ref = tc.ref_gdn.cumsum(g.cpu(), C, tc.cu_seqlens_list)
     return ACCURACY.stats_ok(g_sum.cpu().to(tc.dtype), ref.to(tc.dtype))
-
-
-def test_solve_tril(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
-    T = tc.T
-    ref_solve_tril = tc.ref_gdn.solve_tril
-    ref_cumsum = tc.ref_gdn.cumsum
-    ref_kkt = tc.ref_gdn.kkt
-    cu = (
-        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
-        if tc.cu_seqlens_list
-        else None
-    )
-    torch.manual_seed(42)
-    k = F.normalize(torch.randn(1, T, HG, D, dtype=tc.dtype), dim=-1, p=2)
-    beta = torch.rand(1, T, H, dtype=tc.dtype)
-    g_in = F.logsigmoid(torch.randn(1, T, H, dtype=tc.dtype))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(tc.dtype)
-    A_raw = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
-
-    A_dev = A_raw.to(torch.float16).to(dev)
-    tri_inv = load_tri_inverse()
-    A_inv = solve_tril(A_dev, cu, C, H, tri_inv)
-    torch.npu.synchronize()
-    ref = ref_solve_tril(A_dev.cpu(), C, tc.cu_seqlens_list)
-    return ACCURACY.stats_ok(A_inv.cpu().to(tc.dtype), ref.to(tc.dtype), chunk_size=C)
 
 
 _STAGES = {

--- a/tests/test_single_kernels.py
+++ b/tests/test_single_kernels.py
@@ -38,7 +38,7 @@ from megagdn_pto.kernel_libs import (
     transpose_beta,
     transpose_gates,
 )
-from tests.utils import NumericalAccuracy
+from tests.utils import NumericalAccuracy, generate_random_inputs
 
 ACCURACY = NumericalAccuracy()
 
@@ -90,8 +90,10 @@ class RefGDN:
                 v = e - s
                 for h in range(H):
                     Ac = Af[0, s:e, h, :v]  # [v, v], strictly lower triangular
-                    inv = torch.linalg.inv(torch.eye(v) + Ac)
-                    out[0, s:e, h, :v] = inv
+                    # inv = torch.linalg.inv(torch.eye(v) + Ac)
+                    M = np.linalg.inv((np.identity(v) + Ac.numpy()).astype(np.double))
+                    inv = torch.from_numpy(M)
+                    out[0, s:e, h, :v] = inv.to(self.dtype)
         return out
 
     def kkt(
@@ -169,12 +171,12 @@ class RefGDN:
             ci_base += nc
         return h_out, v_new, final
 
-    def wy(
+    def wy_fast(
         self,
         k: torch.Tensor,
         v: torch.Tensor,
         beta: torch.Tensor,
-        A: torch.Tensor,
+        A_inv: torch.Tensor,
         g_cumsum: torch.Tensor,
         cs: int,
         cu_seqlens=None,
@@ -186,11 +188,11 @@ class RefGDN:
         w = torch.zeros(B, T, H, Kd, dtype=self.dtype)
         u = torch.zeros(B, T, H, v.shape[-1], dtype=self.dtype)
         kf, vf, bf, Af, gf = (
-            k.float(),
-            v.float(),
-            beta.float(),
-            A.float(),
-            g_cumsum.float(),
+            k.to(dtype=self.dtype),
+            v.to(dtype=self.dtype),
+            beta.to(dtype=self.dtype),
+            A_inv.to(dtype=self.dtype),
+            g_cumsum.to(dtype=self.dtype),
         )
         for bos, eos in _seq_ranges(T, cu_seqlens):
             for j in range(0, eos - bos, cs):
@@ -206,7 +208,7 @@ class RefGDN:
                     )
                     u[0, s:e, h, :] = Ab @ vb
                     w[0, s:e, h, :] = Ab @ kb
-        return w.to(k.dtype), u.to(v.dtype)
+        return w, u
 
     def chunk_o(
         self,
@@ -350,11 +352,12 @@ def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
     g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(dev)
+    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(g_in.dtype).to(dev)
     g_t, beta_t = transpose_gates(g_sum), transpose_beta(beta)
     msk = torch.tril(torch.ones(C, C, device=dev), diagonal=-1).float()
     A_out = torch.zeros(1, T, H, C, device=dev, dtype=torch.float16)
     stream = torch.npu.current_stream()._as_parameter_
+    torch.npu.synchronize()
     run_scaled_dot_kkt(
         k,
         beta,
@@ -371,10 +374,8 @@ def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     )
     torch.npu.synchronize()
     ref = ref_kkt(k.cpu(), beta.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
-    A_out_cpu = A_out.cpu()
-    torch.npu.synchronize()
-    print(f"max A_out: {A_out_cpu.abs().max().item()}")
-    return ACCURACY.stats_ok(A_out.cpu().to(tc.dtype), ref.to(tc.dtype))
+
+    return ACCURACY.stats_ok(A_out.cpu().to(tc.dtype), ref.to(tc.dtype), chunk_size=C)
 
 
 def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
@@ -394,7 +395,7 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     w = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     u = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(dev)
+    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(g_in.dtype).to(dev)
     g_t = transpose_gates(g_sum)
     stream = torch.npu.current_stream()._as_parameter_
     tc_n = total_chunks(N_seq, T, C, cu)
@@ -421,41 +422,49 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         k.cpu(), w.cpu(), u.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list
     )
     ok_h = ACCURACY.stats_ok(
-        s_out.cpu().to(tc.dtype).view(tc_n, H, D, D), h_ref.to(tc.dtype)
+        s_out.cpu().to(tc.dtype).view(tc_n, H, D, D), h_ref.to(tc.dtype), chunk_size=C
     )
-    ok_v = ACCURACY.stats_ok(v_out.cpu().to(tc.dtype), v_ref.to(tc.dtype))
+    ok_v = ACCURACY.stats_ok(v_out.cpu().to(tc.dtype), v_ref.to(tc.dtype), chunk_size=C)
     return ok_h and ok_v
 
 
-def test_wy(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
+def test_wy_fast(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
     ref_cumsum = tc.ref_gdn.cumsum
-    ref_wy = tc.ref_gdn.wy
+    ref_wy_fast = tc.ref_gdn.wy_fast
+    ref_solve_tril = tc.ref_gdn.solve_tril
+    ref_kkt = tc.ref_gdn.kkt
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
         else None
     )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
+
     torch.manual_seed(42)
-    k = F.normalize(
-        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
-    )
-    v = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
-    beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
-    A = torch.randn(1, T, H, C, device=dev, dtype=torch.float16)
-    g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(dev)
-    g_t, beta_t = transpose_gates(g_sum), transpose_beta(beta)
+    _, k, v, beta, g_in = generate_random_inputs(T, H, HG, D)
+    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list)
+    A = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+    A_inv = ref_solve_tril(A, C, tc.cu_seqlens_list)
     stream = torch.npu.current_stream()._as_parameter_
+
+    k_npu, v_npu, beta_npu, g_sum_npu, A_inv_npu = (
+        k.to(torch.float16).npu(),
+        v.to(torch.float16).npu(),
+        beta.to(torch.float16).npu(),
+        g_sum.to(torch.float32).npu(),
+        A_inv.to(torch.float16).npu(),
+    )
+    g_t, beta_t = transpose_gates(g_sum_npu), transpose_beta(beta_npu)
     w_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
     u_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
+
     run_wy_fast(
-        k,
-        v,
-        beta,
-        g_sum,
-        A,
+        k_npu,
+        v_npu,
+        beta_npu,
+        g_sum_npu,
+        A_inv_npu,
         w_out,
         u_out,
         stream=stream,
@@ -467,12 +476,10 @@ def test_wy(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
         key_heads=HG,
     )
     torch.npu.synchronize()
-    w_ref, u_ref = ref_wy(
-        k.cpu(), v.cpu(), beta.cpu(), A.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list
-    )
+    w_ref, u_ref = ref_wy_fast(k, v, beta, A_inv, g_sum, C, tc.cu_seqlens_list)
     return ACCURACY.stats_ok(
-        w_out.cpu().to(tc.dtype), w_ref.to(tc.dtype)
-    ) and ACCURACY.stats_ok(u_out.cpu().to(tc.dtype), u_ref.to(tc.dtype))
+        w_out.cpu().to(tc.dtype), w_ref.to(tc.dtype), chunk_size=C
+    ) and ACCURACY.stats_ok(u_out.cpu().to(tc.dtype), u_ref.to(tc.dtype), chunk_size=C)
 
 
 def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
@@ -495,7 +502,7 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     w = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     u = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
-    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(dev)
+    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(g_in.dtype).to(dev)
     g_t = transpose_gates(g_sum)
     stream = torch.npu.current_stream()._as_parameter_
     tc_n = total_chunks(N_seq, T, C, cu)
@@ -540,7 +547,7 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     o_ref = ref_chunk_o(
         q.cpu(), k.cpu(), v_out.cpu(), s_re, g_sum.cpu(), C, tc.cu_seqlens_list
     )
-    return ACCURACY.stats_ok(o_out.cpu().to(tc.dtype), o_ref.to(tc.dtype))
+    return ACCURACY.stats_ok(o_out.cpu().to(tc.dtype), o_ref.to(tc.dtype), chunk_size=C)
 
 
 def test_cumsum(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
@@ -567,31 +574,26 @@ def test_cumsum(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
 def test_solve_tril(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
     ref_solve_tril = tc.ref_gdn.solve_tril
+    ref_cumsum = tc.ref_gdn.cumsum
+    ref_kkt = tc.ref_gdn.kkt
     cu = (
         torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
         if tc.cu_seqlens_list
         else None
     )
     torch.manual_seed(42)
-    # Build A lower-triangular in the (time-within-chunk × chunk-col) space.
-    # Position-within-chunk = (t - bos) % C for each sequence starting at bos.
-    # This handles non-chunk-aligned sequence starts correctly.
-    # Use std=0.1 to keep (I+A)^{-1} well-conditioned in fp16.
-    t_within = torch.zeros(T, dtype=torch.long)
-    if tc.cu_seqlens_list is not None:
-        for i in range(len(tc.cu_seqlens_list) - 1):
-            bos, eos = tc.cu_seqlens_list[i], tc.cu_seqlens_list[i + 1]
-            t_within[bos:eos] = torch.arange(eos - bos) % C
-    else:
-        t_within = torch.arange(T) % C
-    chunk_mask = (t_within[:, None] > torch.arange(C)[None, :]).float()  # [T, C]
-    A_raw = torch.randn(1, T, H, C) * 0.1 * chunk_mask[None, :, None, :]
-    A = A_raw.to(torch.float16).to(dev)
+    k = F.normalize(torch.randn(1, T, HG, D, dtype=tc.dtype), dim=-1, p=2)
+    beta = torch.rand(1, T, H, dtype=tc.dtype)
+    g_in = F.logsigmoid(torch.randn(1, T, H, dtype=tc.dtype))
+    g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(tc.dtype)
+    A_raw = ref_kkt(k, beta, g_sum, C, tc.cu_seqlens_list)
+
+    A_dev = A_raw.to(torch.float16).to(dev)
     tri_inv = load_tri_inverse()
-    A_inv = solve_tril(A, cu, C, H, tri_inv)
+    A_inv = solve_tril(A_dev, cu, C, H, tri_inv)
     torch.npu.synchronize()
-    ref = ref_solve_tril(A.cpu(), C, tc.cu_seqlens_list)
-    return ACCURACY.stats_ok(A_inv.cpu().to(tc.dtype), ref.to(tc.dtype))
+    ref = ref_solve_tril(A_dev.cpu(), C, tc.cu_seqlens_list)
+    return ACCURACY.stats_ok(A_inv.cpu().to(tc.dtype), ref.to(tc.dtype), chunk_size=C)
 
 
 _STAGES = {
@@ -599,7 +601,7 @@ _STAGES = {
     "kkt": ("scaled_dot_kkt", test_kkt),
     "solve_tril": ("solve_tril", test_solve_tril),
     "chunk_h": ("chunk_h", test_chunk_h),
-    "wy_fast": ("wy_fast", test_wy),
+    "wy_fast": ("wy_fast", test_wy_fast),
     "chunk_o": ("chunk_o", test_chunk_o),
 }
 

--- a/tests/test_single_kernels.py
+++ b/tests/test_single_kernels.py
@@ -38,21 +38,17 @@ from megagdn_pto.kernel_libs import (
     transpose_beta,
     transpose_gates,
 )
+from tests.utils import NumericalAccuracy
+
+ACCURACY = NumericalAccuracy()
 
 C = 128  # PTO chunk size
 D = 128  # head dimension
 
-# Accuracy thresholds
-RTOL = 1e-2
-ATOL = 1e-5
-MAX_RMSE_RATIO = 0.05
-MIN_R2 = 0.99
-HARD_FAIL_MAX = 1.0
-
-
 # ---------------------------------------------------------------------------
 # CPU Reference implementations
 # ---------------------------------------------------------------------------
+
 
 def _seq_ranges(T: int, cu_seqlens=None) -> list[tuple[int, int]]:
     if cu_seqlens is None:
@@ -95,8 +91,13 @@ def ref_solve_tril(A: torch.Tensor, cs: int, cu_seqlens=None) -> torch.Tensor:
     return out
 
 
-def ref_kkt(k: torch.Tensor, beta: torch.Tensor, g_cumsum: torch.Tensor,
-            cs: int, cu_seqlens=None) -> torch.Tensor:
+def ref_kkt(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    g_cumsum: torch.Tensor,
+    cs: int,
+    cu_seqlens=None,
+) -> torch.Tensor:
     """CPU reference for scaled_dot_kkt (GQA: k has Hg heads, beta/g have H heads)."""
     B, T, Hg, Dd = k.shape
     H = beta.shape[2]
@@ -110,21 +111,33 @@ def ref_kkt(k: torch.Tensor, beta: torch.Tensor, g_cumsum: torch.Tensor,
             for h in range(H):
                 hg = h // grp
                 kc, gc = kf[0, s:e, hg, :], gf[0, s:e, h]
-                blk = (kc @ kc.T) * _safe_exp(gc[:, None] - gc[None, :]) * bf[0, s:e, h, None]
+                blk = (
+                    (kc @ kc.T)
+                    * _safe_exp(gc[:, None] - gc[None, :])
+                    * bf[0, s:e, h, None]
+                )
                 mask = torch.arange(v)[:, None] > torch.arange(v)[None, :]
                 out[0, s:e, h, :v] = blk * mask.float()
     return out
 
 
-def ref_chunk_h(k: torch.Tensor, w: torch.Tensor, u: torch.Tensor,
-                g_cumsum: torch.Tensor, cs: int, cu_seqlens=None):
+def ref_chunk_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g_cumsum: torch.Tensor,
+    cs: int,
+    cu_seqlens=None,
+):
     """CPU reference for chunk_h: states S, v_new, final states."""
     B, T, Hg, Dd = k.shape
     H = w.shape[2]
     grp = H // Hg
     kf, wf, uf, gf = k.float(), w.float(), u.float(), g_cumsum.float()
     ranges = _seq_ranges(T, cu_seqlens)
-    tc = total_chunks(len(ranges), T, cs, torch.tensor(cu_seqlens) if cu_seqlens else None)
+    tc = total_chunks(
+        len(ranges), T, cs, torch.tensor(cu_seqlens) if cu_seqlens else None
+    )
     h_out = torch.zeros(tc, H, Dd, Dd, dtype=torch.float32)
     v_new = torch.zeros_like(uf)
     final = torch.zeros(len(ranges), H, Dd, Dd, dtype=torch.float32)
@@ -148,8 +161,15 @@ def ref_chunk_h(k: torch.Tensor, w: torch.Tensor, u: torch.Tensor,
     return h_out, v_new, final
 
 
-def ref_wy(k: torch.Tensor, v: torch.Tensor, beta: torch.Tensor, A: torch.Tensor,
-           g_cumsum: torch.Tensor, cs: int, cu_seqlens=None):
+def ref_wy(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    g_cumsum: torch.Tensor,
+    cs: int,
+    cu_seqlens=None,
+):
     """CPU reference for wy_fast."""
     B, T, Hg, Kd = k.shape
     H = v.shape[2]
@@ -172,9 +192,15 @@ def ref_wy(k: torch.Tensor, v: torch.Tensor, beta: torch.Tensor, A: torch.Tensor
     return w.to(k.dtype), u.to(v.dtype)
 
 
-def ref_chunk_o(q: torch.Tensor, k: torch.Tensor, v_new: torch.Tensor,
-                h_states: torch.Tensor, g_cumsum: torch.Tensor, cs: int,
-                cu_seqlens=None) -> torch.Tensor:
+def ref_chunk_o(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v_new: torch.Tensor,
+    h_states: torch.Tensor,
+    g_cumsum: torch.Tensor,
+    cs: int,
+    cu_seqlens=None,
+) -> torch.Tensor:
     """CPU reference for chunk_o (PTO gating convention: min(Δg, 0))."""
     B, T, Hg, Dd = q.shape
     H = v_new.shape[2]
@@ -190,48 +216,27 @@ def ref_chunk_o(q: torch.Tensor, k: torch.Tensor, v_new: torch.Tensor,
             for ci in range(nc):
                 s, e = bos + ci * cs, min(bos + (ci + 1) * cs, eos)
                 vlen = e - s
-                qc, kc, vc, gc = qf[0, s:e, hg, :], kf[0, s:e, hg, :], vf[0, s:e, h, :], gf[0, s:e, h]
+                qc, kc, vc, gc = (
+                    qf[0, s:e, hg, :],
+                    kf[0, s:e, hg, :],
+                    vf[0, s:e, h, :],
+                    gf[0, s:e, h],
+                )
                 inter = (qc @ h_states[ci_base + ci, h]) * torch.exp(gc)[:, None]
                 qk = qc @ kc.T
                 causal = torch.arange(vlen)[:, None] >= torch.arange(vlen)[None, :]
-                gate = torch.exp(torch.minimum(gc[:, None] - gc[None, :], torch.zeros(vlen, vlen)))
+                gate = torch.exp(
+                    torch.minimum(gc[:, None] - gc[None, :], torch.zeros(vlen, vlen))
+                )
                 o[0, s:e, h, :] = inter + (qk * gate * causal.float()) @ vc
         ci_base += nc
     return o
 
 
 # ---------------------------------------------------------------------------
-# Statistical pass/fail
-# ---------------------------------------------------------------------------
-
-def _r2(y_ref: torch.Tensor, y_pred: torch.Tensor) -> float:
-    ref = y_ref.detach().cpu().numpy().ravel().astype(np.float64)
-    pred = y_pred.detach().cpu().numpy().ravel().astype(np.float64)
-    ss_res = np.sum((ref - pred) ** 2)
-    ss_tot = np.sum((ref - np.mean(ref)) ** 2)
-    return float("nan") if ss_tot < 1e-30 else 1.0 - ss_res / ss_tot
-
-
-def stats_ok(actual: torch.Tensor, expected: torch.Tensor) -> bool:
-    diff = (actual - expected).abs()
-    mx = diff.max().item()
-    if mx > HARD_FAIL_MAX:
-        return False
-    bound = ATOL + RTOL * expected.abs()
-    if (diff <= bound).all():
-        return True
-    mean_abs = float(expected.float().flatten().abs().mean())
-    rmse = float(torch.sqrt((diff.float().flatten() ** 2).mean()))
-    ratio = rmse / max(mean_abs, 1e-15)
-    r2 = _r2(expected, actual)
-    if mean_abs < 1e-9:
-        return rmse < 5e-4
-    return ratio <= MAX_RMSE_RATIO and np.isfinite(r2) and r2 >= MIN_R2
-
-
-# ---------------------------------------------------------------------------
 # Test cases
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class TestCase:
@@ -268,13 +273,24 @@ def build_test_cases() -> list[TestCase]:
     cases: list[TestCase] = []
     for T in [128, 256, 385, 512, 1024]:
         cases.append(TestCase(f"fixed T={T}", None, T))
-    for seqlens in [[128], [256], [384], [512], [256, 256], [128, 256], [384, 128],
-                    [128, 128, 128], [256, 128, 384]]:
+    for seqlens in [
+        [128],
+        [256],
+        [384],
+        [512],
+        [256, 256],
+        [128, 256],
+        [384, 128],
+        [128, 128, 128],
+        [256, 128, 384],
+    ]:
         cu = _cu_from_seqlens(seqlens)
         cases.append(TestCase(f"varlen {seqlens}", cu, cu[-1]))
     # Boundary-heavy cases
-    for seqlens in [[1, 63, 64, 65, 127, 128, 129, 447],
-                    [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]]:
+    for seqlens in [
+        [1, 63, 64, 65, 127, 128, 129, 447],
+        [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367],
+    ]:
         cu = _cu_from_seqlens(seqlens)
         cases.append(TestCase(f"varlen {seqlens}", cu, cu[-1]))
     rng = random.Random(42)
@@ -288,12 +304,19 @@ def build_test_cases() -> list[TestCase]:
 # Per-stage test runners
 # ---------------------------------------------------------------------------
 
+
 def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    cu = torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev) if tc.cu_seqlens_list else None
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
     torch.manual_seed(42)
-    k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
+    k = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
     beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
     g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
     g_sum = ref_cumsum(g_in.cpu(), C, tc.cu_seqlens_list).to(dev)
@@ -301,20 +324,37 @@ def test_kkt(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     msk = torch.tril(torch.ones(C, C, device=dev), diagonal=-1).float()
     A_out = torch.zeros(1, T, H, C, device=dev, dtype=torch.float16)
     stream = torch.npu.current_stream()._as_parameter_
-    run_scaled_dot_kkt(k, beta, g_sum, msk, A_out,
-                       stream=stream, g_t=g_t, beta_t=beta_t, chunk_size=C,
-                       cu_seqlens=cu, batch_size_override=N_seq, key_heads=HG)
+    run_scaled_dot_kkt(
+        k,
+        beta,
+        g_sum,
+        msk,
+        A_out,
+        stream=stream,
+        g_t=g_t,
+        beta_t=beta_t,
+        chunk_size=C,
+        cu_seqlens=cu,
+        batch_size_override=N_seq,
+        key_heads=HG,
+    )
     torch.npu.synchronize()
     ref = ref_kkt(k.cpu(), beta.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
-    return stats_ok(A_out.float().cpu(), ref)
+    return ACCURACY.stats_ok(A_out.float().cpu(), ref)
 
 
 def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    cu = torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev) if tc.cu_seqlens_list else None
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
     torch.manual_seed(42)
-    k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
+    k = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
     w = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     u = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
@@ -325,22 +365,42 @@ def test_chunk_h(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     s_out = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
     v_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
     fs_out = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
-    run_chunk_h(k, w, u, g_sum, s_out, v_out, fs_out,
-                stream=stream, g_t=g_t, chunk_size=C,
-                cu_seqlens=cu, batch_size_override=N_seq, key_heads=HG)
+    run_chunk_h(
+        k,
+        w,
+        u,
+        g_sum,
+        s_out,
+        v_out,
+        fs_out,
+        stream=stream,
+        g_t=g_t,
+        chunk_size=C,
+        cu_seqlens=cu,
+        batch_size_override=N_seq,
+        key_heads=HG,
+    )
     torch.npu.synchronize()
-    h_ref, v_ref, _ = ref_chunk_h(k.cpu(), w.cpu(), u.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
-    ok_h = stats_ok(s_out.float().cpu().view(tc_n, H, D, D), h_ref.float())
-    ok_v = stats_ok(v_out.float().cpu(), v_ref.float())
+    h_ref, v_ref, _ = ref_chunk_h(
+        k.cpu(), w.cpu(), u.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list
+    )
+    ok_h = ACCURACY.stats_ok(s_out.float().cpu().view(tc_n, H, D, D), h_ref.float())
+    ok_v = ACCURACY.stats_ok(v_out.float().cpu(), v_ref.float())
     return ok_h and ok_v
 
 
 def test_wy(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    cu = torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev) if tc.cu_seqlens_list else None
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
     torch.manual_seed(42)
-    k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
+    k = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
     v = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
     A = torch.randn(1, T, H, C, device=dev, dtype=torch.float16)
@@ -350,21 +410,46 @@ def test_wy(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     stream = torch.npu.current_stream()._as_parameter_
     w_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
     u_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
-    run_wy_fast(k, v, beta, g_sum, A, w_out, u_out,
-                stream=stream, g_t=g_t, beta_t=beta_t, chunk_size=C,
-                cu_seqlens=cu, batch_size_override=N_seq, key_heads=HG)
+    run_wy_fast(
+        k,
+        v,
+        beta,
+        g_sum,
+        A,
+        w_out,
+        u_out,
+        stream=stream,
+        g_t=g_t,
+        beta_t=beta_t,
+        chunk_size=C,
+        cu_seqlens=cu,
+        batch_size_override=N_seq,
+        key_heads=HG,
+    )
     torch.npu.synchronize()
-    w_ref, u_ref = ref_wy(k.cpu(), v.cpu(), beta.cpu(), A.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list)
-    return stats_ok(w_out.float().cpu(), w_ref.float()) and stats_ok(u_out.float().cpu(), u_ref.float())
+    w_ref, u_ref = ref_wy(
+        k.cpu(), v.cpu(), beta.cpu(), A.cpu(), g_sum.cpu(), C, tc.cu_seqlens_list
+    )
+    return ACCURACY.stats_ok(w_out.float().cpu(), w_ref.float()) and ACCURACY.stats_ok(
+        u_out.float().cpu(), u_ref.float()
+    )
 
 
 def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    cu = torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev) if tc.cu_seqlens_list else None
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
     torch.manual_seed(42)
-    k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
-    q = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
+    k = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
+    q = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
     w = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     u = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     g_in = F.logsigmoid(torch.randn(1, T, H, device=dev, dtype=torch.float32))
@@ -375,39 +460,74 @@ def test_chunk_o(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     s_out = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
     v_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
     fs_out = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
-    run_chunk_h(k, w, u, g_sum, s_out, v_out, fs_out,
-                stream=stream, g_t=g_t, chunk_size=C,
-                cu_seqlens=cu, batch_size_override=N_seq, key_heads=HG)
+    run_chunk_h(
+        k,
+        w,
+        u,
+        g_sum,
+        s_out,
+        v_out,
+        fs_out,
+        stream=stream,
+        g_t=g_t,
+        chunk_size=C,
+        cu_seqlens=cu,
+        batch_size_override=N_seq,
+        key_heads=HG,
+    )
     torch.npu.synchronize()
     msk = torch.tril(torch.ones(C, C, device=dev), diagonal=0).float()
     o_out = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
-    run_chunk_o(q, k, v_out, s_out, g_sum, msk, o_out,
-                stream=stream, g_t=g_t, chunk_size=C,
-                cu_seqlens=cu, batch_size_override=N_seq, key_heads=HG)
+    run_chunk_o(
+        q,
+        k,
+        v_out,
+        s_out,
+        g_sum,
+        msk,
+        o_out,
+        stream=stream,
+        g_t=g_t,
+        chunk_size=C,
+        cu_seqlens=cu,
+        batch_size_override=N_seq,
+        key_heads=HG,
+    )
     torch.npu.synchronize()
     s_re = s_out.float().cpu().view(tc_n, H, D, D)
-    o_ref = ref_chunk_o(q.cpu(), k.cpu(), v_out.cpu(), s_re, g_sum.cpu(), C, tc.cu_seqlens_list)
-    return stats_ok(o_out.float().cpu(), o_ref.float())
+    o_ref = ref_chunk_o(
+        q.cpu(), k.cpu(), v_out.cpu(), s_re, g_sum.cpu(), C, tc.cu_seqlens_list
+    )
+    return ACCURACY.stats_ok(o_out.float().cpu(), o_ref.float())
 
 
 def test_cumsum(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    cu = torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev) if tc.cu_seqlens_list else None
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
     N_seq = len(tc.cu_seqlens_list) - 1 if tc.cu_seqlens_list else 1
     torch.manual_seed(42)
     g = torch.randn(1, T, H, device=dev, dtype=torch.float32)
     g_sum = torch.empty_like(g)
     stream = torch.npu.current_stream()._as_parameter_
-    run_chunk_cumsum(g, g_sum, stream=stream, chunk_size=C,
-                     cu_seqlens=cu, batch_size_override=N_seq)
+    run_chunk_cumsum(
+        g, g_sum, stream=stream, chunk_size=C, cu_seqlens=cu, batch_size_override=N_seq
+    )
     torch.npu.synchronize()
     ref = ref_cumsum(g.cpu(), C, tc.cu_seqlens_list)
-    return stats_ok(g_sum.cpu(), ref)
+    return ACCURACY.stats_ok(g_sum.cpu(), ref)
 
 
 def test_solve_tril(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     T = tc.T
-    cu = torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev) if tc.cu_seqlens_list else None
+    cu = (
+        torch.tensor(tc.cu_seqlens_list, dtype=torch.int32, device=dev)
+        if tc.cu_seqlens_list
+        else None
+    )
     torch.manual_seed(42)
     # Build A lower-triangular in the (time-within-chunk × chunk-col) space.
     # Position-within-chunk = (t - bos) % C for each sequence starting at bos.
@@ -427,28 +547,34 @@ def test_solve_tril(tc: TestCase, dev: torch.device, H: int, HG: int) -> bool:
     A_inv = solve_tril(A, cu, C, H, tri_inv)
     torch.npu.synchronize()
     ref = ref_solve_tril(A.cpu(), C, tc.cu_seqlens_list)
-    return stats_ok(A_inv.float().cpu(), ref)
+    return ACCURACY.stats_ok(A_inv.float().cpu(), ref)
 
 
 _STAGES = {
-    "cumsum":     ("chunk_cumsum",   test_cumsum),
-    "kkt":        ("scaled_dot_kkt", test_kkt),
-    "solve_tril": ("solve_tril",     test_solve_tril),
-    "chunk_h":    ("chunk_h",        test_chunk_h),
-    "wy_fast":    ("wy_fast",        test_wy),
-    "chunk_o":    ("chunk_o",        test_chunk_o),
+    "cumsum": ("chunk_cumsum", test_cumsum),
+    "kkt": ("scaled_dot_kkt", test_kkt),
+    "solve_tril": ("solve_tril", test_solve_tril),
+    "chunk_h": ("chunk_h", test_chunk_h),
+    "wy_fast": ("wy_fast", test_wy),
+    "chunk_o": ("chunk_o", test_chunk_o),
 }
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--device", default=os.getenv("GDN_NPU_DEVICE", "npu:0"))
-    parser.add_argument("--quick", action="store_true", help="Run a single small test case.")
-    parser.add_argument("--H-list", default="16,32,48,64", help="Comma-separated value head counts.")
+    parser.add_argument(
+        "--quick", action="store_true", help="Run a single small test case."
+    )
+    parser.add_argument(
+        "--H-list", default="16,32,48,64", help="Comma-separated value head counts."
+    )
     parser.add_argument("--hg", type=int, default=16, help="Key head count Hg.")
-    parser.add_argument("--stage",
-                        default="cumsum,kkt,solve_tril,chunk_h,wy_fast,chunk_o",
-                        help="Comma-separated stages to test.")
+    parser.add_argument(
+        "--stage",
+        default="cumsum,kkt,solve_tril,chunk_h,wy_fast,chunk_o",
+        help="Comma-separated stages to test.",
+    )
     args = parser.parse_args()
 
     stages = [s.strip() for s in args.stage.split(",") if s.strip()]
@@ -463,7 +589,9 @@ def main() -> None:
 
     cases = [TestCase("quick T=128", None, 128)] if args.quick else build_test_cases()
 
-    print(f"Device: {args.device}  stages={stages}  H={heads_list}  Hg={HG}  D={D}  C={C}")
+    print(
+        f"Device: {args.device}  stages={stages}  H={heads_list}  Hg={HG}  D={D}  C={C}"
+    )
     all_pass = True
 
     for stage in stages:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,16 +12,7 @@ class NumericalAccuracy:
     atol: float = 1.5 * 1e-4
     # Frobenius norm-wise relative tolerance (average correct decimal digits).
     ftol: float = 1e-3
-    max_rmse_ratio: float = 0.05
-    min_r2: float = 0.99
     hard_fail_max: float = 1.0
-
-    def _r2(self, y_ref: torch.Tensor, y_pred: torch.Tensor) -> float:
-        ref = y_ref.detach().cpu().numpy().ravel().astype(np.float64)
-        pred = y_pred.detach().cpu().numpy().ravel().astype(np.float64)
-        ss_res = np.sum((ref - pred) ** 2)
-        ss_tot = np.sum((ref - np.mean(ref)) ** 2)
-        return float("nan") if ss_tot < 1e-30 else 1.0 - ss_res / ss_tot
 
     def stats_ok(
         self, actual: torch.Tensor, expected: torch.Tensor, chunk_size: int = 1
@@ -29,25 +20,25 @@ class NumericalAccuracy:
         adjusted_rtol = min(0.5, self.rtol * chunk_size)
 
         diff = (actual - expected).abs()
-        mx = diff.max().item()
-        if mx > self.hard_fail_max:
-            print(f"ERROR: mx fail: {mx} > {self.hard_fail_max}")
-            return False
-        bound = self.atol + adjusted_rtol * expected.abs()
-        f_err = torch.sqrt(torch.sum(diff**2) / torch.sum(expected**2))
-        if (diff <= bound).all():
-            return True
-        else:
+        max_abs_error = diff.max().item()
+        frob_rel_error = torch.sqrt(torch.sum(diff**2) / torch.sum(expected**2))
+        if max_abs_error > self.hard_fail_max:
             print(
-                f"ERROR: diff is greater than bound: {(diff/bound).max().item()}. ATOL={self.atol} -- RTOL={adjusted_rtol} -- F_ERR={f_err}"
+                f"ERROR: max_abs_error hard fail: {max_abs_error} > {self.hard_fail_max}"
             )
-        mean_abs = float(expected.float().flatten().abs().mean())
-        rmse = float(torch.sqrt((diff.float().flatten() ** 2).mean()))
-        ratio = rmse / max(mean_abs, 1e-15)
-        r2 = self._r2(expected, actual)
-        if mean_abs < 1e-9:
-            return rmse < 5e-4
-        return ratio <= self.max_rmse_ratio and np.isfinite(r2) and r2 >= self.min_r2
+            return False
+        rel_err_bound = self.atol + adjusted_rtol * expected.abs()
+        if (diff > rel_err_bound).all():
+            print(
+                f"ERROR: max relative error larger than the bound: {(diff).max().item()}. ATOL={self.atol} RTOL={adjusted_rtol}"
+            )
+            return False
+        if frob_rel_error > self.ftol:
+            print(
+                f"ERROR: large frobenius relative error: {frob_rel_error}. FTOL={self.ftol}"
+            )
+            return False
+        return True
 
 
 def generate_random_inputs(T, H, HG, D):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,39 @@
+import torch
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class NumericalAccuracy:
+    # Elem-wise relative tolerance. For fp16 this cannot be less than 1e-4 due to precision limits
+    rtol: float = 5e-2
+    # Elem-wise absolute tolerance. For fp16 this should be close to 2^{-14}, the smallest normalized fp16 number.
+    atol: float = 5e-5
+    # Frobenius norm-wise relative tolerance (average correct decimal digits). Should be smaller than RTOL.
+    ftol: float = 1e-3
+    max_rmse_ratio: float = 0.05
+    min_r2: float = 0.99
+    hard_fail_max: float = 1.0
+
+    def _r2(self, y_ref: torch.Tensor, y_pred: torch.Tensor) -> float:
+        ref = y_ref.detach().cpu().numpy().ravel().astype(np.float64)
+        pred = y_pred.detach().cpu().numpy().ravel().astype(np.float64)
+        ss_res = np.sum((ref - pred) ** 2)
+        ss_tot = np.sum((ref - np.mean(ref)) ** 2)
+        return float("nan") if ss_tot < 1e-30 else 1.0 - ss_res / ss_tot
+
+    def stats_ok(self, actual: torch.Tensor, expected: torch.Tensor) -> bool:
+        diff = (actual - expected).abs()
+        mx = diff.max().item()
+        if mx > self.hard_fail_max:
+            return False
+        bound = self.atol + self.rtol * expected.abs()
+        if (diff <= bound).all():
+            return True
+        mean_abs = float(expected.float().flatten().abs().mean())
+        rmse = float(torch.sqrt((diff.float().flatten() ** 2).mean()))
+        ratio = rmse / max(mean_abs, 1e-15)
+        r2 = self._r2(expected, actual)
+        if mean_abs < 1e-9:
+            return rmse < 5e-4
+        return ratio <= self.max_rmse_ratio and np.isfinite(r2) and r2 >= self.min_r2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,13 +23,20 @@ class NumericalAccuracy:
         return float("nan") if ss_tot < 1e-30 else 1.0 - ss_res / ss_tot
 
     def stats_ok(self, actual: torch.Tensor, expected: torch.Tensor) -> bool:
+        print(expected.abs().max().item())
+        print(actual.abs().max().item())
         diff = (actual - expected).abs()
+        # print(actual[0])
+        # print(actual)
         mx = diff.max().item()
         if mx > self.hard_fail_max:
+            print(f"ERROR: mx fail: {mx} > {self.hard_fail_max}")
             return False
         bound = self.atol + self.rtol * expected.abs()
         if (diff <= bound).all():
             return True
+        else:
+            print(f"ERROR: diff is greater than bound: max = {mx}")
         mean_abs = float(expected.float().flatten().abs().mean())
         rmse = float(torch.sqrt((diff.float().flatten() ** 2).mean()))
         ratio = rmse / max(mean_abs, 1e-15)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 import numpy as np
 from dataclasses import dataclass
 
@@ -6,10 +7,10 @@ from dataclasses import dataclass
 @dataclass
 class NumericalAccuracy:
     # Elem-wise relative tolerance. For fp16 this cannot be less than 1e-4 due to precision limits
-    rtol: float = 5e-2
+    rtol: float = 5e-3
     # Elem-wise absolute tolerance. For fp16 this should be close to 2^{-14}, the smallest normalized fp16 number.
-    atol: float = 5e-5
-    # Frobenius norm-wise relative tolerance (average correct decimal digits). Should be smaller than RTOL.
+    atol: float = 1.5 * 1e-4
+    # Frobenius norm-wise relative tolerance (average correct decimal digits).
     ftol: float = 1e-3
     max_rmse_ratio: float = 0.05
     min_r2: float = 0.99
@@ -22,21 +23,24 @@ class NumericalAccuracy:
         ss_tot = np.sum((ref - np.mean(ref)) ** 2)
         return float("nan") if ss_tot < 1e-30 else 1.0 - ss_res / ss_tot
 
-    def stats_ok(self, actual: torch.Tensor, expected: torch.Tensor) -> bool:
-        print(expected.abs().max().item())
-        print(actual.abs().max().item())
+    def stats_ok(
+        self, actual: torch.Tensor, expected: torch.Tensor, chunk_size: int = 1
+    ) -> bool:
+        adjusted_rtol = min(0.5, self.rtol * chunk_size)
+
         diff = (actual - expected).abs()
-        # print(actual[0])
-        # print(actual)
         mx = diff.max().item()
         if mx > self.hard_fail_max:
             print(f"ERROR: mx fail: {mx} > {self.hard_fail_max}")
             return False
-        bound = self.atol + self.rtol * expected.abs()
+        bound = self.atol + adjusted_rtol * expected.abs()
+        f_err = torch.sqrt(torch.sum(diff**2) / torch.sum(expected**2))
         if (diff <= bound).all():
             return True
         else:
-            print(f"ERROR: diff is greater than bound: max = {mx}")
+            print(
+                f"ERROR: diff is greater than bound: {(diff/bound).max().item()}. ATOL={self.atol} -- RTOL={adjusted_rtol} -- F_ERR={f_err}"
+            )
         mean_abs = float(expected.float().flatten().abs().mean())
         rmse = float(torch.sqrt((diff.float().flatten() ** 2).mean()))
         ratio = rmse / max(mean_abs, 1e-15)
@@ -44,3 +48,12 @@ class NumericalAccuracy:
         if mean_abs < 1e-9:
             return rmse < 5e-4
         return ratio <= self.max_rmse_ratio and np.isfinite(r2) and r2 >= self.min_r2
+
+
+def generate_random_inputs(T, H, HG, D):
+    q = F.normalize(torch.randn(1, T, HG, D, dtype=torch.float16), dim=-1, p=2)
+    k = F.normalize(torch.randn(1, T, HG, D, dtype=torch.float16), dim=-1, p=2)
+    v = torch.randn(1, T, H, D, dtype=torch.float16)
+    beta = torch.rand(1, T, H, dtype=torch.float16)
+    g_in = F.logsigmoid(torch.randn(1, T, H, dtype=torch.float32))
+    return q, k, v, beta, g_in


### PR DESCRIPTION
Extends the unit tests (e2e and single kernel). Main changes:
- [x] Move reference implementation from `tests/test_single_kernels.py` into `tests/ref_gdn.py`
- [x] Move `stats_ok` function inside `tests/utils.py`, and add function to generate `q,k,v,beta,...` matrices for all tests.
- [x] allow different tolerance for different input formats (see `NumericalAccuracy` class)
- [x] allow different precision for ref implementation (given as input to `RefGDN` class)

closes #15 