### PR TITLE
feat: 122b has been tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - [1] Compared to the triton kernels used [in vllm-ascend](https://github.com/vllm-project/vllm-ascend/tree/v0.19.1rc1/vllm_ascend/ops/triton/fla)/[sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu/tree/2026.05.01/python/sgl_kernel_npu/sgl_kernel_npu/fla). See [Performance highlights](#performance-highlights).
 - [2] All 6 stages: `chunk_cumsum`, `scaled_dot_kkt`, `solve_tril`, `wy_fast`, `chunk_h`, `chunk_o`. Plus a merged metakernel to save kernel launch overhead.
-- [3] Tested model sizes: `0.8B`, `2B`, `4B`, `9B`, `27B`, `35B-A3B`. (`122B-A10B`, `397B-A17B` are also compatible in principle, yet to test)
+- [3] Tested model sizes: `0.8B`, `2B`, `4B`, `9B`, `27B`, `35B-A3B`, `122B-A10B`. (`397B-A17B` is yet to be tested, but compatible in principle).
 
 See full report [in English](blog/mega_gdn_en.md) or [in Chinese](blog/mega_gdn_zh.md).
 


### PR DESCRIPTION

We see a 37% increase in token/s throughput on the full GSM8k test set, while observing no loss in performance (pto is even better). Setup: Qwen 3.5 122B TP=4 and TP=8.

PTO backend
100%|██████████████████████████████████████████████████| 1319/1319 [19:22<00:00, 1.13it/s]
Accuracy: 0.961
Invalid: 0.000
Latency: 1162.949 s
Output throughput: 196.239 token/s

Triton backend
100%|██████████████████████████████████████████████████| 1319/1319 [26:11<00:00, 1.19s/it]
Accuracy: 0.954
Invalid: 0.000
Latency: 1571.015 s
Output throughput: 143.936 token/s