### PR TITLE
Make KDA head count a runtime kernel argument (staged + fused mega)

### DIFF
--- a/kernels/pto/chunk_h_kda.cpp
+++ b/kernels/pto/chunk_h_kda.cpp
@@ -48,10 +48,6 @@
 #include <runtime/rt_ffts.h>
 using namespace pto;
 
-#ifndef GDN_H
-#define GDN_H 16
-#endif
-
 #ifndef GDN_D
 #define GDN_D 128
 #endif
@@ -254,7 +250,7 @@ gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
 
 #endif
 
-template <int32_t NumHeads, int32_t HiddenSize, int32_t ChunkSize>
+template <int32_t HiddenSize, int32_t ChunkSize>
 AICORE void chunk_h_kda_kernel(
     __gm__ half *K_handle, __gm__ half *W_handle, __gm__ half *U_handle,
     __gm__ half *G_handle,
@@ -262,7 +258,7 @@ AICORE void chunk_h_kda_kernel(
     __gm__ half  *workspace_handle,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
   auto cid = get_block_idx();
   auto block_num = get_block_num();
@@ -273,9 +269,11 @@ AICORE void chunk_h_kda_kernel(
   constexpr int32_t K_DIM = HiddenSize;
   constexpr int32_t V_DIM = HiddenSize;
   constexpr int32_t C     = ChunkSize;
-  constexpr int32_t H     = NumHeads;       // HV in KDA terminology
+  // Head count (HV) is a runtime argument; it only drives the work-item decode
+  // and the BSND GM stride, never a UB buffer size or tile shape.
+  const int32_t H     = num_heads;          // HV in KDA terminology
   constexpr int32_t HalfC = C / 2;
-  constexpr int32_t BSND_STRIDE = H * HiddenSize;
+  const int32_t BSND_STRIDE = H * HiddenSize;
   constexpr int32_t HM_STRIDE   = HiddenSize;        // head-major K, G stride
   constexpr int32_t KV = K_DIM * V_DIM;
 
@@ -824,9 +822,9 @@ extern "C" __global__ AICORE void launch_chunk_h_kda(
     __gm__ uint8_t *workspace,
     __gm__ uint8_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
-  chunk_h_kda_kernel<GDN_H, GDN_D, GDN_C>(
+  chunk_h_kda_kernel<GDN_D, GDN_C>(
       reinterpret_cast<__gm__ half *>(K),
       reinterpret_cast<__gm__ half *>(W),
       reinterpret_cast<__gm__ half *>(U),
@@ -835,7 +833,7 @@ extern "C" __global__ AICORE void launch_chunk_h_kda(
       reinterpret_cast<__gm__ half *>(V_corr),
       reinterpret_cast<__gm__ half *>(workspace),
       reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
-      batch_size, seq_len, total_tokens, ffts_addr);
+      batch_size, seq_len, total_tokens, num_heads, ffts_addr);
 }
 
 extern "C" void call_kernel(
@@ -844,12 +842,14 @@ extern "C" void call_kernel(
     uint8_t *S, uint8_t *V_corr,
     uint8_t *workspace,
     uint8_t *cu_seqlens,
-    int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint32_t num_heads)
 {
   uint32_t fftsLen{0};
   uint64_t fftsAddr{0};
   rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
   launch_chunk_h_kda<<<block_dim, nullptr, stream>>>(
       K, W, U, G, S, V_corr, workspace, cu_seqlens,
-      batch_size, seq_len, total_tokens, fftsAddr);
+      batch_size, seq_len, total_tokens,
+      static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/kernels/pto/chunk_o_kda.cpp
+++ b/kernels/pto/chunk_o_kda.cpp
@@ -58,10 +58,6 @@
 #include <runtime/rt_ffts.h>
 using namespace pto;
 
-#ifndef GDN_H
-#define GDN_H 16
-#endif
-
 #ifndef GDN_D
 #define GDN_D 128
 #endif
@@ -191,7 +187,7 @@ gemm_oneshot(TileMatL1<T1, M, K, M, K> &A,
 
 #endif
 
-template <int32_t NumHeads, int32_t HiddenSize, int32_t ChunkSize>
+template <int32_t HiddenSize, int32_t ChunkSize>
 AICORE void chunk_o_kda_kernel(
     __gm__ half *Q_handle, __gm__ half *K_handle,
     __gm__ half *V_handle, __gm__ half *S_handle,
@@ -200,7 +196,7 @@ AICORE void chunk_o_kda_kernel(
     __gm__ half *O_handle,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
   auto cid = get_block_idx();
   auto block_num = get_block_num();
@@ -209,9 +205,11 @@ AICORE void chunk_o_kda_kernel(
   constexpr int32_t K_DIM = HiddenSize;
   constexpr int32_t V_DIM = HiddenSize;
   constexpr int32_t C     = ChunkSize;
-  constexpr int32_t H     = NumHeads;       // HV in KDA terminology
+  // Head count (HV) is a runtime argument; it only drives the work-item decode
+  // and the BSND GM stride, never a UB buffer size or tile shape.
+  const int32_t H     = num_heads;          // HV in KDA terminology
   constexpr int32_t HalfC = C / 2;
-  constexpr int32_t BSND_STRIDE = H * HiddenSize;
+  const int32_t BSND_STRIDE = H * HiddenSize;
   constexpr int32_t HM_STRIDE   = HiddenSize;    // head-major Q, K, G stride
   constexpr int32_t KV = K_DIM * V_DIM;
 
@@ -867,9 +865,9 @@ extern "C" __global__ AICORE void launch_chunk_o_kda(
     __gm__ uint8_t *workspace, __gm__ uint8_t *O,
     __gm__ uint8_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
-  chunk_o_kda_kernel<GDN_H, GDN_D, GDN_C>(
+  chunk_o_kda_kernel<GDN_D, GDN_C>(
       reinterpret_cast<__gm__ half *>(Q),
       reinterpret_cast<__gm__ half *>(K),
       reinterpret_cast<__gm__ half *>(V_corr),
@@ -879,7 +877,7 @@ extern "C" __global__ AICORE void launch_chunk_o_kda(
       reinterpret_cast<__gm__ half  *>(workspace),
       reinterpret_cast<__gm__ half *>(O),
       reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
-      batch_size, seq_len, total_tokens, ffts_addr);
+      batch_size, seq_len, total_tokens, num_heads, ffts_addr);
 }
 
 extern "C" void call_kernel(
@@ -888,12 +886,14 @@ extern "C" void call_kernel(
     uint8_t *G, uint8_t *Mask,
     uint8_t *workspace, uint8_t *O,
     uint8_t *cu_seqlens,
-    int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint32_t num_heads)
 {
   uint32_t fftsLen{0};
   uint64_t fftsAddr{0};
   rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
   launch_chunk_o_kda<<<block_dim, nullptr, stream>>>(
       Q, K, V_corr, S, G, Mask, workspace, O, cu_seqlens,
-      batch_size, seq_len, total_tokens, fftsAddr);
+      batch_size, seq_len, total_tokens,
+      static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/kernels/pto/gate_cumsum_kda.cpp
+++ b/kernels/pto/gate_cumsum_kda.cpp
@@ -24,10 +24,12 @@
 //   Number of column tiles per chunk = RowWidth / ColTile
 //   (e.g. HV=4,K=128 → 4 tiles; HV=8 → 8 tiles).
 //
-// Template parameters (injected by bisheng at compile time):
-//   GDN_H  = HV (number of value/gate heads)
+// Compile-time template parameters (injected by bisheng):
 //   GDN_D  = K  (key/gate vector dimension per head)
 //   GDN_C  = C  (chunk size in tokens)
+// Runtime argument:
+//   num_heads = HV (number of value/gate heads) — only affects loop bounds and
+//   GM strides, so it need not be a compile-time constant.
 //
 // ─── NPU / PTO recap (see chunk_cumsum.cpp for the full primer) ────────────
 //   GM  — off-chip DRAM shared by all AI cores.
@@ -41,10 +43,6 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 using namespace pto;
-
-#ifndef GDN_H
-#define GDN_H 4
-#endif
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -62,12 +60,12 @@ using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
                        RV, CV, pto::SLayout::NoneBox, 512, P>;
 #endif
 
-template <int32_t NumHeads, int32_t KDim, int32_t ChunkSize>
+template <int32_t KDim, int32_t ChunkSize>
 AICORE void gate_cumsum_kda_kernel(
     __gm__ half *g_ptr, __gm__ half *g_sum_ptr,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
   auto cid = get_block_idx();
   auto block_num = get_block_num();
@@ -82,19 +80,22 @@ AICORE void gate_cumsum_kda_kernel(
   set_vector_mask(-1, -1);
 
   // Flat 2D view of g: [total_tokens, HV*K] (row-major, contiguous).
-  constexpr int32_t RowWidth = NumHeads * KDim;
+  // Head count is a runtime argument, so RowWidth is runtime too.
+  const int32_t RowWidth = num_heads * KDim;
 
   // ColTile: number of HV*K columns processed in one UB-resident slice.
-  // 128 is safe for ChunkSize up to 128 (per-tile UB ≈ 66 KB) and divides
-  // RowWidth = HV*KDim whenever KDim is a multiple of 128 (the typical case).
+  // It is derived from the *compile-time* per-head dim KDim (not RowWidth), so
+  // the UB tile buffers below stay statically sized regardless of head count —
+  // 128 is safe for ChunkSize up to 128 (per-tile UB ≈ 66 KB).  KDim is a
+  // multiple of 128 in practice, so ColTile=128 divides KDim and therefore
+  // divides RowWidth = num_heads*KDim for any head count.
   constexpr int32_t ColTileTarget = 128;
-  constexpr int32_t ColTile = (RowWidth < ColTileTarget) ? RowWidth : ColTileTarget;
+  constexpr int32_t ColTile = (KDim < ColTileTarget) ? KDim : ColTileTarget;
   constexpr int32_t CTC = ((ColTile + 7) / 8) * 8;  // 8-elem alignment
-  static_assert(RowWidth % ColTile == 0,
-                "RowWidth (HV*KDim) must be a multiple of ColTile (128). "
-                "Reduce ColTileTarget or pick HV/KDim values whose product "
-                "is divisible by it.");
-  constexpr int32_t NumColTiles = RowWidth / ColTile;
+  static_assert(KDim % ColTile == 0,
+                "KDim must be a multiple of ColTile (128).");
+  // Number of column tiles a row spans — runtime, since RowWidth is runtime.
+  const int32_t NumColTiles = RowWidth / ColTile;
 
   // Per-tile UB layout (fp16):
   //   [0          .. BlockBytes)           = g input  (ChunkSize × CTC)
@@ -110,8 +111,10 @@ AICORE void gate_cumsum_kda_kernel(
   // Strided 2D loads (row_stride > col_count) are supported — same pattern as
   // chunk_h.cpp's per-head BSND loads at e.g. lines 599-604.
   using GmShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-  using GmStride = Stride<1, 1, 1, RowWidth, 1>;
+  using GmStride = Stride<1, 1, 1, DYNAMIC, 1>;
   using GmHalf = GlobalTensor<half, GmShape, GmStride>;
+  // Runtime row stride (RowWidth) shared by every g / g_sum GM view below.
+  GmStride row_stride(RowWidth);
 
   // Row accumulator — pre-assigned, re-initialised at each column tile.
   UbND<half, 1, CTC> acc_ub;
@@ -145,7 +148,7 @@ AICORE void gate_cumsum_kda_kernel(
           GmShape gs;
           gs.shape[3] = valid;
           gs.shape[4] = ColTile;
-          GmHalf g_gm(g_ptr + chunk_start * RowWidth + col_off, gs);
+          GmHalf g_gm(g_ptr + chunk_start * RowWidth + col_off, gs, row_stride);
           UbND<half, ChunkSize, CTC, DYNAMIC, DYNAMIC, PadValue::Zero>
               g_load(valid, ColTile);
           TASSIGN(g_load, GUbAddr);
@@ -203,7 +206,7 @@ AICORE void gate_cumsum_kda_kernel(
           GmShape ss;
           ss.shape[3] = valid;
           ss.shape[4] = ColTile;
-          GmHalf gs_gm(g_sum_ptr + chunk_start * RowWidth + col_off, ss);
+          GmHalf gs_gm(g_sum_ptr + chunk_start * RowWidth + col_off, ss, row_stride);
           UbND<half, ChunkSize, CTC, DYNAMIC, DYNAMIC>
               s_store(valid, ColTile);
           TASSIGN(s_store, SUbAddr);
@@ -243,7 +246,7 @@ AICORE void gate_cumsum_kda_kernel(
               GmShape gs;
               gs.shape[3] = valid;
               gs.shape[4] = ColTile;
-              GmHalf g_gm(g_ptr + chunk_start * RowWidth + col_off, gs);
+              GmHalf g_gm(g_ptr + chunk_start * RowWidth + col_off, gs, row_stride);
               UbND<half, ChunkSize, CTC, DYNAMIC, DYNAMIC, PadValue::Zero>
                   g_load(valid, ColTile);
               TASSIGN(g_load, GUbAddr);
@@ -293,7 +296,7 @@ AICORE void gate_cumsum_kda_kernel(
               GmShape ss;
               ss.shape[3] = valid;
               ss.shape[4] = ColTile;
-              GmHalf gs_gm(g_sum_ptr + chunk_start * RowWidth + col_off, ss);
+              GmHalf gs_gm(g_sum_ptr + chunk_start * RowWidth + col_off, ss, row_stride);
               UbND<half, ChunkSize, CTC, DYNAMIC, DYNAMIC>
                   s_store(valid, ColTile);
               TASSIGN(s_store, SUbAddr);
@@ -315,24 +318,25 @@ extern "C" __global__ AICORE void launch_gate_cumsum_kda(
     __gm__ uint8_t *g_ptr, __gm__ uint8_t *g_sum_ptr,
     __gm__ uint8_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
-  gate_cumsum_kda_kernel<GDN_H, GDN_D, GDN_C>(
+  gate_cumsum_kda_kernel<GDN_D, GDN_C>(
       reinterpret_cast<__gm__ half *>(g_ptr),
       reinterpret_cast<__gm__ half *>(g_sum_ptr),
       reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
-      batch_size, seq_len, ffts_addr);
+      batch_size, seq_len, num_heads, ffts_addr);
 }
 
 // ── Host-side launcher (called from Python via ctypes) ────────────────────
 extern "C" void call_kernel(
     uint32_t block_dim, void *stream,
     uint8_t *g_ptr, uint8_t *g_sum_ptr, uint8_t *cu_seqlens,
-    int64_t batch_size, int64_t seq_len)
+    int64_t batch_size, int64_t seq_len, uint32_t num_heads)
 {
   uint32_t fftsLen{0};
   uint64_t fftsAddr{0};
   rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
   launch_gate_cumsum_kda<<<block_dim, nullptr, stream>>>(
-      g_ptr, g_sum_ptr, cu_seqlens, batch_size, seq_len, fftsAddr);
+      g_ptr, g_sum_ptr, cu_seqlens, batch_size, seq_len,
+      static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/kernels/pto/kkt_kda.cpp
+++ b/kernels/pto/kkt_kda.cpp
@@ -45,17 +45,13 @@
 //   Peak @ C=16,  K=128: mask 0.5 + pre 14 ≈ 15 KB ✓
 //
 // Template parameters:
-//   GDN_H = HV, GDN_D = K, GDN_C = C
+//   Compile-time: GDN_D = K, GDN_C = C.  Runtime: num_heads = HV.
 // ============================================================================
 
 #include <pto/pto-inst.hpp>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 using namespace pto;
-
-#ifndef GDN_H
-#define GDN_H 4
-#endif
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -121,7 +117,7 @@ using L1MatZN = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::RowMajor,
                           RV, CV, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 #endif
 
-template <int32_t NumHeads, int32_t KDim, int32_t ChunkSize>
+template <int32_t KDim, int32_t ChunkSize>
 AICORE void kkt_kda_kernel(
     __gm__ half *k_ptr,
     __gm__ half *g_cs_ptr,
@@ -132,12 +128,17 @@ AICORE void kkt_kda_kernel(
     __gm__ half *L_out_ptr,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
     auto cid = get_block_idx();
     auto block_num = get_block_num();
     auto vid = get_subblockid();
     set_ffts_base_addr(ffts_addr);
+
+    // Head count is a runtime argument (HV).  Only loop bounds, the work-item
+    // decode, and GM strides depend on it — no UB buffer or tile shape does —
+    // so it never needs to be a compile-time constant.
+    const int32_t NumHeads = num_heads;
 
     constexpr int32_t HalfChunk = ChunkSize / 2;
     constexpr int32_t KTC = ((KDim + 7) / 8) * 8;
@@ -171,8 +172,11 @@ AICORE void kkt_kda_kernel(
     using GmShapeDyn = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
     using GmHalfK = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>;
     using GmHalf_1 = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, 1, 1>>;
+    // L output is BSND-interleaved [total_tokens, NumHeads, ChunkSize]; the
+    // token stride NumHeads*ChunkSize is now runtime, so the GM stride is
+    // DYNAMIC and supplied at construction (see the store site below).
     using GmHalfOut = GlobalTensor<half, GmShapeDyn,
-                                   Stride<1, 1, 1, NumHeads * ChunkSize, 1>>;
+                                   Stride<1, 1, 1, DYNAMIC, 1>>;
     using GmHalfWsIn = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>;
     using GmHalfWsOut = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, ChunkSize, 1>>;
 
@@ -479,7 +483,8 @@ AICORE void kkt_kda_kernel(
                     GmShapeDyn gs;
                     gs.shape[3] = local_valid;
                     gs.shape[4] = ChunkSize;
-                    GmHalfOut gm(L_out_ptr + l_base, gs);
+                    Stride<1, 1, 1, DYNAMIC, 1> out_stride(NumHeads * ChunkSize);
+                    GmHalfOut gm(L_out_ptr + l_base, gs, out_stride);
                     UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC>
                         L_h_st(local_valid, ChunkSize);
                     TASSIGN(L_h_st, LHalfUbAddr);
@@ -660,9 +665,9 @@ extern "C" __global__ AICORE void launch_kkt_kda(
     __gm__ uint8_t *L_out_ptr,
     __gm__ uint8_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
-    kkt_kda_kernel<GDN_H, GDN_D, GDN_C>(
+    kkt_kda_kernel<GDN_D, GDN_C>(
         reinterpret_cast<__gm__ half *>(k_ptr),
         reinterpret_cast<__gm__ half *>(g_cs_ptr),
         reinterpret_cast<__gm__ half *>(beta_ptr),
@@ -671,7 +676,7 @@ extern "C" __global__ AICORE void launch_kkt_kda(
         reinterpret_cast<__gm__ half *>(ws_out_ptr),
         reinterpret_cast<__gm__ half *>(L_out_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
-        batch_size, seq_len, total_tokens, ffts_addr);
+        batch_size, seq_len, total_tokens, num_heads, ffts_addr);
 }
 
 // ── Host entry point (called from Python via ctypes) ─────────────────────────
@@ -685,7 +690,8 @@ extern "C" void call_kernel(
     uint8_t *ws_out_ptr,
     uint8_t *L_out_ptr,
     uint8_t *cu_seqlens,
-    int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint32_t num_heads)
 {
     uint32_t fftsLen{0};
     uint64_t fftsAddr{0};
@@ -693,5 +699,6 @@ extern "C" void call_kernel(
     launch_kkt_kda<<<block_dim, nullptr, stream>>>(
         k_ptr, g_cs_ptr, beta_ptr, mask_ptr,
         ws_in_ptr, ws_out_ptr, L_out_ptr, cu_seqlens,
-        batch_size, seq_len, total_tokens, fftsAddr);
+        batch_size, seq_len, total_tokens,
+        static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/kernels/pto/mega_kernel_kda.cpp
+++ b/kernels/pto/mega_kernel_kda.cpp
@@ -19,9 +19,6 @@
 // inputs (q, k, beta) are permuted to head-major in Python; only g_sum — produced inside
 // the kernel by gate_cumsum — is transposed on-device here.
 
-#ifndef GDN_H
-#define GDN_H 16
-#endif
 #ifndef GDN_D
 #define GDN_D 128
 #endif
@@ -83,9 +80,9 @@ AICORE inline void SyncAllImpl()
 // [HV,T,K].  K stays innermost-contiguous; only the (T,HV) axes swap, so this is a pure
 // gather/scatter of K-contiguous rows (no element transpose).  Layout-only — independent
 // of cu_seqlens.
-template <typename T, int32_t HV, int32_t KD>
+template <typename T, int32_t KD>
 AICORE void mega_permute_THK_to_HTK(
-    __gm__ T *src, __gm__ T *dst, int64_t T_len)
+    __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t HV)
 {
 #if defined(__DAV_C220_VEC__)
     if (get_subblockid() != 0) return;
@@ -101,8 +98,9 @@ AICORE void mega_permute_THK_to_HTK(
     using UBTileDyn = Tile<TileType::Vec, T, BLOCK, KD, BLayout::RowMajor,
                            DYNAMIC, DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
     using Gm2D   = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-    using GmSrcS = Stride<1, 1, 1, HV * KD, 1>;   // row stride = HV*K (skip other heads)
+    using GmSrcS = Stride<1, 1, 1, DYNAMIC, 1>;   // row stride = HV*K (runtime; skip other heads)
     using GmDstS = Stride<1, 1, 1, KD, 1>;        // contiguous
+    GmSrcS src_stride(HV * KD);
 
     int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
     int64_t total = static_cast<int64_t>(HV) * num_tok_blocks;
@@ -119,7 +117,7 @@ AICORE void mega_permute_THK_to_HTK(
         {
             Gm2D gs; gs.shape[3] = valid; gs.shape[4] = KD;
             GlobalTensor<T, Gm2D, GmSrcS> gm(
-                src + (t0 * static_cast<int64_t>(HV) + h) * KD, gs);
+                src + (t0 * static_cast<int64_t>(HV) + h) * KD, gs, src_stride);
             UBTileDyn ld(valid, KD);
             TASSIGN(ld, UB0);
             TLOAD(ld, gm);
@@ -241,20 +239,23 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     int64_t seq_len,
     int64_t total_tokens,
     uint32_t num_matrices,
+    int32_t num_heads,
     uint64_t ffts_addr)
 {
     set_ffts_base_addr(ffts_addr);
 
-    constexpr int32_t HV = GDN_H;
+    // Head count (HV) is a runtime argument; only GDN_D (K) and GDN_C (C) stay
+    // compile-time, so the fused .so is head-count-agnostic like the staged ones.
+    const int32_t HV = num_heads;
     constexpr int32_t KD = GDN_D;
     constexpr int32_t C  = GDN_C;
 
     // ── Stage 1: gate_cumsum (BSND -> BSND) ──────────────────────────
-    mk_gc::gate_cumsum_kda_kernel<HV, KD, C>(
+    mk_gc::gate_cumsum_kda_kernel<KD, C>(
         reinterpret_cast<__gm__ half *>(g_in_ptr),
         reinterpret_cast<__gm__ half *>(g_sum_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, ffts_addr);
+        batch_size, seq_len, HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_CUMSUM
     pipe_barrier(PIPE_ALL);
@@ -264,10 +265,10 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     SyncAllImpl<false>();
 
     // ── Stage 2: transpose g_sum -> head-major g_cs ──────────────────
-    mega_permute_THK_to_HTK<half, HV, KD>(
+    mega_permute_THK_to_HTK<half, KD>(
         reinterpret_cast<__gm__ half *>(g_sum_ptr),
         reinterpret_cast<__gm__ half *>(g_cs_hm_ptr),
-        total_tokens);
+        total_tokens, HV);
 
 #ifdef MEGA_STOP_AFTER_TRANSPOSE
     pipe_barrier(PIPE_ALL);
@@ -277,7 +278,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     SyncAllImpl<false>();
 
     // ── Stage 3: kkt (gated K·K^T lower-tri matrix) ──────────────────
-    mk_kkt::kkt_kda_kernel<HV, KD, C>(
+    mk_kkt::kkt_kda_kernel<KD, C>(
         reinterpret_cast<__gm__ half *>(k_hm_ptr),
         reinterpret_cast<__gm__ half *>(g_cs_hm_ptr),
         reinterpret_cast<__gm__ half *>(beta_hm_ptr),
@@ -286,7 +287,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
         reinterpret_cast<__gm__ half *>(kkt_ws_out_ptr),
         reinterpret_cast<__gm__ half *>(L_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, ffts_addr);
+        batch_size, seq_len, total_tokens, HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_KKT
     pipe_barrier(PIPE_ALL);
@@ -311,7 +312,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     SyncAllImpl<false>();
 
     // ── Stage 5: wy (auxiliaries u, w) ───────────────────────────────
-    mk_wy::wy_kda_kernel<HV, KD, C>(
+    mk_wy::wy_kda_kernel<KD, C>(
         reinterpret_cast<__gm__ half *>(k_hm_ptr),
         reinterpret_cast<__gm__ half *>(v_ptr),
         reinterpret_cast<__gm__ half *>(beta_hm_ptr),
@@ -322,7 +323,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
         reinterpret_cast<__gm__ half *>(u_ptr),
         reinterpret_cast<__gm__ half *>(w_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, ffts_addr);
+        batch_size, seq_len, total_tokens, HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_WY
     pipe_barrier(PIPE_ALL);
@@ -332,7 +333,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     SyncAllImpl<false>();
 
     // ── Stage 6: chunk_h (state snapshots + v_corr) ──────────────────
-    mk_h::chunk_h_kda_kernel<HV, KD, C>(
+    mk_h::chunk_h_kda_kernel<KD, C>(
         reinterpret_cast<__gm__ half *>(k_hm_ptr),
         reinterpret_cast<__gm__ half *>(w_ptr),
         reinterpret_cast<__gm__ half *>(u_ptr),
@@ -341,7 +342,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
         reinterpret_cast<__gm__ half *>(v_corr_ptr),
         reinterpret_cast<__gm__ half *>(h_ws_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, ffts_addr);
+        batch_size, seq_len, total_tokens, HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_H
     pipe_barrier(PIPE_ALL);
@@ -351,7 +352,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     SyncAllImpl<false>();
 
     // ── Stage 7: chunk_o (output) ────────────────────────────────────
-    mk_o::chunk_o_kda_kernel<HV, KD, C>(
+    mk_o::chunk_o_kda_kernel<KD, C>(
         reinterpret_cast<__gm__ half *>(q_hm_ptr),
         reinterpret_cast<__gm__ half *>(k_hm_ptr),
         reinterpret_cast<__gm__ half *>(v_corr_ptr),
@@ -361,7 +362,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
         reinterpret_cast<__gm__ half *>(o_ws_ptr),
         reinterpret_cast<__gm__ half *>(o_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, ffts_addr);
+        batch_size, seq_len, total_tokens, HV, ffts_addr);
 }
 
 extern "C" void call_kernel(
@@ -374,7 +375,7 @@ extern "C" void call_kernel(
     uint8_t *kkt_ws_in, uint8_t *kkt_ws_out, uint8_t *wy_ws_a2, uint8_t *wy_ws_keff,
     uint8_t *h_ws, uint8_t *o_ws,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint32_t num_matrices)
+    uint32_t num_matrices, uint32_t num_heads)
 {
     uint32_t fftsLen{0};
     uint64_t fftsAddr{0};
@@ -386,5 +387,5 @@ extern "C" void call_kernel(
         g_sum, g_cs_hm, L, A_inv, u, w, s, v_corr,
         kkt_ws_in, kkt_ws_out, wy_ws_a2, wy_ws_keff, h_ws, o_ws,
         batch_size, seq_len, total_tokens, num_matrices,
-        fftsAddr);
+        static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/kernels/pto/wy_kda.cpp
+++ b/kernels/pto/wy_kda.cpp
@@ -59,7 +59,8 @@
 //   u_out   BSND       [B, T, HV, V] fp32
 //   w_out   BSND       [B, T, HV, K] fp32
 //
-// Template parameters: GDN_H = HV, GDN_D = K (= V_DIM here), GDN_C = C.
+// Compile-time template params: GDN_D = K (= V_DIM here), GDN_C = C.
+// Runtime argument: num_heads = HV.
 // ============================================================================
 
 #include <pto/pto-inst.hpp>
@@ -67,10 +68,6 @@
 #include <runtime/rt_ffts.h>
 #include <type_traits>
 using namespace pto;
-
-#ifndef GDN_H
-#define GDN_H 16
-#endif
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -270,7 +267,7 @@ gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
 
 #endif
 
-template <int32_t NumHeads, int32_t HiddenSize, int32_t ChunkSize>
+template <int32_t HiddenSize, int32_t ChunkSize>
 AICORE void wy_kda_kernel(
     __gm__ half *K_handle, __gm__ half *V_handle,
     __gm__ half *Beta_handle, __gm__ half *G_handle,
@@ -279,7 +276,7 @@ AICORE void wy_kda_kernel(
     __gm__ half *U_handle, __gm__ half *W_handle,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
   // Per-chunk math (matches ref_wy_kda):
   //   A2[r, c]    = INV[r, c] * beta[c]
@@ -293,11 +290,14 @@ AICORE void wy_kda_kernel(
   constexpr uint32_t KTail =
       (ChunkSize % 128 == 0) ? 128 : (ChunkSize % 128);
 
-  constexpr int32_t H = NumHeads;
+  // Head count (HV) is a runtime argument — it only drives loop bounds and GM
+  // strides, never a UB buffer size or tile shape.
+  const int32_t NumHeads = num_heads;
+  const int32_t H = NumHeads;
   // In KDA the keys arrive pre-expanded to HV heads (no GQA at this stage),
   // so K, V, U, W all use stride H * HiddenSize.
-  constexpr int32_t BSND_STRIDE = H * HiddenSize;
-  constexpr int32_t BSND_C_STRIDE = H * ChunkSize;
+  const int32_t BSND_STRIDE = H * HiddenSize;
+  const int32_t BSND_C_STRIDE = H * ChunkSize;
 
   // ── UB address plan ───────────────────────────────────────────────────────
   // Phase 1 (A2 = INV * beta_2d) and Phase 2 (K_eff = k * exp(g_cs)) run
@@ -1019,9 +1019,9 @@ extern "C" __global__ AICORE void launch_wy_kda(
     __gm__ uint8_t *U_handle, __gm__ uint8_t *W_handle,
     __gm__ uint8_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint64_t ffts_addr)
+    int32_t num_heads, uint64_t ffts_addr)
 {
-  wy_kda_kernel<GDN_H, GDN_D, GDN_C>(
+  wy_kda_kernel<GDN_D, GDN_C>(
       reinterpret_cast<__gm__ half *>(K_handle),
       reinterpret_cast<__gm__ half *>(V_handle),
       reinterpret_cast<__gm__ half *>(Beta_handle),
@@ -1032,7 +1032,7 @@ extern "C" __global__ AICORE void launch_wy_kda(
       reinterpret_cast<__gm__ half *>(U_handle),
       reinterpret_cast<__gm__ half *>(W_handle),
       reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
-      batch_size, seq_len, total_tokens, ffts_addr);
+      batch_size, seq_len, total_tokens, num_heads, ffts_addr);
 }
 
 extern "C" void call_kernel(
@@ -1041,7 +1041,8 @@ extern "C" void call_kernel(
     uint8_t *workspace_a2, uint8_t *workspace_keff,
     uint8_t *u, uint8_t *w,
     uint8_t *cu_seqlens,
-    int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint32_t num_heads)
 {
   uint32_t fftsLen{0};
   uint64_t fftsAddr{0};
@@ -1051,5 +1052,6 @@ extern "C" void call_kernel(
       workspace_a2, workspace_keff,
       u, w,
       cu_seqlens,
-      batch_size, seq_len, total_tokens, fftsAddr);
+      batch_size, seq_len, total_tokens,
+      static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/megagdn_pto/compile.py
+++ b/megagdn_pto/compile.py
@@ -154,29 +154,26 @@ def compile_mega_kernel(
 @lru_cache(maxsize=None)
 def compile_mega_kernel_kda(
     *,
-    num_heads: int = 16,
     hidden_size: int = 128,
     chunk_size: int = 128,
     cpp_mtime_ns: int = 0,
 ) -> str:
     """Compile the fused KDA mega-kernel and return the path to the resulting ``.so``.
 
-    Template parameters injected at compile time:
-        GDN_H = num_heads   (HV, value/gate heads)
+    Compile-time template parameters:
         GDN_D = hidden_size (K == V, per-head dimension)
         GDN_C = chunk_size  (C, tokens per chunk)
+    The head count (HV) is a runtime kernel argument, so a single .so serves all
+    head counts (one binary per K/C).
     """
     os.makedirs(_COMPILED_DIR, exist_ok=True)
     cpp_path = os.path.join(_KERNELS_PTO, "mega_kernel_kda.cpp")
     lib_path = os.path.join(
         _COMPILED_DIR,
-        f"mega_kernel_kda_H{num_heads}_D{hidden_size}_C{chunk_size}.so",
+        f"mega_kernel_kda_D{hidden_size}_C{chunk_size}.so",
     )
-    flags = _common_flags(
-        num_heads=num_heads, key_heads=num_heads,
-        hidden_size=hidden_size, chunk_size=chunk_size,
-    )
-    print(f"[megagdn_pto] Compiling mega_kernel_kda (HV={num_heads} K={hidden_size}) …")
+    flags = _common_flags(hidden_size=hidden_size, chunk_size=chunk_size)
+    print(f"[megagdn_pto] Compiling mega_kernel_kda (K={hidden_size} C={chunk_size}) …")
     _run_bisheng(["bisheng", *flags, cpp_path, "-o", lib_path], timeout=600)
     print(f"[megagdn_pto] Compiled → {lib_path}")
     return lib_path

--- a/megagdn_pto/kda_kernel_libs.py
+++ b/megagdn_pto/kda_kernel_libs.py
@@ -44,23 +44,22 @@ def load_gate_cumsum_kda(
 ) -> ctypes.CDLL:
     """Compile + load the KDA gate cumsum kernel.
 
-    Template parameters injected at compile time:
-        GDN_H = num_heads  (HV, number of value/gate heads)
-        GDN_D = k_dim      (K, key/gate vector dimension)
-        GDN_C = chunk_size (C, tokens per chunk)
+    Head count (HV) is a *runtime* kernel argument, so the compiled .so is
+    head-count-agnostic (one binary per K/C).  Only GDN_D (K) and GDN_C (C) are
+    compile-time template parameters.  ``num_heads`` here is just the lru_cache
+    key + the value passed to ``call_kernel`` at launch.
 
     C signature::
         void call_kernel(uint32_t block_dim, void *stream,
                          uint8_t *g, uint8_t *g_sum, uint8_t *cu_seqlens,
-                         int64_t batch_size, int64_t seq_len)
+                         int64_t batch_size, int64_t seq_len,
+                         uint32_t num_heads)
     """
     lib_path = compile_chunk_kernel(
         "gate_cumsum_kda.cpp",
         "gate_cumsum_kda",
-        num_heads=num_heads,
         hidden_size=k_dim,
         chunk_size=chunk_size,
-        key_heads=None,
         cpp_mtime_ns=_mtime("gate_cumsum_kda.cpp"),
     )
     lib = ctypes.CDLL(os.path.abspath(lib_path))
@@ -68,6 +67,7 @@ def load_gate_cumsum_kda(
         [ctypes.c_uint32, ctypes.c_void_p]
         + [ctypes.c_void_p] * 3
         + [ctypes.c_int64, ctypes.c_int64]
+        + [ctypes.c_uint32]   # num_heads (runtime)
     )
     lib.call_kernel.restype = None
     return lib
@@ -106,7 +106,7 @@ def run_gate_cumsum_kda(
     cu32 = _ensure_int32(cu_seqlens)
 
     lib = load_gate_cumsum_kda(HV, K, chunk_size)
-    lib.call_kernel(bd, stream, _vp(g), _vp(g_sum), _vp(cu32), batch, T)
+    lib.call_kernel(bd, stream, _vp(g), _vp(g_sum), _vp(cu32), batch, T, HV)
 
 
 # ---------------------------------------------------------------------------
@@ -121,25 +121,22 @@ def load_kkt_kda(
 ) -> ctypes.CDLL:
     """Compile + load the KDA kkt kernel.
 
-    Template parameters injected at compile time:
-        GDN_H = num_heads  (HV, number of value/gate heads)
-        GDN_D = k_dim      (K, key/gate vector dimension)
-        GDN_C = chunk_size (C, tokens per chunk)
+    Head count (HV) is a *runtime* kernel argument; only GDN_D (K) and GDN_C (C)
+    are compile-time template parameters, so the .so is head-count-agnostic.
 
     C signature::
         void call_kernel(uint32_t block_dim, void *stream,
                          uint8_t *k, uint8_t *g_cs, uint8_t *beta,
                          uint8_t *mask, uint8_t *ws_in, uint8_t *ws_out,
                          uint8_t *L_out, uint8_t *cu_seqlens,
-                         int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+                         int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+                         uint32_t num_heads)
     """
     lib_path = compile_chunk_kernel(
         "kkt_kda.cpp",
         "kkt_kda",
-        num_heads=num_heads,
         hidden_size=k_dim,
         chunk_size=chunk_size,
-        key_heads=None,
         cpp_mtime_ns=_mtime("kkt_kda.cpp"),
     )
     lib = ctypes.CDLL(os.path.abspath(lib_path))
@@ -147,6 +144,7 @@ def load_kkt_kda(
         [ctypes.c_uint32, ctypes.c_void_p]
         + [ctypes.c_void_p] * 8   # k, g_cs, beta, mask, ws_in, ws_out, L_out, cu_seqlens
         + [ctypes.c_int64] * 3    # batch_size, seq_len, total_tokens
+        + [ctypes.c_uint32]       # num_heads (runtime)
     )
     lib.call_kernel.restype = None
     return lib
@@ -219,7 +217,7 @@ def run_kkt_kda(
         _vp(k_t), _vp(g_cs_t), _vp(beta_t),
         _vp(mask), _vp(ws_in), _vp(ws_out), _vp(L_out),
         _vp(cu32),
-        batch, T, total_tokens,
+        batch, T, total_tokens, HV,
     )
 
 
@@ -235,10 +233,8 @@ def load_wy_kda(
 ) -> ctypes.CDLL:
     """Compile + load the KDA wy kernel.
 
-    Template parameters injected at compile time:
-        GDN_H = num_heads  (HV)
-        GDN_D = k_dim      (K, also used as V_DIM)
-        GDN_C = chunk_size (C)
+    Head count (HV) is a *runtime* kernel argument; only GDN_D (K) and GDN_C (C)
+    are compile-time template parameters, so the .so is head-count-agnostic.
 
     C signature::
         void call_kernel(uint32_t block_dim, void *stream,
@@ -246,15 +242,14 @@ def load_wy_kda(
                          uint8_t *ws_a2, uint8_t *ws_keff,
                          uint8_t *u, uint8_t *w,
                          uint8_t *cu_seqlens,
-                         int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+                         int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+                         uint32_t num_heads)
     """
     lib_path = compile_chunk_kernel(
         "wy_kda.cpp",
         "wy_kda",
-        num_heads=num_heads,
         hidden_size=k_dim,
         chunk_size=chunk_size,
-        key_heads=None,
         cpp_mtime_ns=_mtime("wy_kda.cpp"),
     )
     lib = ctypes.CDLL(os.path.abspath(lib_path))
@@ -262,6 +257,7 @@ def load_wy_kda(
         [ctypes.c_uint32, ctypes.c_void_p]
         + [ctypes.c_void_p] * 10   # k, v, beta, g_cs, A, ws_a2, ws_keff, u, w, cu_seqlens
         + [ctypes.c_int64] * 3     # batch_size, seq_len, total_tokens
+        + [ctypes.c_uint32]        # num_heads (runtime)
     )
     lib.call_kernel.restype = None
     return lib
@@ -334,7 +330,7 @@ def run_wy_kda(
         _vp(ws_a2), _vp(ws_keff),
         _vp(u_out), _vp(w_out),
         _vp(cu32),
-        batch, T, T,
+        batch, T, T, HV,
     )
 
 
@@ -350,25 +346,22 @@ def load_chunk_h_kda(
 ) -> ctypes.CDLL:
     """Compile + load the KDA chunk_h kernel.
 
-    Template parameters injected at compile time:
-        GDN_H = num_heads  (HV)
-        GDN_D = k_dim      (K, also used as V_DIM)
-        GDN_C = chunk_size (C)
+    Head count (HV) is a *runtime* kernel argument; only GDN_D (K) and GDN_C (C)
+    are compile-time template parameters, so the .so is head-count-agnostic.
 
     C signature::
         void call_kernel(uint32_t block_dim, void *stream,
                          uint8_t *K, uint8_t *W, uint8_t *U, uint8_t *G,
                          uint8_t *S, uint8_t *V_corr,
                          uint8_t *workspace, uint8_t *cu_seqlens,
-                         int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+                         int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+                         uint32_t num_heads)
     """
     lib_path = compile_chunk_kernel(
         "chunk_h_kda.cpp",
         "chunk_h_kda",
-        num_heads=num_heads,
         hidden_size=k_dim,
         chunk_size=chunk_size,
-        key_heads=None,
         cpp_mtime_ns=_mtime("chunk_h_kda.cpp"),
     )
     lib = ctypes.CDLL(os.path.abspath(lib_path))
@@ -376,6 +369,7 @@ def load_chunk_h_kda(
         [ctypes.c_uint32, ctypes.c_void_p]
         + [ctypes.c_void_p] * 8   # K, W, U, G, S, V_corr, workspace, cu_seqlens
         + [ctypes.c_int64] * 3    # batch_size, seq_len, total_tokens
+        + [ctypes.c_uint32]       # num_heads (runtime)
     )
     lib.call_kernel.restype = None
     return lib
@@ -445,7 +439,7 @@ def run_chunk_h_kda(
         bd, stream,
         _vp(k_t), _vp(w.contiguous()), _vp(u), _vp(g_cs_t),
         _vp(s_snapshots_out), _vp(v_corr_out), _vp(ws), _vp(cu32),
-        batch, T, T,
+        batch, T, T, HV,
     )
 
 
@@ -461,10 +455,8 @@ def load_chunk_o_kda(
 ) -> ctypes.CDLL:
     """Compile + load the KDA chunk_o kernel.
 
-    Template parameters injected at compile time:
-        GDN_H = num_heads  (HV)
-        GDN_D = k_dim      (K, also used as V_DIM)
-        GDN_C = chunk_size (C)
+    Head count (HV) is a *runtime* kernel argument; only GDN_D (K) and GDN_C (C)
+    are compile-time template parameters, so the .so is head-count-agnostic.
 
     C signature::
         void call_kernel(uint32_t block_dim, void *stream,
@@ -472,15 +464,14 @@ def load_chunk_o_kda(
                          uint8_t *G, uint8_t *Mask,
                          uint8_t *workspace, uint8_t *O,
                          uint8_t *cu_seqlens,
-                         int64_t batch_size, int64_t seq_len, int64_t total_tokens)
+                         int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+                         uint32_t num_heads)
     """
     lib_path = compile_chunk_kernel(
         "chunk_o_kda.cpp",
         "chunk_o_kda",
-        num_heads=num_heads,
         hidden_size=k_dim,
         chunk_size=chunk_size,
-        key_heads=None,
         cpp_mtime_ns=_mtime("chunk_o_kda.cpp"),
     )
     lib = ctypes.CDLL(os.path.abspath(lib_path))
@@ -488,6 +479,7 @@ def load_chunk_o_kda(
         [ctypes.c_uint32, ctypes.c_void_p]
         + [ctypes.c_void_p] * 9   # Q, K, V_corr, S, G, Mask, workspace, O, cu_seqlens
         + [ctypes.c_int64] * 3    # batch_size, seq_len, total_tokens
+        + [ctypes.c_uint32]       # num_heads (runtime)
     )
     lib.call_kernel.restype = None
     return lib
@@ -569,5 +561,5 @@ def run_chunk_o_kda(
         _vp(q_t), _vp(k_t), _vp(v_corr), _vp(s_snapshots),
         _vp(g_cs_t), _vp(mask),
         _vp(ws), _vp(o_out), _vp(cu32),
-        batch, T, T,
+        batch, T, T, HV,
     )

--- a/megagdn_pto/kda_mega_kernel.py
+++ b/megagdn_pto/kda_mega_kernel.py
@@ -39,9 +39,10 @@ def _load_mega_kernel_kda(
     hidden_size: int = 128,
     chunk_size: int = 128,
 ) -> ctypes.CDLL:
+    # Head count (HV) is a runtime kernel argument now, so the fused .so is
+    # head-count-agnostic; ``num_heads`` here is only the lru_cache key.
     mtime = os.stat(os.path.join(_KERNELS_PTO, "mega_kernel_kda.cpp")).st_mtime_ns
     lib_path = compile_mega_kernel_kda(
-        num_heads=num_heads,
         hidden_size=hidden_size,
         chunk_size=chunk_size,
         cpp_mtime_ns=mtime,
@@ -50,7 +51,8 @@ def _load_mega_kernel_kda(
     lib.call_kernel.argtypes = (
         [ctypes.c_uint32, ctypes.c_void_p]
         + [ctypes.c_void_p] * 24
-        + [ctypes.c_int64, ctypes.c_int64, ctypes.c_int64, ctypes.c_uint32]
+        + [ctypes.c_int64, ctypes.c_int64, ctypes.c_int64,
+           ctypes.c_uint32, ctypes.c_uint32]  # ..., num_matrices, num_heads
     )
     lib.call_kernel.restype = None
     return lib
@@ -150,6 +152,6 @@ def run_mega_kernel_kda(
         _vp(u), _vp(w), _vp(s), _vp(v_corr),
         _vp(kkt_ws_in), _vp(kkt_ws_out), _vp(wy_ws_a2), _vp(wy_ws_keff),
         _vp(h_ws), _vp(o_ws),
-        N_seq, T, T, num_matrices,
+        N_seq, T, T, num_matrices, HV,
     )
     return o_out


### PR DESCRIPTION
## Summary

Migrates **all** KDA kernels — the five staged chunk kernels and the fused mega-kernel — from templating the value/gate head count `HV` at compile time (`-DGDN_H`) to taking it as a runtime kernel argument, matching how the GDN kernels already handle `num_heads`. One compiled `.so` per `(K, C)` now serves every head count, for both the staged and fused paths.

This **removes the KDA kernels' compile-time `-DGDN_H` dependency entirely**: `_common_flags` no longer needs (and is never passed) a head count, so no KDA binary is specialized per `HV`.

## Motivation

`HV` only influences loop bounds, the per-core work-item decode (`pid % HV`), int64 GM offsets, and runtime GM strides — never a UB buffer size, tile shape, or matmul fractal (those depend only on `GDN_D = K` and `GDN_C = C`, which stay compile-time). So `HV` never needed to be a compile-time constant; making it a runtime argument mirrors the GDN kernels and avoids a separate binary per head count.

## Changes

**Staged kernels** (`kkt_kda`, `wy_kda`, `chunk_h_kda`, `chunk_o_kda`, `gate_cumsum_kda`):
- Drop `NumHeads` from the template (kernels are now `<GDN_D, GDN_C>`); add a runtime `int32_t num_heads`, threaded through `launch_*` and `call_kernel`.
- `kkt_kda`: the one compile-time stride baking in the head count (`Stride<1,1,1,NumHeads*ChunkSize,1>` for the L output) → DYNAMIC stride set at the store, mirroring the GDN kkt store.
- `gate_cumsum_kda`: `RowWidth` / column-tile loop count / GM stride become runtime; UB tile buffers stay statically sized off compile-time `KDim`, so behavior is unchanged for `KDim=128`.

**Fused mega-kernel** (`mega_kernel_kda.cpp`):
- `constexpr HV = GDN_H` → `const HV = num_heads`; the five `#include`d sub-kernel device calls updated to the new `<GDN_D, GDN_C>(…, num_heads, …)` signature.
- The on-device head-major transpose helper (which had a compile-time `Stride<…, HV*KD, …>`) takes `HV` at runtime with a DYNAMIC source stride.
- `launch`/`call_kernel` gain a trailing `num_heads`.

**Host & build**:
- `kda_kernel_libs.py` / `kda_mega_kernel.py`: stop forwarding `num_heads` to the compile helpers, add a `c_uint32` argtype, and pass `HV` at launch.
- `compile.py`: `compile_mega_kernel_kda` drops its `num_heads` parameter, the per-head `.so` filename tag, and the (previously broken) `_common_flags` head-count arguments. `_common_flags`, `compile_chunk_kernel`, and all GDN paths are unchanged.

## Backward compatibility

GDN kernels, GDN host code, and `_common_flags` are untouched. The only `compile.py` edit is inside `compile_mega_kernel_kda`. `git diff --stat` is limited to the six KDA kernels, two KDA host modules, and that one function.

## Validation

- `tests/test_kda_single_kernels.py --H {4, 16, 32}` — ALL PASS (staged).
- `tests/test_kda_e2e.py --H {4, 16, 32}` — ALL PASS, every case `[staged=ok mega=ok mega~staged=ok]`; a single untagged `.so` per kernel (staged and fused) serves all three head counts.
- Downstream 4-way KDA benchmark at `HV=32` — bit-identical numerics to the prior compile-time version.
- `tests/test_gdn_single_kernels.py --H 32 --hg 16` — ALL PASS (no regression).