### PR TITLE
Optimize kda_kkt kernel

### DIFF
--- a/benchmarks/kernel/bench_kda_vs_gdn.py
+++ b/benchmarks/kernel/bench_kda_vs_gdn.py
@@ -127,19 +127,19 @@ def bench_gate_cumsum(HV: int, T: int, cu_seqlens, dev, stream, bd: int):
     gs_kda   = torch.empty(1, T, HV, D, device=dev, dtype=torch.float32)
 
     def run_kda():
-        lib_kda.call_kernel(bd, stream, _vp(g_kda), _vp(gs_kda), _vp(cu32), batch, T)
+        lib_kda.call_kernel(bd, stream, _vp(g_kda), _vp(gs_kda), _vp(cu32), batch, T, HV)
 
     run_kda()
     torch.npu.synchronize()
     ms_kda = _bench_npu(run_kda)
 
     # GDN: [B, T, HV] fp32 — scalar gate per head per token
-    lib_gdn  = load_chunk_cumsum(HV, D, C)
+    lib_gdn  = load_chunk_cumsum(C)
     g_gdn    = torch.randn(1, T, HV, device=dev, dtype=torch.float32)
     gs_gdn   = torch.empty_like(g_gdn)
 
     def run_gdn():
-        lib_gdn.call_kernel(bd, stream, _vp(g_gdn), _vp(gs_gdn), _vp(cu32), batch, T)
+        lib_gdn.call_kernel(bd, stream, _vp(g_gdn), _vp(gs_gdn), _vp(cu32), batch, T, HV)
 
     run_gdn()
     torch.npu.synchronize()
@@ -170,20 +170,22 @@ def bench_kkt(HV: int, HG: int, T: int, cu_seqlens, dev, stream, bd: int):
     mask_kda   = (rows > cols).to(torch.float32)          # strictly lower tri
     ws_in_kda  = torch.zeros(bd * 2, 2 * C, D, device=dev, dtype=torch.float32)
     ws_out_kda = torch.zeros(bd * 2, C,      C, device=dev, dtype=torch.float32)
+    b_ws_kda   = torch.zeros(bd * 2, C,         device=dev, dtype=torch.float32)
     L_kda      = torch.zeros(1, T, HV, C,    device=dev, dtype=torch.float16)
 
     def run_kda():
         lib_kda.call_kernel(bd, stream,
                             _vp(k_kda_hm), _vp(g_cs_hm), _vp(beta_kda_hm),
-                            _vp(mask_kda), _vp(ws_in_kda), _vp(ws_out_kda), _vp(L_kda),
-                            _vp(cu32), batch, T, T)
+                            _vp(mask_kda), _vp(ws_in_kda), _vp(ws_out_kda),
+                            _vp(b_ws_kda), _vp(L_kda),
+                            _vp(cu32), batch, T, T, HV)
 
     run_kda()
     torch.npu.synchronize()
     ms_kda = _bench_npu(run_kda)
 
     # GDN: k [B,T,HG,D] fp16; β [B,HV,T] fp16 (head-major); g [B,HV,T] fp32 (head-major)
-    lib_gdn    = load_scaled_dot_kkt(HV, D, C, key_heads=HG)
+    lib_gdn    = load_scaled_dot_kkt(D, C)
     k_gdn      = torch.randn(1, T, HG, D, device=dev, dtype=torch.float16)
     beta_gdn   = torch.rand(1, T, HV,    device=dev, dtype=torch.float16)
     g_gdn      = torch.randn(1, T, HV,   device=dev, dtype=torch.float32)
@@ -197,7 +199,7 @@ def bench_kkt(HV: int, HG: int, T: int, cu_seqlens, dev, stream, bd: int):
         lib_gdn.call_kernel(bd, stream,
                             _vp(k_gdn), _vp(beta_t_gdn), _vp(g_t_gdn),
                             _vp(mask_gdn), _vp(ws_gdn), _vp(A_gdn),
-                            _vp(cu32), batch, T, T)
+                            _vp(cu32), batch, T, T, HV, HG)
 
     run_gdn()
     torch.npu.synchronize()
@@ -282,14 +284,14 @@ def bench_wy(HV: int, HG: int, T: int, cu_seqlens, dev, stream, bd: int):
                             _vp(k_hm), _vp(v_fp16), _vp(beta_hm), _vp(g_cs_hm), _vp(INV_kda),
                             _vp(ws_a2), _vp(ws_keff),
                             _vp(u_kda), _vp(w_kda),
-                            _vp(cu32), batch, T, T)
+                            _vp(cu32), batch, T, T, HV)
 
     run_kda()
     torch.npu.synchronize()
     ms_kda = _bench_npu(run_kda)
 
     # GDN: k [B,T,HG,D] fp16; v/A_inv [B,T,HV,D/C] fp16; β/g head-major
-    lib_gdn    = load_wy_fast(HV, D, C, key_heads=HG)
+    lib_gdn    = load_wy_fast(D, C)
     k_gdn      = torch.randn(1, T, HG, D, device=dev, dtype=torch.float16)
     v_gdn      = torch.randn(1, T, HV, D, device=dev, dtype=torch.float16)
     beta_gdn   = torch.rand(1, T, HV,    device=dev, dtype=torch.float16)
@@ -307,7 +309,7 @@ def bench_wy(HV: int, HG: int, T: int, cu_seqlens, dev, stream, bd: int):
                             _vp(k_gdn), _vp(v_gdn), _vp(beta_t_gdn), _vp(g_t_gdn), _vp(A_inv_gdn),
                             _vp(ws1_gdn), _vp(ws2_gdn),
                             _vp(w_gdn), _vp(u_gdn),
-                            _vp(cu32), batch, T, T)
+                            _vp(cu32), batch, T, T, HV, HG)
 
     run_gdn()
     torch.npu.synchronize()
@@ -339,14 +341,14 @@ def bench_chunk_h(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd
         lib_kda.call_kernel(bd, stream,
                             _vp(k_hm), _vp(w_kda), _vp(u_kda), _vp(g_cs_hm),
                             _vp(s_kda), _vp(vcorr_kda), _vp(ws_kda), _vp(cu32),
-                            batch, T, T)
+                            batch, T, T, HV)
 
     run_kda()
     torch.npu.synchronize()
     ms_kda = _bench_npu(run_kda)
 
     # GDN: k [B,T,HG,D] fp16; w/u BSND fp16; g head-major fp32; state [tc*HV,D,D] fp16
-    lib_gdn     = load_chunk_h(HV, D, C, key_heads=HG)
+    lib_gdn     = load_chunk_h(D, C)
     k_gdn       = torch.randn(1, T, HG, D,    device=dev, dtype=torch.float16)
     w_gdn       = torch.randn(1, T, HV, D,    device=dev, dtype=torch.float16)
     u_gdn       = torch.randn(1, T, HV, D,    device=dev, dtype=torch.float16)
@@ -357,10 +359,12 @@ def bench_chunk_h(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd
     ws_gdn      = torch.zeros(bd * 4, D, D,   device=dev, dtype=torch.float16)
 
     def run_gdn():
+        # final_state written to fs_gdn (output_final_state=1); no initial state (h0 null).
         lib_gdn.call_kernel(bd, stream,
                             _vp(k_gdn), _vp(w_gdn), _vp(u_gdn), _vp(g_t_gdn),
-                            _vp(s_gdn), _vp(vnew_gdn), _vp(fs_gdn), _vp(ws_gdn), _vp(cu32),
-                            batch, T, T)
+                            _vp(s_gdn), _vp(vnew_gdn), _vp(fs_gdn),
+                            ctypes.c_void_p(0), 0, 1, _vp(ws_gdn), _vp(cu32),
+                            batch, T, T, HV, HG)
 
     run_gdn()
     torch.npu.synchronize()
@@ -397,7 +401,7 @@ def bench_chunk_o(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd
     lib_h_kda.call_kernel(bd, stream,
                           _vp(k_hm), _vp(w_kda), _vp(u_kda), _vp(g_cs_hm),
                           _vp(s_kda), _vp(vcorr_kda), _vp(ws_h_kda), _vp(cu32),
-                          batch, T, T)
+                          batch, T, T, HV)
     torch.npu.synchronize()
 
     mask_kda    = (rows >= cols).to(torch.float32)   # inclusive diagonal
@@ -409,15 +413,15 @@ def bench_chunk_o(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd
                               _vp(q_hm), _vp(k_hm), _vp(vcorr_kda), _vp(s_kda),
                               _vp(g_cs_hm), _vp(mask_kda),
                               _vp(ws_o_kda), _vp(o_kda), _vp(cu32),
-                              batch, T, T)
+                              batch, T, T, HV)
 
     run_kda()
     torch.npu.synchronize()
     ms_kda = _bench_npu(run_kda)
 
     # GDN: pre-populate s and v_new via chunk_h warmup
-    lib_h_gdn   = load_chunk_h(HV, D, C, key_heads=HG)
-    lib_o_gdn   = load_chunk_o(HV, D, C, key_heads=HG)
+    lib_h_gdn   = load_chunk_h(D, C)
+    lib_o_gdn   = load_chunk_o(D, C)
     k_gdn       = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
     q_gdn       = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
     w_gdn       = torch.randn(1, T, HV, D, device=dev, dtype=torch.float16)
@@ -429,8 +433,9 @@ def bench_chunk_o(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd
     ws_h_gdn    = torch.zeros(bd * 4, D, D,  device=dev, dtype=torch.float16)
     lib_h_gdn.call_kernel(bd, stream,
                           _vp(k_gdn), _vp(w_gdn), _vp(u_gdn), _vp(g_t_gdn),
-                          _vp(s_gdn), _vp(vnew_gdn), _vp(fs_gdn), _vp(ws_h_gdn), _vp(cu32),
-                          batch, T, T)
+                          _vp(s_gdn), _vp(vnew_gdn), _vp(fs_gdn),
+                          ctypes.c_void_p(0), 0, 1, _vp(ws_h_gdn), _vp(cu32),
+                          batch, T, T, HV, HG)
     torch.npu.synchronize()
 
     mask_gdn    = torch.tril(torch.ones(C, C, device=dev), diagonal=0).float()
@@ -443,7 +448,7 @@ def bench_chunk_o(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd
         lib_o_gdn.call_kernel(bd, stream,
                               _vp(q_gdn), _vp(k_gdn), _vp(vnew_gdn), _vp(s_gdn), _vp(g_t_gdn),
                               _vp(mask_gdn), _vp(ws1_gdn), _vp(ws2_gdn), _vp(ws3_gdn), _vp(o_gdn),
-                              _vp(cu32), batch, T, T)
+                              _vp(cu32), batch, T, T, HV, HG)
 
     run_gdn()
     torch.npu.synchronize()
@@ -501,6 +506,7 @@ def bench_e2e(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd: in
     # Workspaces (pre-allocated, not timed); kkt + chunk_o are fp32 (overflow-safe).
     ws_kkt_in  = torch.zeros(bd * 2, 2 * C, D, device=dev, dtype=torch.float32)
     ws_kkt_out = torch.zeros(bd * 2, C,      C, device=dev, dtype=torch.float32)
+    ws_kkt_b   = torch.zeros(bd * 2, C,         device=dev, dtype=torch.float32)
     ws_wy_a2   = torch.zeros(bd, C, C, device=dev, dtype=torch.float16)
     ws_wy_keff = torch.zeros(bd, C, D, device=dev, dtype=torch.float16)
     ws_h       = torch.zeros(bd * 5, D, D, device=dev, dtype=torch.float16)
@@ -521,14 +527,15 @@ def bench_e2e(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd: in
 
     def run_kda():
         # 1. gate_cumsum_kda
-        lib_cumsum.call_kernel(bd, stream, _vp(g_log), _vp(g_sum_bsnd), _vp(cu32), batch, T)
+        lib_cumsum.call_kernel(bd, stream, _vp(g_log), _vp(g_sum_bsnd), _vp(cu32), batch, T, HV)
         g_sum_hm.copy_(g_sum_bsnd.permute(0, 2, 1, 3))   # BSND → head-major (fp32)
 
         # 2. kkt_kda (all fp16)
         lib_kkt.call_kernel(bd, stream,
                             _vp(k_hm), _vp(g_sum_hm), _vp(beta_hm),
-                            _vp(mask_strict), _vp(ws_kkt_in), _vp(ws_kkt_out), _vp(L_kkt),
-                            _vp(cu32), batch, T, T)
+                            _vp(mask_strict), _vp(ws_kkt_in), _vp(ws_kkt_out),
+                            _vp(ws_kkt_b), _vp(L_kkt),
+                            _vp(cu32), batch, T, T, HV)
 
         # 3. solve_tril (fp16 in; tri_inverse writes fp32 to ws_tri; copy → A_inv fp16)
         launch_tri_inverse_kernel(ws_tri, L_kkt, minus_I, C, n_mat, HV,
@@ -541,20 +548,20 @@ def bench_e2e(HV: int, HG: int, T: int, tc: int, cu_seqlens, dev, stream, bd: in
                            _vp(k_hm), _vp(v_bsnd), _vp(beta_hm), _vp(g_sum_hm), _vp(A_inv),
                            _vp(ws_wy_a2), _vp(ws_wy_keff),
                            _vp(u_out), _vp(w_out),
-                           _vp(cu32), batch, T, T)
+                           _vp(cu32), batch, T, T, HV)
 
         # 5. chunk_h_kda (all fp16; w_out already fp16)
         lib_h.call_kernel(bd, stream,
                           _vp(k_hm), _vp(w_out), _vp(u_out), _vp(g_sum_hm),
                           _vp(s_snap), _vp(v_corr), _vp(ws_h), _vp(cu32),
-                          batch, T, T)
+                          batch, T, T, HV)
 
         # 6. chunk_o_kda (all fp16)
         lib_o.call_kernel(bd, stream,
                           _vp(q_hm), _vp(k_hm), _vp(v_corr), _vp(s_snap),
                           _vp(g_sum_hm), _vp(mask_causal),
                           _vp(ws_o), _vp(o_kda), _vp(cu32),
-                          batch, T, T)
+                          batch, T, T, HV)
 
     run_kda()
     torch.npu.synchronize()

--- a/kernels/pto/chunk_cumsum.cpp
+++ b/kernels/pto/chunk_cumsum.cpp
@@ -60,6 +60,55 @@ using namespace pto;
 #define GDN_C 128
 #endif
 
+// GDN_MAX_HEADS: compile-time ceiling on the value-head count. NumHeads is now a
+// RUNTIME argument (one .so serves every head count), but the UB tiles must still
+// be sized at compile time, so they are sized for the worst case HTC=align(MAX,8).
+// Any NumHeads <= GDN_MAX_HEADS works; the unused columns are zero-padded and ride
+// along the SIMD lanes harmlessly. Must match the host-side _MAX_HEADS guard.
+#ifndef GDN_MAX_HEADS
+#define GDN_MAX_HEADS 64
+#endif
+
+// ── Recurrent prefix-sum chain synchronization ──────────────────────────────
+// The recurrent chain alternates TADD(acc,acc,g_i) (Vec) and TMOV(s_i,acc) (Vec)
+// with TASSIGN address/descriptor setup on each row. TADD/TMOV lower to PIPE_V,
+// but TASSIGN is a SCALAR op (PIPE_S, see opPipeList in pto/common/event.hpp), and
+// on this core the scalar unit ISSUES the vec instructions. So the ordering edge
+// that actually matters is Vec→Scalar: without it, the scalar issuer launches the
+// next TADD/TMOV before the previous vec write to acc_ub has committed → a RAW race
+// on acc_ub.
+//
+// pipe_barrier(PIPE_V) only fences Vec-vs-Vec and never enforces this V↔S edge, so
+// it is insufficient under the fused kernel — the recurrence races and corrupts the
+// last rows of each chunk non-deterministically (surfaced at H=64, whose wider tile
+// lengthens the race window). It happens to be harmless standalone because the
+// scheduler there doesn't reorder across the boundary the same way.
+//
+// The fix is an explicit Vec→Scalar sync: set_flag(PIPE_V, PIPE_S) + wait_flag,
+// here via PtoSetWaitFlag<PIPE_V, PIPE_S>(). This stalls the scalar issuer until the
+// vec pipe drains, serializing the recurrence correctly. EVENT_ID2 is used to avoid
+// colliding with the EVENT_ID0 V↔MTE3 flags already live in this stage.
+//
+// MINIMAL placement (per-site bisection, H=64, 50-run determinism + e2e + partial
+// chunks): the V↔S sync is needed at EXACTLY ONE site — immediately after the
+// per-row TADD(acc,acc,g_i) write inside the main loop (in both the fixed-length
+// and varlen paths). That single sync serializes the whole recurrence; every other
+// site (the row-0 prologue, the per-row TMOV(s_i,acc) read, and the partial-chunk
+// tail zero-fill) is fine as a plain pipe_barrier(PIPE_V). Verified: bit2-only is
+// correct AND deterministic for full and partial chunks; all-PIPE_V or
+// prologue-only-V↔S races. (The post-read TMOV site is an equally-valid single
+// choice; we sync after the write because it orders acc before every consumer.)
+//
+// Two things that do NOT work, for the record:
+//   • pipe_barrier(PIPE_ALL) also fixes it, but only incidentally — it is a superset
+//     fence that happens to include the V↔S edge. It is heavier and obscures the
+//     real cause, so we use the targeted V↔S sync instead.
+//   • set_flag(PIPE_V, PIPE_MTE3) does NOT help: it targets the wrong pipe pair
+//     (store-DMA, not the scalar issuer), leaving the real edge unenforced and
+//     producing deterministic-but-WRONG output (~20% frob error) that the run-to-run
+//     determinism test cannot detect — always run the cumsum *correctness* test.
+
+
 // ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
 // UB tile in row-major (ND) layout, used by Vec engine.
 // T=dtype, R×C=static shape, RV×CV=valid region, P=pad value for TLOAD.
@@ -77,11 +126,12 @@ using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
                        RV, CV, pto::SLayout::NoneBox, 512, P>;
 #endif
 
-template <int32_t NumHeads, int32_t ChunkSize>
+template <int32_t ChunkSize>
 AICORE void cumsum_kernel(
     __gm__ float *g_ptr, __gm__ float *g_sum_ptr,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len,
+    int32_t NumHeads,
     uint64_t ffts_addr)
 {
   // get_block_idx(): Returns this AI core's index (0..block_num-1).
@@ -113,14 +163,14 @@ AICORE void cumsum_kernel(
   set_mask_norm();
   set_vector_mask(-1, -1);
 
-  // HeadTileCols: NumHeads rounded up to 8-element alignment (32B for float)
-  // HTC = NumHeads rounded up to nearest multiple of 8.
-  // Why? The Vec engine processes data in 32-byte granularity.
-  // For float (4 bytes), that's 8 elements per SIMD "word".
-  // Rounding up ensures every row is a whole number of SIMD words,
-  // avoiding partial-lane issues. The extra columns are zero-padded.
-  // Example: NumHeads=16 → HTC=16 (already aligned), NumHeads=13 → HTC=16.
-  constexpr int32_t HTC = ((NumHeads + 7) / 8) * 8;
+  // HeadTileCols: worst-case head count rounded up to 8-element alignment (32B
+  // for float). NumHeads is a runtime value, so the UB tiles are sized for the
+  // compile-time ceiling GDN_MAX_HEADS; the actual NumHeads columns are used and
+  // the padding columns (NumHeads..HTC) are zero-filled, so the prefix sum over
+  // them stays zero and only rides the SIMD lanes at no correctness cost.
+  // Why 8-alignment? The Vec engine processes data in 32-byte granularity;
+  // for float (4 bytes) that's 8 elements per SIMD "word".
+  constexpr int32_t HTC = ((GDN_MAX_HEADS + 7) / 8) * 8;
   constexpr int32_t BlockBytes = ChunkSize * HTC *
                                  static_cast<int32_t>(sizeof(float));
   constexpr int32_t RowBytes = HTC * static_cast<int32_t>(sizeof(float));
@@ -146,8 +196,10 @@ AICORE void cumsum_kernel(
   // This is equivalent to:
   //   g_gm = torch.as_strided(g_ptr, size=[valid, NumHeads], stride=[NumHeads, 1])
   using GmShape  = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-  using GmStride = Stride<1, 1, 1, NumHeads, 1>;
+  using GmStride = Stride<1, 1, 1, DYNAMIC, 1>;
   using GmFloat  = GlobalTensor<float, GmShape, GmStride>;
+  // Runtime row pitch = NumHeads elements (BSND: token t at offset t*NumHeads).
+  GmStride g_stride(NumHeads);
 
   // Pre-assign row accumulator at fixed UB address
   // TASSIGN(tile, address): Binds a tile descriptor to a fixed byte address in UB.
@@ -184,7 +236,7 @@ AICORE void cumsum_kernel(
       // NumHeads up to the 8-aligned HTC) so downstream Vec ops see zeros.
       {
         GmShape gs; gs.shape[3] = valid; gs.shape[4] = NumHeads;
-        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs, g_stride);
         UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
             g_load(valid, NumHeads);
         TASSIGN(g_load, GUbAddr);
@@ -223,11 +275,6 @@ AICORE void cumsum_kernel(
       TASSIGN(g_row_0, GUbAddr);
       // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
       TMOV(acc_ub, g_row_0);
-      // pipe_barrier(PIPE_V): Ensures all pending Vec (SIMD) operations complete
-      // before the next Vec instruction begins. Needed because Vec ops are pipelined
-      // and may not finish in order. Think of it as a local __syncthreads() for the
-      // Vec engine only. Much lighter than set_flag/wait_flag (which sync across
-      // different hardware units).
       pipe_barrier(PIPE_V);
 
       UbND<float, 1, HTC> s_row_0;
@@ -241,8 +288,11 @@ AICORE void cumsum_kernel(
         TASSIGN(g_row_i, GUbAddr + i * RowBytes);
         // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
         // Operates on all HTC elements in parallel (SIMD).
+        // *** The one load-bearing sync (see chain-sync note above): Vec→Scalar
+        // after this per-row write to acc_ub, ordering it before the scalar issuer
+        // launches the next row. Every other barrier in this chain is plain PIPE_V.
         TADD(acc_ub, acc_ub, g_row_i);
-        pipe_barrier(PIPE_V);
+        PtoSetWaitFlag<PIPE_V, PIPE_S>(EVENT_ID2, EVENT_ID2);
 
         UbND<float, 1, HTC> s_row_i;
         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
@@ -273,7 +323,7 @@ AICORE void cumsum_kernel(
 
       {
         GmShape ss; ss.shape[3] = valid; ss.shape[4] = NumHeads;
-        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss, g_stride);
         UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC>
             s_store(valid, NumHeads);
         TASSIGN(s_store, SUbAddr);
@@ -312,7 +362,7 @@ AICORE void cumsum_kernel(
           // Load g chunk from GM → UB, zero-padded
           {
             GmShape gs; gs.shape[3] = valid; gs.shape[4] = NumHeads;
-            GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+            GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs, g_stride);
             UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
                 g_load(valid, NumHeads);
             TASSIGN(g_load, GUbAddr);
@@ -342,8 +392,10 @@ AICORE void cumsum_kernel(
           for (int32_t i = 1; i < valid; ++i) {
             UbND<float, 1, HTC> g_row_i;
             TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+            // The one load-bearing sync (see chain-sync note above): Vec→Scalar
+            // after this per-row write to acc_ub. All other barriers here are PIPE_V.
             TADD(acc_ub, acc_ub, g_row_i);
-            pipe_barrier(PIPE_V);
+            PtoSetWaitFlag<PIPE_V, PIPE_S>(EVENT_ID2, EVENT_ID2);
 
             UbND<float, 1, HTC> s_row_i;
             TASSIGN(s_row_i, SUbAddr + i * RowBytes);
@@ -367,7 +419,7 @@ AICORE void cumsum_kernel(
 
           {
             GmShape ss; ss.shape[3] = valid; ss.shape[4] = NumHeads;
-            GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+            GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss, g_stride);
             UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC>
                 s_store(valid, NumHeads);
             TASSIGN(s_store, SUbAddr);
@@ -395,26 +447,16 @@ extern "C" __global__ AICORE void launch_cumsum(
     uint32_t num_heads,
     uint64_t ffts_addr)
 {
-#define DISPATCH_CUMSUM_H(H)                                      \
-  case H:                                                         \
-    cumsum_kernel<H, GDN_C>(                                      \
-        reinterpret_cast<__gm__ float *>(g_ptr),                  \
-        reinterpret_cast<__gm__ float *>(g_sum_ptr),              \
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens),           \
-        batch_size, seq_len, ffts_addr);                          \
-    return
-
-  switch (num_heads) {
-    DISPATCH_CUMSUM_H(16);
-    DISPATCH_CUMSUM_H(24);
-    DISPATCH_CUMSUM_H(32);
-    DISPATCH_CUMSUM_H(48);
-    DISPATCH_CUMSUM_H(64);
-    default:
-      return;
+  // NumHeads is a runtime kernel argument (one .so serves every head count).
+  // Guard the compile-time UB ceiling; host also validates before launch.
+  if (num_heads == 0 || num_heads > GDN_MAX_HEADS) {
+    return;
   }
-
-#undef DISPATCH_CUMSUM_H
+  cumsum_kernel<GDN_C>(
+      reinterpret_cast<__gm__ float *>(g_ptr),
+      reinterpret_cast<__gm__ float *>(g_sum_ptr),
+      reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
+      batch_size, seq_len, static_cast<int32_t>(num_heads), ffts_addr);
 }
 
 // ── Host-side launcher (called from Python via ctypes) ────────────

--- a/kernels/pto/kkt_kda.cpp
+++ b/kernels/pto/kkt_kda.cpp
@@ -1,73 +1,58 @@
 // ============================================================================
-// kkt_kda.cpp — Within-chunk gated attention matrix for KDA (numerically stable)
+// kkt_kda.cpp — Within-chunk gated attention matrix for KDA (Cube-accelerated,
+//               numerically stable via per-token exp offset)
 //
 // Mathematical operation (per chunk of C tokens, per head h):
 //   L[r,c] = beta[r] * sum_d k[r,d] * k[c,d] * exp(g_cs[r,d] - g_cs[c,d])
 //            for r > c (strictly lower-tri), else 0
 //
-// STABILITY: Kimi KDA gates (g = -exp(A_log)*softplus(...)) are unbounded; the
-//   within-chunk cumulative gate g_cs can reach ~-500.  The previous factorized
-//   form  A_eff=k*exp(g_cs), B_eff=k*exp(-g_cs), L=A_eff@B_eff^T  computes
-//   exp(-g_cs)=exp(+500) which overflows fp32 (max e^88) -> inf -> inf*0 = NaN.
+// THE STABILITY PROBLEM:
+//   The Cube-friendly factorization  A=k*exp(g_cs), B=k*exp(-g_cs), L=A@B^T
+//   computes exp(-g_cs)=exp(+500) on Kimi KDA gates (cumulative g_cs ~ -500),
+//   which overflows even fp32 (max e^88) -> inf -> inf*0 = NaN.
 //
-//   This kernel instead computes exp(g_cs[r]-g_cs[c]) as a DIFFERENCE, never the
-//   product of two separate exponentials.  For the kept (lower-tri) entries r>c,
-//   g_cs[r] <= g_cs[c] (g_cs monotone decreasing within a chunk) so the argument
-//   is <= 0 and exp(.) <= 1 — always finite.  We clamp the argument with
-//   min(., 0) so the masked (upper-tri) entries also stay finite (then discarded
-//   by only storing the strict-lower part).  No pivot, no saturation, exact.
+// THE FIX — per-token offset (two exponentials that *almost* cancel):
+//   Pick one scalar per token  b[t] = max_d g_cs[t,d]  and factor it out of
+//   BOTH legs of the matmul:
+//       A[t,d] = k[t,d] * exp(g_cs[t,d] - b[t])     (<= k  ⇒ never overflows)
+//       B[t,d] = k[t,d] * exp(b[t] - g_cs[t,d])     (>= k, |exp| = channel spread)
+//       M[r,c] = sum_d A[r,d]*B[c,d]                (= A @ B^T, on the Cube, fp32)
+//       L[r,c] = beta[r] * exp(min(b[r]-b[c], 0)) * M[r,c]      for r > c
+//   The b[t] inside A and B cancels exactly in the per-d product; the residual
+//   is the post-matmul correction exp(b[r]-b[c]).  Because b is monotone
+//   decreasing within a chunk (g_cs is), b[r]-b[c] <= 0 for kept entries (r>c),
+//   so the correction is <= 1; min(.,0) keeps the masked (r<c) entries finite
+//   too (they are then zeroed by the strict-lower mask, avoiding inf*0=NaN).
 //
-// IMPLEMENTATION: per (head, chunk) the work is split across the two Vec
-//   sub-blocks by row range (vid=0 -> rows [0,C/2), vid=1 -> rows [C/2, C)),
-//   mirroring the GDN scaled_dot_kkt row split.  Each vid loops over columns c
-//   and computes its rows' column-c of L via a per-column elementwise reduction:
-//
-//     diff[r,d] = g_cs[my_row r, d] - g_cs[c, d]   (TCOLEXPANDSUB, per-dim c)
-//     diff      = min(diff, 0)                       (TMINS)
-//     t[r,d]    = exp(diff) * k[c,d] * k[my_row r,d] (TEXP, TCOLEXPANDMUL, TMUL)
-//     L[my_row r, c] = beta[r] * sum_d t[r,d]        (TROWSUM, TMUL)
-//
-//   then stores the strict-lower rows (global_row > c) to L_out.  This is a
-//   Vec-only kernel; the Cube pass only participates in the entry/exit barriers.
-//   (A GEMM-accelerated off-diagonal path is a future optimization.)
+//   The cross-TOKEN cumulative blow-up (~-500) is fully absorbed into b[t]; the
+//   only magnitude left in the matmul factors is the within-token cross-CHANNEL
+//   spread  max_d g_cs[t,d] - min_d g_cs[t,d]  (carried by the B factor).  The
+//   fp32 GEMM (e^88) is safe as long as that spread stays < ~88.
 //
 // Inputs (all on GM, head-major [HV, total_tokens, K]):
 //   k       [HV, total_tokens, K]  float16  — keys
 //   g_cs    [HV, total_tokens, K]  float32  — within-chunk cumulative gate sum
 //   beta    [HV, total_tokens]     float16  — post-sigmoid beta in (0, 1)
-//   mask    [C, C]                 float32  — (unused; kept for ABI stability)
-//   ws_in   [block_dim*2, 2*C, K]  float32  — (unused; kept for ABI stability)
-//   ws_out  [block_dim*2, C, C]    float32  — (unused; kept for ABI stability)
+//   mask    [C, C]                 float32  — strict-lower-tri (1 below diag, else 0)
+//   ws_in   [block_dim*2, 2*C, K]  float32  — workspace: A (rows 0..C-1) + B (C..2C-1)
+//   ws_out  [block_dim*2, C, C]    float32  — workspace: GEMM result M
+//   b_ws    [block_dim*2, C]       float32  — workspace: per-token offset b[t]
 //   L_out   [total_tokens, HV, C]  float16  — strictly-lower-tri L (BSND)
 //
-// Output:
-//   L_out   [total_tokens, HV, C]  float32  — strictly-lower-tri L matrix (BSND)
-//
-// Cross-core architecture (mirrors GDN scaled_dot_kkt pattern):
+// Cross-core architecture (mirrors GDN scaled_dot_kkt / main kkt_kda pattern):
 //   Both Vec sub-blocks (vid=0,1) do real work: each handles HalfChunk rows.
 //     vid=0 → rows [0, C/2),  vid=1 → rows [C/2, C)
-//   Vec pre:  load k, g_cs (my rows) → A_eff = k*exp(g), B_eff = k*exp(-g),
-//             cast fp16 → ws_in[my rows]
-//   Cube:     load full A_eff, B_eff from ws_in → GEMM A @ B^T → ws_out
-//   Vec post: load ws_out[my rows], cast fp32 → apply mask + beta row-scale → L_out
+//   Vec pre:  load k, g_cs (my rows) → b=rowmax(g_cs) → A=k*exp(g-b),
+//             B=k*exp(b-g) (fp32) → ws_in[my rows];  b[my rows] → b_ws.
+//   Cube:     load full A, B from ws_in → fp32 GEMM A @ B^T → ws_out.
+//   Vec post: load M[my rows] + full b → corr=exp(min(b[r]-b[c],0)) →
+//             L = M*corr*beta*mask → cast fp16 → L_out.
 //
 // FFTS flags (double-buffered, slot = ci & 1):
 //   0, 1 : Vec → Cube  "ws_in[slot] ready"  (both vids must sig under mode-2 reduce)
 //   2, 3 : Cube → Vec  "ws_out[slot] ready" (broadcast: each vid gets a signal)
-//   4, 5 : Vec → Cube  "ws_out[slot] free"  (Vec done reading L_full; conditional)
-//
-// UB budget (per vid, HalfChunk=C/2 rows; UB ~192 KB per Vec sub-block):
-//   mask fp32 [C/2, C] lives always at offset 0 (loaded once per launch).
-//   The rest of UB is a shared pool reused between pre-compute and post-process
-//   (they never run concurrently within a chunk).
-//   Pre-compute pool (live simultaneously):
-//     g_ub  fp32 [C/2, KTC],  k_ub fp32 [C/2, KTC],
-//     ab_ub fp32 [C/2, KTC],  half_buf fp16 [C/2, KTC]    (scratch reused A → B)
-//   Post-process pool (live simultaneously; overlaps pre-compute addresses):
-//     L_half fp16 [C/2, C],  L_ub fp32 [C/2, C],
-//     beta_2d fp32 [C/2, C], beta fp32 [1, C/2]
-//   Peak @ C=128, K=128: mask 32 + pre 112 = 144 KB ✓ (under 192 KB)
-//   Peak @ C=16,  K=128: mask 0.5 + pre 14 ≈ 15 KB ✓
+//   4, 5 : Vec → Cube  "ws_out[slot] free"  (Vec done reading M; conditional)
+//   6-9  : reserved for sync_all() entry/exit barriers
 //
 // Template parameters:
 //   Compile-time: GDN_D = K, GDN_C = C.  Runtime: num_heads = HV.
@@ -117,6 +102,73 @@ using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
 template <typename T, int R, int C, int RV = R, int CV = C>
 using UbDN = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::ColMajor,
                        RV, CV, pto::SLayout::NoneBox, 512>;
+
+// ── Cube tile aliases (fp32 GEMM), copied from chunk_o_kda.cpp ──────────────
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL1 = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                            pto::BLayout::ColMajor, RowValid, ColValid,
+                            pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                              pto::BLayout::RowMajor, RowValid, ColValid,
+                              pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
+          int32_t ColValid = Cols>
+using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int32_t Rows, int32_t Cols>
+using DynMatL1 = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                           pto::BLayout::ColMajor, pto::DYNAMIC,
+                           pto::DYNAMIC, pto::SLayout::RowMajor, 512,
+                           pto::PadValue::Zero>;
+
+// Single-shot dense GEMM  C = A @ B^T  via L0A/L0B — used when the K-dim is one
+// L0 tile (inner dim KDim == 128 == L0 tile size, so no K-slicing needed).
+// transpose-B only (avoids a <type_traits> dependency, which would break the
+// mega kernel's namespaced #include ordering vs chunk_o_kda.cpp).
+template <typename T1, typename T2, int32_t M, int32_t N, int32_t K>
+AICORE PTO_INLINE void
+gemm_abt(TileMatL1<T1, M, K, M, K> &A,
+         TileMatL1<T1, N, K, N, K> &B,
+         pto::TileAcc<T2, M, N, M, N> &C)
+{
+    TileMatL0A<T1, M, K, M, K> l0a;
+    TileMatL0B<T1, K, N, K, N> l0b;
+    pto::TASSIGN(l0a, 0x0);
+    pto::TASSIGN(l0b, 0x0);
+
+    auto war_event_id = (event_t)(((int)EVENT_ID0 + 1) % 8);
+    set_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+    set_flag(PIPE_M, PIPE_MTE1, war_event_id);
+    wait_flag(PIPE_M, PIPE_MTE1, war_event_id);
+
+    pto::TEXTRACT(l0a, A, 0, 0);
+    TileMatL1ZN<T1, K, N, K, N> B_t;
+    pto::TRESHAPE(B_t, B);
+    pto::TEXTRACT(l0b, B_t, 0, 0);
+
+    set_flag(PIPE_MTE1, PIPE_M, war_event_id);
+    wait_flag(PIPE_MTE1, PIPE_M, war_event_id);
+    pto::TMATMUL(C, l0a, l0b);
+
+    set_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+    wait_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+    set_flag(PIPE_M, PIPE_FIX, war_event_id);
+    wait_flag(PIPE_M, PIPE_FIX, war_event_id);
+}
 #endif
 
 template <int32_t KDim, int32_t ChunkSize>
@@ -127,6 +179,7 @@ AICORE void kkt_kda_kernel(
     __gm__ float *mask_ptr,
     __gm__ float *ws_in_ptr,
     __gm__ float *ws_out_ptr,
+    __gm__ float *b_ws_ptr,
     __gm__ half *L_out_ptr,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
@@ -134,12 +187,8 @@ AICORE void kkt_kda_kernel(
 {
     auto cid = get_block_idx();
     auto block_num = get_block_num();
-    auto vid = get_subblockid();
     set_ffts_base_addr(ffts_addr);
 
-    // Head count is a runtime argument (HV).  Only loop bounds, the work-item
-    // decode, and GM strides depend on it — no UB buffer or tile shape does —
-    // so it never needs to be a compile-time constant.
     const int32_t NumHeads = num_heads;
 
     constexpr int32_t HalfChunk = ChunkSize / 2;
@@ -148,51 +197,65 @@ AICORE void kkt_kda_kernel(
     int64_t num_seqs = batch_size;
     int64_t total_work = num_seqs * NumHeads;
 
+    // Workspace element counts per slot (fp32 elements):
+    constexpr int32_t WsInSlotElems = 2 * ChunkSize * KDim;   // A + B
+    constexpr int32_t WsOutSlotElems = ChunkSize * ChunkSize; // M
+    constexpr int32_t BWsSlotElems = ChunkSize;               // b[t]
+
     // ── GM type aliases (head-major [HV, T, K]) ──────────────────────────────
     using GmShapeDyn = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
     using GmFloatK = GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>;
     using GmHalfK = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>;
     using GmHalf_1 = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, 1, 1>>;
-    // L output is BSND-interleaved [total_tokens, NumHeads, ChunkSize]; the
-    // token stride NumHeads*ChunkSize is now runtime, so the GM stride is
-    // DYNAMIC and supplied at construction (see the store site below).
-    using GmHalfOut = GlobalTensor<half, GmShapeDyn,
-                                   Stride<1, 1, 1, DYNAMIC, 1>>;
-    using GmHalfWsIn = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>;
-    using GmHalfWsOut = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, ChunkSize, 1>>;
-    // Strict-lower mask [C, C]; read one column c as a [my_rows, 1] strip where
-    // the row dim steps down by ChunkSize and the single column is contiguous
-    // (innermost stride 1).  Independent of head count, so a compile-time stride.
-    using GmFloatMaskColRow = GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, ChunkSize, 1>>;
+    using GmFloat_1 = GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, 1, 1>>;
+    // L output is BSND-interleaved [total_tokens, NumHeads, ChunkSize].
+    using GmHalfOut = GlobalTensor<half, GmShapeDyn, Stride<1, 1, 1, DYNAMIC, 1>>;
+    using GmFloatWsIn = GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>;
+    using GmFloatWsOut = GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, ChunkSize, 1>>;
 
-#if defined(__DAV_C220_CUBE__)
-    // Cube does no compute here; it only participates in the entry/exit barriers
-    // so the Vec-side sync_all() handshakes complete.
-    sync_all();
-    sync_all();
-#endif
-
+    // =========================================================================
+    // VEC PHASE
+    // =========================================================================
 #if defined(__DAV_C220_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
     sync_all();
 
-    // ── UB layout (per vid) ──────────────────────────────────────────────────
-    constexpr int32_t MYG_ADDR = 0;                               // [HalfChunk, K] fp32
-    constexpr int32_t MYK_ADDR = MYG_ADDR + HalfChunk * KTC * 4;  // [HalfChunk, K] fp32
-    constexpr int32_t DIFF_ADDR = MYK_ADDR + HalfChunk * KTC * 4; // [HalfChunk, K] fp32 (diff/t)
-    constexpr int32_t TMP_ADDR = DIFF_ADDR + HalfChunk * KTC * 4; // [HalfChunk, K] fp32 (rowsum tmp)
-    constexpr int32_t MYKH_ADDR = TMP_ADDR + HalfChunk * KTC * 4; // [HalfChunk, K] fp16 (k staging)
-    constexpr int32_t GC_ADDR = MYKH_ADDR + HalfChunk * KTC * 2;  // [1, K] fp32 (column g_c)
-    constexpr int32_t KC_ADDR = GC_ADDR + KTC * 4;                // [1, K] fp32 (column k_c)
-    constexpr int32_t KCH_ADDR = KC_ADDR + KTC * 4;               // [1, K] fp16 (k_c staging)
-    constexpr int32_t COL_ADDR = KCH_ADDR + KTC * 2;              // [HalfChunk, 16] fp32 (colsum, RowMajor padded)
-    constexpr int32_t COLH_ADDR = COL_ADDR + HalfChunk * 16 * 4;  // [HalfChunk, 16] fp16 (padded store, RowMajor)
-    constexpr int32_t BETA_ADDR = COLH_ADDR + HalfChunk * 16 * 2; // [1, HalfChunk] fp32 (beta)
-    constexpr int32_t BETAH_ADDR = BETA_ADDR + HalfChunk * 4;     // [1, HalfChunk] fp16 (beta staging)
-    constexpr int32_t MSKC_ADDR = BETAH_ADDR + HalfChunk * 2;     // [1, HalfChunk] fp32 (mask col)
-
+    auto vid = get_subblockid();
     int32_t my_off = static_cast<int32_t>(vid) * HalfChunk;
+
+    // ── UB layout (per vid) ──────────────────────────────────────────────────
+    // Mask persists at offset 0; the rest is a pool reused between pre-compute
+    // and post-process (they never run concurrently within a chunk).
+    constexpr int32_t MSK_ADDR = 0; // [HalfChunk, C] fp32
+    constexpr int32_t POOL = MSK_ADDR + HalfChunk * ChunkSize * 4;
+    // Pre-compute tiles (live simultaneously: g, k, A, B):
+    constexpr int32_t G_ADDR = POOL;                            // [HalfChunk, KTC] fp32
+    constexpr int32_t K_ADDR = G_ADDR + HalfChunk * KTC * 4;    // [HalfChunk, KTC] fp32
+    constexpr int32_t A_ADDR = K_ADDR + HalfChunk * KTC * 4;    // [HalfChunk, KTC] fp32
+    constexpr int32_t B_ADDR = A_ADDR + HalfChunk * KTC * 4;    // [HalfChunk, KTC] fp32
+    constexpr int32_t BCOL_ADDR = B_ADDR + HalfChunk * KTC * 4; // [HalfChunk, 1] fp32 (b, ColMajor)
+    // Post-process tiles (overlap pre-compute addresses):
+    constexpr int32_t M_ADDR = POOL;                                   // [HalfChunk, C] fp32
+    constexpr int32_t CORR_ADDR = M_ADDR + HalfChunk * ChunkSize * 4;  // [HalfChunk, C] fp32
+    constexpr int32_t LH_ADDR = CORR_ADDR + HalfChunk * ChunkSize * 4; // [HalfChunk, C] fp16
+    constexpr int32_t BROW_ADDR = LH_ADDR + HalfChunk * ChunkSize * 2; // [1, C] fp32 (b cols)
+    constexpr int32_t BETA_ADDR = BROW_ADDR + ChunkSize * 4;           // [HalfChunk, 1] fp32 (beta, ColMajor)
+    constexpr int32_t BETAH_ADDR = BETA_ADDR + HalfChunk * 4;          // [1, HalfChunk] fp16 (beta staging)
+
+    // ── Load this vid's HalfChunk rows of the strict-lower mask (once) ──────
+    {
+        UbND<float, HalfChunk, ChunkSize> msk_ub;
+        TASSIGN(msk_ub, MSK_ADDR);
+        GmShapeDyn gs;
+        gs.shape[3] = HalfChunk;
+        gs.shape[4] = ChunkSize;
+        GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, ChunkSize, 1>>
+            msk_gm(mask_ptr + static_cast<int64_t>(my_off) * ChunkSize, gs);
+        TLOAD(msk_ub, msk_gm);
+    }
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
     for (int64_t work_idx = 0;
          work_idx < (total_work + block_num - 1) / block_num; ++work_idx)
@@ -220,27 +283,27 @@ AICORE void kkt_kda_kernel(
 
         for (int64_t ci = 0; ci < num_chunks; ++ci)
         {
+            int32_t slot = static_cast<int32_t>(ci & 1);
+
             int64_t chunk_start = ci * ChunkSize;
             int64_t remaining = slen - chunk_start;
             int32_t valid_rows = static_cast<int32_t>(
                 remaining < ChunkSize ? remaining : ChunkSize);
-
-            // This vid's row range within the chunk: [my_off, my_off + my_rows).
             int32_t my_rows = valid_rows - my_off;
             if (my_rows > HalfChunk)
                 my_rows = HalfChunk;
-            if (my_rows <= 0)
-                continue; // no rows for this vid in this chunk
-
-            // Columns this vid must cover: c in [0, col_end).  A row r is kept
-            // for column c only if global_row(r) > c, so the largest column any
-            // of my rows touches is (my_off + my_rows - 1).
-            int32_t col_end = my_off + my_rows; // exclusive upper bound for c
+            if (my_rows < 0)
+                my_rows = 0;
 
             int64_t hbase = static_cast<int64_t>(head_idx) * total_tokens * KDim;
-            int64_t my_first = bos + chunk_start + my_off; // global row index of my row 0
+            int64_t my_first = bos + chunk_start + my_off;
+            int64_t ws_in_base =
+                (static_cast<int64_t>(cid) * 2 + slot) * static_cast<int64_t>(WsInSlotElems);
+            int64_t b_ws_base =
+                (static_cast<int64_t>(cid) * 2 + slot) * static_cast<int64_t>(BWsSlotElems);
 
-            // ── Load my rows' g_cs (fp32) and k (fp16 -> fp32) ───────────────
+            // ── PRE-COMPUTE ────────────────────────────────────────────────
+            if (my_rows > 0)
             {
                 GmShapeDyn gs;
                 gs.shape[3] = my_rows;
@@ -309,111 +372,369 @@ AICORE void kkt_kda_kernel(
                 int64_t col_off = hbase + (bos + chunk_start + c) * KDim;
                 {
                     GmShapeDyn gs;
-                    gs.shape[3] = 1;
+                    gs.shape[3] = my_rows;
                     gs.shape[4] = KDim;
-                    GmFloatK gc_gm(g_cs_ptr + col_off, gs);
-                    UbND<float, 1, KTC, 1, KTC> gc_ld;
-                    TASSIGN(gc_ld, GC_ADDR);
-                    TLOAD(gc_ld, gc_gm);
-                    GmHalfK kc_gm(k_ptr + col_off, gs);
-                    UbND<half, 1, KTC, 1, KTC> kc_ld;
-                    TASSIGN(kc_ld, KCH_ADDR);
-                    TLOAD(kc_ld, kc_gm);
+                    GmFloatK g_gm(g_cs_ptr + hbase + my_first * KDim, gs);
+                    UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC, PadValue::Zero>
+                        g_ld(my_rows, KDim);
+                    TASSIGN(g_ld, G_ADDR);
+                    TLOAD(g_ld, g_gm);
+                    if (my_rows != HalfChunk || KDim != KTC)
+                    {
+                        UbND<float, HalfChunk, KTC, HalfChunk, KTC, PadValue::Zero> g_pad;
+                        TASSIGN(g_pad, G_ADDR);
+                        TFILLPAD_INPLACE(g_pad, g_ld);
+                    }
+                }
+                // Load k (fp16) → A_ADDR (fp16 staging), cvt → K_ADDR (fp32).
+                {
+                    GmShapeDyn gs;
+                    gs.shape[3] = my_rows;
+                    gs.shape[4] = KDim;
+                    GmHalfK k_gm(k_ptr + hbase + my_first * KDim, gs);
+                    UbND<half, HalfChunk, KTC, DYNAMIC, DYNAMIC, PadValue::Zero>
+                        k_ld(my_rows, KDim);
+                    TASSIGN(k_ld, A_ADDR);
+                    TLOAD(k_ld, k_gm);
+                    if (my_rows != HalfChunk || KDim != KTC)
+                    {
+                        UbND<half, HalfChunk, KTC, HalfChunk, KTC, PadValue::Zero> k_pad;
+                        TASSIGN(k_pad, A_ADDR);
+                        TFILLPAD_INPLACE(k_pad, k_ld);
+                    }
                 }
                 set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                 wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                 {
-                    UbND<half, 1, KTC, 1, KTC> kc_h;
-                    TASSIGN(kc_h, KCH_ADDR);
-                    UbND<float, 1, KTC, 1, KTC> kc_f;
-                    TASSIGN(kc_f, KC_ADDR);
-                    TCVT(kc_f, kc_h, pto::RoundMode::CAST_NONE);
+                    UbND<half, HalfChunk, KTC> k_h;
+                    TASSIGN(k_h, A_ADDR);
+                    UbND<float, HalfChunk, KTC> k_f;
+                    TASSIGN(k_f, K_ADDR);
+                    TCVT(k_f, k_h, pto::RoundMode::CAST_NONE);
                     pipe_barrier(PIPE_V);
                 }
 
-                UbND<float, 1, KTC, 1, KTC> gc;
-                TASSIGN(gc, GC_ADDR);
-                UbND<float, 1, KTC, 1, KTC> kc;
-                TASSIGN(kc, KC_ADDR);
-                UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> diff(my_rows, KDim);
-                TASSIGN(diff, DIFF_ADDR);
-                UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> tmp(my_rows, KDim);
-                TASSIGN(tmp, TMP_ADDR);
-                UbND<float, HalfChunk, 16, DYNAMIC, DYNAMIC> colsum(my_rows, 1);
-                TASSIGN(colsum, COL_ADDR);
+                UbND<float, HalfChunk, KTC> g_ub;
+                TASSIGN(g_ub, G_ADDR);
+                UbND<float, HalfChunk, KTC> k_ub;
+                TASSIGN(k_ub, K_ADDR);
+                UbND<float, HalfChunk, KTC> a_ub;
+                TASSIGN(a_ub, A_ADDR);
+                UbND<float, HalfChunk, KTC> b_ub;
+                TASSIGN(b_ub, B_ADDR);
+                UbDN<float, HalfChunk, 1> bcol;
+                TASSIGN(bcol, BCOL_ADDR);
 
-                // diff[r,d] = g_cs[my r, d] - g_cs[c, d]
-                TCOLEXPANDSUB(diff, myg, gc);
-                pipe_barrier(PIPE_V);
-                // clamp to <= 0 so exp(.) is finite for masked (r<c) entries too
-                TMINS(diff, diff, 0.0f);
-                pipe_barrier(PIPE_V);
-                TEXP(diff, diff);
-                pipe_barrier(PIPE_V);
-                // *= k[c,d]  (per-dim broadcast), then *= k[my r, d]
-                TCOLEXPANDMUL(diff, diff, kc);
-                pipe_barrier(PIPE_V);
-                TMUL(diff, diff, myk);
-                pipe_barrier(PIPE_V);
-                // per-row beta scale (TMUL can't take a [R,1] column directly)
-                TROWEXPANDMUL(diff, diff, beta_col);
-                pipe_barrier(PIPE_V);
-                // colsum[r] = beta[r] * sum_d diff[r,d]   (unmasked)
-                TROWSUM(colsum, diff, tmp);
-                pipe_barrier(PIPE_V);
-
-                // Strict-lower mask: load mask[my_off+r, c] as a padded [my_rows,1]
-                // strip (row-strided gather, innermost contiguous) and zero the
-                // upper-tri rows (my_off+r <= c) via elementwise TMUL.
+                // b[r] = max_d g_cs[r,d]   (use B_ADDR space as the rowmax tmp).
                 {
-                    UbND<float, HalfChunk, 16, DYNAMIC, DYNAMIC> mk(my_rows, 1);
-                    TASSIGN(mk, MSKC_ADDR);
-                    GmShapeDyn gs;
-                    gs.shape[3] = my_rows;
-                    gs.shape[4] = 1;
-                    GmFloatMaskColRow mk_gm(
-                        mask_ptr + static_cast<int64_t>(my_off) * ChunkSize + c, gs);
-                    TLOAD(mk, mk_gm);
-                    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-                    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-                    TMUL(colsum, colsum, mk);
+                    UbND<float, HalfChunk, KTC> rmax_tmp;
+                    TASSIGN(rmax_tmp, B_ADDR);
+                    TROWMAX(bcol, g_ub, rmax_tmp);
                     pipe_barrier(PIPE_V);
                 }
-
-                // cvt colsum -> fp16 into a padded RowMajor [my_rows, 1] tile and
-                // store column c of L for the strided set of tokens (row dim steps
-                // by NumHeads*ChunkSize, the single column is contiguous).
-                UbND<half, HalfChunk, 16, DYNAMIC, DYNAMIC> col_h(my_rows, 1);
-                TASSIGN(col_h, COLH_ADDR);
-                TCVT(col_h, colsum, pto::RoundMode::CAST_NONE);
+                // A = k * exp(g_cs - b)        (exp(g-b) <= 1, never overflows)
+                TROWEXPANDEXPDIF(a_ub, g_ub, bcol);
+                pipe_barrier(PIPE_V);
+                TMUL(a_ub, a_ub, k_ub);
+                pipe_barrier(PIPE_V);
+                // B = k * exp(b - g_cs) = k * exp(-(g_cs - b))
+                // The exponent (b - g_cs) >= 0 equals the within-token cross-channel
+                // spread; for heavily-decayed channels (Kimi per-channel gate spikes
+                // ~-160) it exceeds the fp32 exp limit.  Saturate it at 80 so B stays
+                // finite (exp(80)~5.5e34; 128-term sum stays < fp32 max 3.4e38).  This
+                // keeps the result exact wherever the spread < 80 and merely
+                // under-counts the rare heavily-decayed channel (whose A factor has
+                // already underflowed to 0) instead of producing inf -> 0*inf = NaN.
+                TROWEXPANDSUB(b_ub, g_ub, bcol); // g - b   (<= 0)
+                pipe_barrier(PIPE_V);
+                TNEG(b_ub, b_ub); // b - g   (>= 0)
+                pipe_barrier(PIPE_V);
+                TMINS(b_ub, b_ub, 80.0f); // saturating exp
+                pipe_barrier(PIPE_V);
+                TEXP(b_ub, b_ub);
+                pipe_barrier(PIPE_V);
+                TMUL(b_ub, b_ub, k_ub);
                 pipe_barrier(PIPE_V);
 
-                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                // Store A → ws_in[slot] rows [my_off, …).
                 {
-                    int64_t l_off = my_first * static_cast<int64_t>(NumHeads) * ChunkSize +
-                                    static_cast<int64_t>(head_idx) * ChunkSize + c;
                     GmShapeDyn gs;
-                    gs.shape[3] = my_rows;
-                    gs.shape[4] = 1;
-                    // Row (token) dim steps by NumHeads*ChunkSize — runtime now,
-                    // so supply the stride at construction (see GmHalfOut above).
-                    Stride<1, 1, 1, DYNAMIC, 1> l_stride(NumHeads * ChunkSize);
-                    GmHalfOut l_gm(L_out_ptr + l_off, gs, l_stride);
-                    TSTORE(l_gm, col_h);
+                    gs.shape[3] = HalfChunk;
+                    gs.shape[4] = KDim;
+                    int64_t off = ws_in_base + static_cast<int64_t>(my_off) * KDim;
+                    GmFloatWsIn gm_a(ws_in_ptr + off, gs);
+                    UbND<float, HalfChunk, KTC, HalfChunk, KTC> a_st;
+                    TASSIGN(a_st, A_ADDR);
+                    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                    TSTORE(gm_a, a_st);
+                }
+                // Store B → ws_in[slot] rows [C+my_off, …).
+                {
+                    GmShapeDyn gs;
+                    gs.shape[3] = HalfChunk;
+                    gs.shape[4] = KDim;
+                    int64_t off = ws_in_base +
+                                  static_cast<int64_t>(ChunkSize) * KDim +
+                                  static_cast<int64_t>(my_off) * KDim;
+                    GmFloatWsIn gm_b(ws_in_ptr + off, gs);
+                    UbND<float, HalfChunk, KTC, HalfChunk, KTC> b_st;
+                    TASSIGN(b_st, B_ADDR);
+                    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                    TSTORE(gm_b, b_st);
+                }
+                // Store b[my rows] → b_ws[slot] (contiguous [my_rows] floats).
+                // bcol is ColMajor [my_rows,1] but its bytes are my_rows contiguous
+                // floats, identical to a RowMajor [1,my_rows] — alias and store as a
+                // row so the GM (ND) store is a supported ND2ND copy.
+                {
+                    GmShapeDyn gs;
+                    gs.shape[3] = 1;
+                    gs.shape[4] = my_rows;
+                    GmFloat_1 b_gm(b_ws_ptr + b_ws_base + my_off, gs);
+                    UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_st(1, my_rows);
+                    TASSIGN(b_st, BCOL_ADDR);
+                    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+                    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+                    TSTORE(b_gm, b_st);
                 }
                 set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
                 wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-                // Drain all pipes before the next column iteration so its gc/kc/
-                // mask loads (MTE2) cannot race the current column's still-draining
-                // Vec reads of the same UB slots.
-                pipe_barrier(PIPE_ALL);
+            }
+
+            // Both vids signal flag(slot) under V→C reduce mode 2.
+            pipe_barrier(PIPE_ALL);
+            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (slot << 8));
+            wait_flag_dev(2 + slot); // Cube: ws_out[slot] ready
+            pipe_barrier(PIPE_ALL);
+
+            // ── POST-PROCESS ───────────────────────────────────────────────
+            if (my_rows > 0)
+            {
+                // Load M[my rows, :] (fp32) from ws_out[slot].
+                {
+                    int64_t wo_base = (static_cast<int64_t>(cid) * 2 + slot) *
+                                      static_cast<int64_t>(WsOutSlotElems);
+                    int64_t off = wo_base + static_cast<int64_t>(my_off) * ChunkSize;
+                    GmShapeDyn gs;
+                    gs.shape[3] = my_rows;
+                    gs.shape[4] = ChunkSize;
+                    GmFloatWsOut gm(ws_out_ptr + off, gs);
+                    UbND<float, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC, PadValue::Zero>
+                        m_ld(my_rows, ChunkSize);
+                    TASSIGN(m_ld, M_ADDR);
+                    TLOAD(m_ld, gm);
+                }
+                // Load full b[0..C-1] → BROW_ADDR ([1,C], RowMajor, ND2ND).  The
+                // per-row offsets b[my_off + r] are the contiguous sub-range starting
+                // at BROW_ADDR + my_off floats; alias it below as a ColMajor [my_rows,1]
+                // (same bytes) for the per-row broadcast — no separate load needed.
+                {
+                    GmShapeDyn gs;
+                    gs.shape[3] = 1;
+                    gs.shape[4] = ChunkSize;
+                    GmFloat_1 brow_gm(b_ws_ptr + b_ws_base, gs);
+                    UbND<float, 1, ChunkSize> brow_ld;
+                    TASSIGN(brow_ld, BROW_ADDR);
+                    TLOAD(brow_ld, brow_gm);
+                }
+                // Load beta[my rows] (fp16) → BETAH_ADDR.
+                {
+                    GmShapeDyn gs;
+                    gs.shape[3] = 1;
+                    gs.shape[4] = my_rows;
+                    GmHalf_1 b_gm(beta_ptr +
+                                      static_cast<int64_t>(head_idx) * total_tokens +
+                                      my_first,
+                                  gs);
+                    UbND<half, 1, HalfChunk, DYNAMIC, DYNAMIC> b_ld(1, my_rows);
+                    TASSIGN(b_ld, BETAH_ADDR);
+                    TLOAD(b_ld, b_gm);
+                }
+                set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+                wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+                {
+                    UbND<half, 1, HalfChunk, DYNAMIC, DYNAMIC> b_h(1, my_rows);
+                    TASSIGN(b_h, BETAH_ADDR);
+                    UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_f(1, my_rows);
+                    TASSIGN(b_f, BETA_ADDR);
+                    TCVT(b_f, b_h, pto::RoundMode::CAST_NONE);
+                    pipe_barrier(PIPE_V);
+                }
+
+                UbND<float, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> m_ub(my_rows, ChunkSize);
+                TASSIGN(m_ub, M_ADDR);
+                UbND<float, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> corr(my_rows, ChunkSize);
+                TASSIGN(corr, CORR_ADDR);
+                UbND<float, 1, ChunkSize> brow;
+                TASSIGN(brow, BROW_ADDR);
+                // b[my_off + r] sub-range of brow, viewed as a ColMajor [my_rows,1].
+                UbDN<float, HalfChunk, 1, DYNAMIC, DYNAMIC> bcol(my_rows, 1);
+                TASSIGN(bcol, BROW_ADDR + my_off * 4);
+                UbDN<float, HalfChunk, 1, DYNAMIC, DYNAMIC> beta_col(my_rows, 1);
+                TASSIGN(beta_col, BETA_ADDR);
+                UbND<float, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> msk_ub(my_rows, ChunkSize);
+                TASSIGN(msk_ub, MSK_ADDR);
+
+                // corr[r,c] = exp(min(b[r] - b[c], 0))
+                //   fill with b[r] per row, subtract b[c] per col, clamp, exp.
+                TEXPANDS(corr, 0.0f);
+                pipe_barrier(PIPE_V);
+                TROWEXPANDADD(corr, corr, bcol); // corr[r,c] = b[r]
+                pipe_barrier(PIPE_V);
+                TCOLEXPANDSUB(corr, corr, brow); // corr[r,c] = b[r] - b[c]
+                pipe_barrier(PIPE_V);
+                TMINS(corr, corr, 0.0f);
+                pipe_barrier(PIPE_V);
+                TEXP(corr, corr);
+                pipe_barrier(PIPE_V);
+
+                // L = M * corr * beta[r] * mask
+                TMUL(m_ub, m_ub, corr);
+                pipe_barrier(PIPE_V);
+                TROWEXPANDMUL(m_ub, m_ub, beta_col);
+                pipe_barrier(PIPE_V);
+                TMUL(m_ub, m_ub, msk_ub);
+                pipe_barrier(PIPE_V);
+
+                // Cast fp32 → fp16 and store to L_out (BSND).
+                {
+                    UbND<half, HalfChunk, ChunkSize> l_h;
+                    TASSIGN(l_h, LH_ADDR);
+                    TCVT(l_h, m_ub, pto::RoundMode::CAST_NONE);
+                    pipe_barrier(PIPE_V);
+                    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                    int64_t l_off = my_first * static_cast<int64_t>(NumHeads) * ChunkSize +
+                                    static_cast<int64_t>(head_idx) * ChunkSize;
+                    GmShapeDyn gs;
+                    gs.shape[3] = my_rows;
+                    gs.shape[4] = ChunkSize;
+                    Stride<1, 1, 1, DYNAMIC, 1> l_stride(NumHeads * ChunkSize);
+                    GmHalfOut l_gm(L_out_ptr + l_off, gs, l_stride);
+                    UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> l_st(my_rows, ChunkSize);
+                    TASSIGN(l_st, LH_ADDR);
+                    TSTORE(l_gm, l_st);
+                }
+                set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+                wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            }
+
+            // Drain Vec pipes before next chunk, then free ws_out[slot].
+            pipe_barrier(PIPE_ALL);
+            if (ci < num_chunks - 2)
+            {
+                ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | ((4 + slot) << 8));
             }
         }
     }
 
     sync_all();
 #endif // __DAV_C220_VEC__
+
+    // =========================================================================
+    // CUBE PHASE: fp32 GEMM  A @ B^T → M
+    // =========================================================================
+#if defined(__DAV_C220_CUBE__)
+    constexpr int32_t L1BAddr = ChunkSize * KDim * static_cast<int32_t>(sizeof(float));
+
+    sync_all();
+
+    for (int64_t work_idx = 0;
+         work_idx < (total_work + block_num - 1) / block_num; ++work_idx)
+    {
+        int64_t pid = work_idx * static_cast<int64_t>(block_num) +
+                      static_cast<int64_t>(cid);
+        if (pid >= total_work)
+            continue;
+
+        int64_t seq_idx = pid / NumHeads;
+
+        int64_t bos, slen;
+        if (cu_seqlens != nullptr)
+        {
+            bos = static_cast<int64_t>(cu_seqlens[seq_idx]);
+            slen = static_cast<int64_t>(cu_seqlens[seq_idx + 1]) - bos;
+        }
+        else
+        {
+            bos = seq_idx * seq_len;
+            slen = seq_len;
+        }
+        int64_t num_chunks = (slen + ChunkSize - 1) / ChunkSize;
+
+        for (int64_t ci = 0; ci < num_chunks; ++ci)
+        {
+            int32_t slot = static_cast<int32_t>(ci & 1);
+
+            if (ci >= 2)
+            {
+                wait_flag_dev(4 + slot); // ws_out[slot] free
+                pipe_barrier(PIPE_ALL);
+            }
+            wait_flag_dev(slot); // ws_in[slot] ready (both vids sig'd)
+            pipe_barrier(PIPE_ALL);
+
+            int64_t ws_in_base =
+                (static_cast<int64_t>(cid) * 2 + slot) * static_cast<int64_t>(WsInSlotElems);
+
+            TileMatL1<float, ChunkSize, KDim, ChunkSize, KDim> a_l1;
+            TASSIGN(a_l1, 0);
+            TileMatL1<float, ChunkSize, KDim, ChunkSize, KDim> b_l1;
+            TASSIGN(b_l1, L1BAddr);
+            TileAcc<float, ChunkSize, ChunkSize, ChunkSize, ChunkSize> m_l0;
+            TASSIGN(m_l0, 0);
+
+            // Load A [C,K] from ws_in[slot, 0:C, :].
+            {
+                DynMatL1<float, ChunkSize, KDim> _l1(ChunkSize, KDim);
+                TASSIGN(_l1, 0);
+                GmShapeDyn _gs;
+                _gs.shape[3] = ChunkSize;
+                _gs.shape[4] = KDim;
+                GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>
+                    _gm(ws_in_ptr + ws_in_base, _gs);
+                TLOAD(_l1, _gm);
+            }
+            // Load B [C,K] from ws_in[slot, C:2C, :].
+            {
+                DynMatL1<float, ChunkSize, KDim> _l1(ChunkSize, KDim);
+                TASSIGN(_l1, L1BAddr);
+                GmShapeDyn _gs;
+                _gs.shape[3] = ChunkSize;
+                _gs.shape[4] = KDim;
+                GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, KDim, 1>>
+                    _gm(ws_in_ptr + ws_in_base + static_cast<int64_t>(ChunkSize) * KDim, _gs);
+                TLOAD(_l1, _gm);
+            }
+
+            set_flag(PIPE_MTE2, PIPE_M, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID0);
+
+            // M = A @ B^T  (fp32).
+            gemm_abt<float, float, ChunkSize, ChunkSize, KDim>(a_l1, b_l1, m_l0);
+
+            // Store M [C,C] (fp32) → ws_out[slot].
+            {
+                int64_t wo_base = (static_cast<int64_t>(cid) * 2 + slot) *
+                                  static_cast<int64_t>(WsOutSlotElems);
+                GmShapeDyn _gs;
+                _gs.shape[3] = ChunkSize;
+                _gs.shape[4] = ChunkSize;
+                GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, ChunkSize, 1>>
+                    _gm(ws_out_ptr + wo_base, _gs);
+                TSTORE(_gm, m_l0);
+            }
+
+            pipe_barrier(PIPE_ALL);
+            // Signal Vec: ws_out[slot] ready (GEMM done; ws_in[slot] also free).
+            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | ((2 + slot) << 8));
+        }
+    }
+
+    sync_all();
+#endif // __DAV_C220_CUBE__
 }
 
 // ── Device entry point ────────────────────────────────────────────────────────
@@ -424,6 +745,7 @@ extern "C" __global__ AICORE void launch_kkt_kda(
     __gm__ uint8_t *mask_ptr,
     __gm__ uint8_t *ws_in_ptr,
     __gm__ uint8_t *ws_out_ptr,
+    __gm__ uint8_t *b_ws_ptr,
     __gm__ uint8_t *L_out_ptr,
     __gm__ uint8_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
@@ -436,6 +758,7 @@ extern "C" __global__ AICORE void launch_kkt_kda(
         reinterpret_cast<__gm__ float *>(mask_ptr),
         reinterpret_cast<__gm__ float *>(ws_in_ptr),
         reinterpret_cast<__gm__ float *>(ws_out_ptr),
+        reinterpret_cast<__gm__ float *>(b_ws_ptr),
         reinterpret_cast<__gm__ half *>(L_out_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
         batch_size, seq_len, total_tokens, num_heads, ffts_addr);
@@ -450,6 +773,7 @@ extern "C" void call_kernel(
     uint8_t *mask_ptr,
     uint8_t *ws_in_ptr,
     uint8_t *ws_out_ptr,
+    uint8_t *b_ws_ptr,
     uint8_t *L_out_ptr,
     uint8_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
@@ -460,7 +784,7 @@ extern "C" void call_kernel(
     rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
     launch_kkt_kda<<<block_dim, nullptr, stream>>>(
         k_ptr, g_cs_ptr, beta_ptr, mask_ptr,
-        ws_in_ptr, ws_out_ptr, L_out_ptr, cu_seqlens,
+        ws_in_ptr, ws_out_ptr, b_ws_ptr, L_out_ptr, cu_seqlens,
         batch_size, seq_len, total_tokens,
         static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/kernels/pto/kkt_kda.cpp
+++ b/kernels/pto/kkt_kda.cpp
@@ -302,74 +302,20 @@ AICORE void kkt_kda_kernel(
             int64_t b_ws_base =
                 (static_cast<int64_t>(cid) * 2 + slot) * static_cast<int64_t>(BWsSlotElems);
 
-            // ── PRE-COMPUTE ────────────────────────────────────────────────
+            // ── COMPUTE A / B / b for my HalfChunk rows (per-token max offset) ──
+            // Each vid owns rows [my_off, my_off+my_rows).  A and B are always stored
+            // as full HalfChunk blocks; absent rows (my_rows == 0) and intra-block pad
+            // rows are zero so the Cube GEMM over all C rows is unaffected.
+            UbND<float, HalfChunk, KTC> a_ub;
+            TASSIGN(a_ub, A_ADDR);
+            UbND<float, HalfChunk, KTC> b_ub;
+            TASSIGN(b_ub, B_ADDR);
+            UbDN<float, HalfChunk, 1> bcol;
+            TASSIGN(bcol, BCOL_ADDR);
+
             if (my_rows > 0)
             {
-                GmShapeDyn gs;
-                gs.shape[3] = my_rows;
-                gs.shape[4] = KDim;
-                GmFloatK g_gm(g_cs_ptr + hbase + my_first * KDim, gs);
-                UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC, PadValue::Zero>
-                    g_ld(my_rows, KDim);
-                TASSIGN(g_ld, MYG_ADDR);
-                TLOAD(g_ld, g_gm);
-            }
-            {
-                GmShapeDyn gs;
-                gs.shape[3] = my_rows;
-                gs.shape[4] = KDim;
-                GmHalfK k_gm(k_ptr + hbase + my_first * KDim, gs);
-                UbND<half, HalfChunk, KTC, DYNAMIC, DYNAMIC, PadValue::Zero>
-                    k_ld(my_rows, KDim);
-                TASSIGN(k_ld, MYKH_ADDR);
-                TLOAD(k_ld, k_gm);
-            }
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            {
-                UbND<half, HalfChunk, KTC, DYNAMIC, DYNAMIC> k_h(my_rows, KDim);
-                TASSIGN(k_h, MYKH_ADDR);
-                UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> k_f(my_rows, KDim);
-                TASSIGN(k_f, MYK_ADDR);
-                TCVT(k_f, k_h, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
-            }
-            // ── Load my rows' beta (fp16 -> fp32) as a [1, my_rows] row, then
-            //    re-view as a [my_rows, 1] column for the per-row scale. ───────
-            {
-                GmShapeDyn gs;
-                gs.shape[3] = 1;
-                gs.shape[4] = my_rows;
-                GmHalf_1 b_gm(beta_ptr + static_cast<int64_t>(head_idx) * total_tokens +
-                                  my_first,
-                              gs);
-                UbND<half, 1, HalfChunk, DYNAMIC, DYNAMIC> b_ld(1, my_rows);
-                TASSIGN(b_ld, BETAH_ADDR);
-                TLOAD(b_ld, b_gm);
-            }
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            {
-                UbND<half, 1, HalfChunk, DYNAMIC, DYNAMIC> b_h(1, my_rows);
-                TASSIGN(b_h, BETAH_ADDR);
-                UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_f(1, my_rows);
-                TASSIGN(b_f, BETA_ADDR);
-                TCVT(b_f, b_h, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
-            }
-
-            UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> myg(my_rows, KDim);
-            TASSIGN(myg, MYG_ADDR);
-            UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> myk(my_rows, KDim);
-            TASSIGN(myk, MYK_ADDR);
-            UbDN<float, HalfChunk, 1, DYNAMIC, DYNAMIC> beta_col(my_rows, 1);
-            TASSIGN(beta_col, BETA_ADDR);
-
-            // ── Column loop ──────────────────────────────────────────────────
-            for (int32_t c = 0; c < col_end; ++c)
-            {
-                // Load column c's g_cs (fp32) and k (fp16 -> fp32) — [1, K].
-                int64_t col_off = hbase + (bos + chunk_start + c) * KDim;
+                // Load my rows' g_cs (fp32) → G_ADDR, zero-pad to HalfChunk.
                 {
                     GmShapeDyn gs;
                     gs.shape[3] = my_rows;
@@ -418,12 +364,6 @@ AICORE void kkt_kda_kernel(
                 TASSIGN(g_ub, G_ADDR);
                 UbND<float, HalfChunk, KTC> k_ub;
                 TASSIGN(k_ub, K_ADDR);
-                UbND<float, HalfChunk, KTC> a_ub;
-                TASSIGN(a_ub, A_ADDR);
-                UbND<float, HalfChunk, KTC> b_ub;
-                TASSIGN(b_ub, B_ADDR);
-                UbDN<float, HalfChunk, 1> bcol;
-                TASSIGN(bcol, BCOL_ADDR);
 
                 // b[r] = max_d g_cs[r,d]   (use B_ADDR space as the rowmax tmp).
                 {
@@ -455,53 +395,63 @@ AICORE void kkt_kda_kernel(
                 pipe_barrier(PIPE_V);
                 TMUL(b_ub, b_ub, k_ub);
                 pipe_barrier(PIPE_V);
-
-                // Store A → ws_in[slot] rows [my_off, …).
-                {
-                    GmShapeDyn gs;
-                    gs.shape[3] = HalfChunk;
-                    gs.shape[4] = KDim;
-                    int64_t off = ws_in_base + static_cast<int64_t>(my_off) * KDim;
-                    GmFloatWsIn gm_a(ws_in_ptr + off, gs);
-                    UbND<float, HalfChunk, KTC, HalfChunk, KTC> a_st;
-                    TASSIGN(a_st, A_ADDR);
-                    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-                    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-                    TSTORE(gm_a, a_st);
-                }
-                // Store B → ws_in[slot] rows [C+my_off, …).
-                {
-                    GmShapeDyn gs;
-                    gs.shape[3] = HalfChunk;
-                    gs.shape[4] = KDim;
-                    int64_t off = ws_in_base +
-                                  static_cast<int64_t>(ChunkSize) * KDim +
-                                  static_cast<int64_t>(my_off) * KDim;
-                    GmFloatWsIn gm_b(ws_in_ptr + off, gs);
-                    UbND<float, HalfChunk, KTC, HalfChunk, KTC> b_st;
-                    TASSIGN(b_st, B_ADDR);
-                    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-                    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-                    TSTORE(gm_b, b_st);
-                }
-                // Store b[my rows] → b_ws[slot] (contiguous [my_rows] floats).
-                // bcol is ColMajor [my_rows,1] but its bytes are my_rows contiguous
-                // floats, identical to a RowMajor [1,my_rows] — alias and store as a
-                // row so the GM (ND) store is a supported ND2ND copy.
-                {
-                    GmShapeDyn gs;
-                    gs.shape[3] = 1;
-                    gs.shape[4] = my_rows;
-                    GmFloat_1 b_gm(b_ws_ptr + b_ws_base + my_off, gs);
-                    UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_st(1, my_rows);
-                    TASSIGN(b_st, BCOL_ADDR);
-                    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
-                    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
-                    TSTORE(b_gm, b_st);
-                }
-                set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-                wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
             }
+            else
+            {
+                // No valid rows for this vid in this chunk: emit zeros so the GEMM
+                // reads a clean ws_in for this HalfChunk block.
+                TEXPANDS(a_ub, 0.0f);
+                pipe_barrier(PIPE_V);
+                TEXPANDS(b_ub, 0.0f);
+                pipe_barrier(PIPE_V);
+            }
+
+            // Store A → ws_in[slot] rows [my_off, …).
+            {
+                GmShapeDyn gs;
+                gs.shape[3] = HalfChunk;
+                gs.shape[4] = KDim;
+                int64_t off = ws_in_base + static_cast<int64_t>(my_off) * KDim;
+                GmFloatWsIn gm_a(ws_in_ptr + off, gs);
+                UbND<float, HalfChunk, KTC, HalfChunk, KTC> a_st;
+                TASSIGN(a_st, A_ADDR);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                TSTORE(gm_a, a_st);
+            }
+            // Store B → ws_in[slot] rows [C+my_off, …).
+            {
+                GmShapeDyn gs;
+                gs.shape[3] = HalfChunk;
+                gs.shape[4] = KDim;
+                int64_t off = ws_in_base +
+                              static_cast<int64_t>(ChunkSize) * KDim +
+                              static_cast<int64_t>(my_off) * KDim;
+                GmFloatWsIn gm_b(ws_in_ptr + off, gs);
+                UbND<float, HalfChunk, KTC, HalfChunk, KTC> b_st;
+                TASSIGN(b_st, B_ADDR);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                TSTORE(gm_b, b_st);
+            }
+            // Store b[my rows] → b_ws[slot] (contiguous [my_rows] floats).
+            // bcol is ColMajor [my_rows,1] but its bytes are my_rows contiguous
+            // floats, identical to a RowMajor [1,my_rows] — alias and store as a
+            // row so the GM (ND) store is a supported ND2ND copy.
+            if (my_rows > 0)
+            {
+                GmShapeDyn gs;
+                gs.shape[3] = 1;
+                gs.shape[4] = my_rows;
+                GmFloat_1 b_gm(b_ws_ptr + b_ws_base + my_off, gs);
+                UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_st(1, my_rows);
+                TASSIGN(b_st, BCOL_ADDR);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+                TSTORE(b_gm, b_st);
+            }
+            set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
 
             // Both vids signal flag(slot) under V→C reduce mode 2.
             pipe_barrier(PIPE_ALL);

--- a/kernels/pto/mega_kernel.cpp
+++ b/kernels/pto/mega_kernel.cpp
@@ -19,6 +19,14 @@
 #ifndef GDN_C
 #define GDN_C 128
 #endif
+// GDN_MAX_HEADS: compile-time ceiling on the value-head count. num_heads is a
+// RUNTIME argument (one .so serves every head count), so the transpose/cumsum UB
+// tiles are sized for this worst case; any num_heads <= GDN_MAX_HEADS works with
+// the unused columns zero-padded. Must match the host-side _MAX_HEADS guard and
+// the GDN_MAX_HEADS in chunk_cumsum.cpp.
+#ifndef GDN_MAX_HEADS
+#define GDN_MAX_HEADS 64
+#endif
 #ifndef MEMORY_BASE
 #define MEMORY_BASE
 #endif
@@ -67,9 +75,9 @@ AICORE inline void SyncAllImpl()
 #endif
 }
 
-template <typename T, int32_t H_val>
+template <typename T>
 AICORE void mega_transpose_TH_to_HT(
-    __gm__ T *src, __gm__ T *dst, int64_t T_len)
+    __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
 {
 #if defined(__DAV_C220_VEC__)
     if (get_subblockid() != 0) return;
@@ -80,11 +88,13 @@ AICORE void mega_transpose_TH_to_HT(
     auto block_num = get_block_num();
 
     constexpr int32_t BLOCK = 128;
-    constexpr int32_t H = static_cast<int32_t>(H_val);
     constexpr int32_t ES = static_cast<int32_t>(sizeof(T));
     constexpr int32_t MinTransposeCols = 16;
     constexpr int32_t AlignElems = ((32 / ES) > MinTransposeCols) ? (32 / ES) : MinTransposeCols;
-    constexpr int32_t HP = ((H + AlignElems - 1) / AlignElems) * AlignElems;
+    // H is runtime; size the UB tiles for the worst-case head count. TTRANS always
+    // processes the full BLOCK×HP tile (unused cols H..HP are zero-padded), and the
+    // store loop below writes only the first H transposed rows.
+    constexpr int32_t HP = ((GDN_MAX_HEADS + AlignElems - 1) / AlignElems) * AlignElems;
     constexpr int32_t SRC_UB = 0;
     constexpr int32_t DST_UB = SRC_UB + BLOCK * HP * ES;
     constexpr int32_t TMP_UB = DST_UB + HP * BLOCK * ES;
@@ -107,8 +117,9 @@ AICORE void mega_transpose_TH_to_HT(
 
     using Gm2D      = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
     using Gm1D      = Shape<1, 1, 1, 1, DYNAMIC>;
-    using GmSrcS    = Stride<1, 1, 1, H, 1>;
+    using GmSrcS    = Stride<1, 1, 1, DYNAMIC, 1>;
     using GmS1      = Stride<1, 1, 1, 1, 1>;
+    GmSrcS src_stride(H);  // runtime row pitch = H elements (skip other heads)
 
     UBSrcFull ub_src; TASSIGN(ub_src, SRC_UB);
     UBDst     ub_dst; TASSIGN(ub_dst, DST_UB);
@@ -125,7 +136,7 @@ AICORE void mega_transpose_TH_to_HT(
 
         {
             Gm2D gs; gs.shape[3] = valid; gs.shape[4] = H;
-            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs);
+            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs, src_stride);
             UBSrcDyn ld(valid, H);
             TASSIGN(ld, SRC_UB);
             TLOAD(ld, gm);
@@ -276,7 +287,6 @@ AICORE void mega_solve_tril(
             num_bsnd_heads, cu_seqlens, is_lower);
 }
 
-template <int32_t H>
 AICORE inline void mega_kernel_impl(
     __gm__ uint8_t *q_ptr,
     __gm__ uint8_t *k_ptr,
@@ -308,6 +318,7 @@ AICORE inline void mega_kernel_impl(
     __gm__ uint8_t *o_ws_qk_ptr,
     __gm__ uint8_t *o_ws_qs_ptr,
     __gm__ uint8_t *o_ws_gated_ptr,
+    int32_t H,
     uint32_t num_key_heads,
     int64_t batch_size,
     int64_t seq_len,
@@ -324,11 +335,11 @@ AICORE inline void mega_kernel_impl(
         return;
     }
 
-    mk_cumsum::cumsum_kernel<H, C>(
+    mk_cumsum::cumsum_kernel<C>(
         reinterpret_cast<__gm__ float *>(g_in_ptr),
         reinterpret_cast<__gm__ float *>(g_sum_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, ffts_addr);
+        batch_size, seq_len, H, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_CUMSUM
     pipe_barrier(PIPE_ALL);
@@ -341,14 +352,14 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    mega_transpose_TH_to_HT<float, H>(
+    mega_transpose_TH_to_HT<float>(
         reinterpret_cast<__gm__ float *>(g_sum_ptr),
         reinterpret_cast<__gm__ float *>(g_t_ptr),
-        total_tokens);
-    mega_transpose_TH_to_HT<half, H>(
+        total_tokens, H);
+    mega_transpose_TH_to_HT<half>(
         reinterpret_cast<__gm__ half *>(beta_ptr),
         reinterpret_cast<__gm__ half *>(beta_t_ptr),
-        total_tokens);
+        total_tokens, H);
 
 #ifdef MEGA_STOP_AFTER_TRANSPOSE
     pipe_barrier(PIPE_ALL);
@@ -520,26 +531,17 @@ extern "C" __global__ AICORE void launch_mega_kernel(
     uint32_t num_matrices,
     uint64_t ffts_addr)
 {
-#define DISPATCH_MEGA_H(H)                                                                                         \
-    case H:                                                                                                        \
-        mega_kernel_impl<H>(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr, msk_full_ptr, minus_id_ptr,    \
-                            cu_seqlens_ptr, o_ptr, g_sum_ptr, g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr, \
-                            w_ptr, u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state, kkt_ws_ptr,          \
-                            wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr, o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,         \
-                            num_key_heads, batch_size, seq_len, total_tokens, num_matrices, ffts_addr);            \
-        return
-
-    switch (num_heads) {
-        DISPATCH_MEGA_H(16);
-        DISPATCH_MEGA_H(24);
-        DISPATCH_MEGA_H(32);
-        DISPATCH_MEGA_H(48);
-        DISPATCH_MEGA_H(64);
-        default:
-            return;
+    // num_heads is a runtime kernel argument (one .so serves every head count).
+    // Guard the compile-time UB ceiling; the host validates before launch too.
+    if (num_heads == 0 || num_heads > GDN_MAX_HEADS) {
+        return;
     }
-
-#undef DISPATCH_MEGA_H
+    mega_kernel_impl(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr, msk_full_ptr, minus_id_ptr,
+                     cu_seqlens_ptr, o_ptr, g_sum_ptr, g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr,
+                     w_ptr, u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state, kkt_ws_ptr,
+                     wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr, o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,
+                     static_cast<int32_t>(num_heads), num_key_heads, batch_size, seq_len, total_tokens,
+                     num_matrices, ffts_addr);
 }
 
 extern "C" void call_kernel(

--- a/kernels/pto/mega_kernel_kda.cpp
+++ b/kernels/pto/mega_kernel_kda.cpp
@@ -241,8 +241,9 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     __gm__ uint8_t *s_ptr,       // [tc, HV, K, V] fp16
     __gm__ uint8_t *v_corr_ptr,  // [1, T, HV, V] fp16
     // ── per-core workspaces ─────────────────────────────────────────
-    __gm__ uint8_t *kkt_ws_in_ptr,  // [bd*2, 2C, K] fp32 (stages exp(±g_cs))
-    __gm__ uint8_t *kkt_ws_out_ptr, // [bd*2, C, C]  fp32 (unmasked gated K·K^T)
+    __gm__ uint8_t *kkt_ws_in_ptr,  // [bd*2, 2C, K] fp32 (A=k*exp(g_cs-b), B=k*exp(b-g_cs))
+    __gm__ uint8_t *kkt_ws_out_ptr, // [bd*2, C, C]  fp32 (unmasked gated K·K^T = A@B^T)
+    __gm__ uint8_t *kkt_b_ws_ptr,   // [bd*2, C]     fp32 (per-token offset b[t]=max_d g_cs)
     __gm__ uint8_t *wy_ws_a2_ptr,   // [bd, C, C]    fp16
     __gm__ uint8_t *wy_ws_keff_ptr, // [bd, C, K]    fp16
     __gm__ uint8_t *h_ws_ptr,       // [bd*5, K, K]  fp16
@@ -298,6 +299,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
         reinterpret_cast<__gm__ float *>(mask_strict_ptr),
         reinterpret_cast<__gm__ float *>(kkt_ws_in_ptr),
         reinterpret_cast<__gm__ float *>(kkt_ws_out_ptr),
+        reinterpret_cast<__gm__ float *>(kkt_b_ws_ptr),
         reinterpret_cast<__gm__ half *>(L_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
         batch_size, seq_len, total_tokens, HV, ffts_addr);
@@ -385,7 +387,8 @@ extern "C" void call_kernel(
     uint8_t *o,
     uint8_t *g_sum, uint8_t *g_cs_hm, uint8_t *L, uint8_t *A_inv,
     uint8_t *u, uint8_t *w, uint8_t *s, uint8_t *v_corr,
-    uint8_t *kkt_ws_in, uint8_t *kkt_ws_out, uint8_t *wy_ws_a2, uint8_t *wy_ws_keff,
+    uint8_t *kkt_ws_in, uint8_t *kkt_ws_out, uint8_t *kkt_b_ws,
+    uint8_t *wy_ws_a2, uint8_t *wy_ws_keff,
     uint8_t *h_ws, uint8_t *o_ws,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
     uint32_t num_matrices, uint32_t num_heads)
@@ -398,7 +401,7 @@ extern "C" void call_kernel(
         mask_strict, mask_incl, minus_id, cu_seqlens,
         o,
         g_sum, g_cs_hm, L, A_inv, u, w, s, v_corr,
-        kkt_ws_in, kkt_ws_out, wy_ws_a2, wy_ws_keff, h_ws, o_ws,
+        kkt_ws_in, kkt_ws_out, kkt_b_ws, wy_ws_a2, wy_ws_keff, h_ws, o_ws,
         batch_size, seq_len, total_tokens, num_matrices,
         static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/megagdn_pto/kda_kernel_libs.py
+++ b/megagdn_pto/kda_kernel_libs.py
@@ -128,7 +128,7 @@ def load_kkt_kda(
         void call_kernel(uint32_t block_dim, void *stream,
                          uint8_t *k, uint8_t *g_cs, uint8_t *beta,
                          uint8_t *mask, uint8_t *ws_in, uint8_t *ws_out,
-                         uint8_t *L_out, uint8_t *cu_seqlens,
+                         uint8_t *b_ws, uint8_t *L_out, uint8_t *cu_seqlens,
                          int64_t batch_size, int64_t seq_len, int64_t total_tokens,
                          uint32_t num_heads)
     """
@@ -142,7 +142,7 @@ def load_kkt_kda(
     lib = ctypes.CDLL(os.path.abspath(lib_path))
     lib.call_kernel.argtypes = (
         [ctypes.c_uint32, ctypes.c_void_p]
-        + [ctypes.c_void_p] * 8   # k, g_cs, beta, mask, ws_in, ws_out, L_out, cu_seqlens
+        + [ctypes.c_void_p] * 9   # k, g_cs, beta, mask, ws_in, ws_out, b_ws, L_out, cu_seqlens
         + [ctypes.c_int64] * 3    # batch_size, seq_len, total_tokens
         + [ctypes.c_uint32]       # num_heads (runtime)
     )
@@ -200,10 +200,12 @@ def run_kkt_kda(
     cols = torch.arange(chunk_size, device=dev).unsqueeze(0)
     mask = (rows > cols).to(torch.float32)
 
-    # fp32: A_eff=k*exp(g_cs)/B_eff=k*exp(-g_cs) and the unmasked K·K^T reach
-    # ~e^64 (per-128-chunk |g_cs|≈64), which overflows fp16.
+    # fp32 cube GEMM: A=k*exp(g_cs-b)/B=k*exp(b-g_cs) (per-token offset b) and the
+    # unmasked M=A@B^T can reach ~e^64; fp32 (max 3.4e38) holds them, fp16 would not.
     ws_in  = torch.zeros(bd * 2, 2 * chunk_size, K,          device=dev, dtype=torch.float32)
     ws_out = torch.zeros(bd * 2, chunk_size,      chunk_size, device=dev, dtype=torch.float32)
+    # Per-token exp offset b[t] = max_d g_cs[t,d], exchanged Vec(pre) → Vec(post).
+    b_ws   = torch.zeros(bd * 2, chunk_size,                 device=dev, dtype=torch.float32)
     # Force the workspace zero-fill (and any pending stream work) to fully
     # complete before launching the kkt_kda kernel.  Without this barrier,
     # cold-start runs can race the FFTS V↔C handshake against the zero-fill,
@@ -217,7 +219,7 @@ def run_kkt_kda(
     lib.call_kernel(
         bd, stream,
         _vp(k_t), _vp(g_cs_t), _vp(beta_t),
-        _vp(mask), _vp(ws_in), _vp(ws_out), _vp(L_out),
+        _vp(mask), _vp(ws_in), _vp(ws_out), _vp(b_ws), _vp(L_out),
         _vp(cu32),
         batch, T, total_tokens, HV,
     )

--- a/megagdn_pto/kda_mega_kernel.py
+++ b/megagdn_pto/kda_mega_kernel.py
@@ -50,7 +50,7 @@ def _load_mega_kernel_kda(
     lib = ctypes.CDLL(os.path.abspath(lib_path))
     lib.call_kernel.argtypes = (
         [ctypes.c_uint32, ctypes.c_void_p]
-        + [ctypes.c_void_p] * 24
+        + [ctypes.c_void_p] * 25
         + [ctypes.c_int64, ctypes.c_int64, ctypes.c_int64,
            ctypes.c_uint32, ctypes.c_uint32]  # ..., num_matrices, num_heads
     )
@@ -162,6 +162,7 @@ def run_mega_kernel_kda(
     # gated GEMMs, whose values reach ~e^64 and would overflow fp16.
     kkt_ws_in  = torch.zeros(bd * 2, 2 * C, K, device=dev, dtype=torch.float32)
     kkt_ws_out = torch.zeros(bd * 2, C, C, device=dev, dtype=torch.float32)
+    kkt_b_ws   = torch.zeros(bd * 2, C, device=dev, dtype=torch.float32)
     wy_ws_a2   = torch.zeros(bd, C, C, device=dev, dtype=torch.float16)
     wy_ws_keff = torch.zeros(bd, C, K, device=dev, dtype=torch.float16)
     h_ws       = torch.zeros(bd * 5, K, K, device=dev, dtype=torch.float16)
@@ -178,7 +179,7 @@ def run_mega_kernel_kda(
         _vp(o_out),
         _vp(g_sum), _vp(g_cs_hm), _vp(L), _vp(A_inv),
         _vp(u), _vp(w), _vp(s), _vp(v_corr),
-        _vp(kkt_ws_in), _vp(kkt_ws_out), _vp(wy_ws_a2), _vp(wy_ws_keff),
+        _vp(kkt_ws_in), _vp(kkt_ws_out), _vp(kkt_b_ws), _vp(wy_ws_a2), _vp(wy_ws_keff),
         _vp(h_ws), _vp(o_ws),
         N_seq, T, T, num_matrices, HV,
     )

--- a/megagdn_pto/kernel_libs.py
+++ b/megagdn_pto/kernel_libs.py
@@ -43,14 +43,17 @@ def _ensure_int32(cu: torch.Tensor | None) -> torch.Tensor | None:
     return cu if cu.dtype == torch.int32 else cu.to(torch.int32)
 
 
-_SUPPORTED_HEADS = frozenset({16, 24, 32, 48, 64})
+# The head count is a runtime kernel argument, so any value up to the compile-time
+# UB ceiling works (one .so serves all head counts). _MAX_HEADS must match
+# GDN_MAX_HEADS in kernels/pto/{mega_kernel,chunk_cumsum}.cpp.
+_MAX_HEADS = 64
 
 
 def _check_supported_heads(value_heads: int, key_heads: int | None = None) -> None:
-    if value_heads not in _SUPPORTED_HEADS:
+    if value_heads < 1 or value_heads > _MAX_HEADS:
         raise ValueError(
-            f"H={value_heads} is not supported by the compiled dispatch binary; "
-            f"choose one of {_SUPPORTED_HEADS}"
+            f"H={value_heads} is out of range; the kernels support "
+            f"1..{_MAX_HEADS} value heads (compile-time UB ceiling)."
         )
     if key_heads is not None and value_heads % key_heads != 0:
         raise ValueError(f"H={value_heads} must be divisible by key_heads={key_heads}")


### PR DESCRIPTION
Improved kkt_kda performance from 30x slower to 2.53x slower compared to kkt_gdn
```
kkt_kda k[32,T,D] fp16  vs  scaled_dot_kkt k[T,16,D] fp16
         KDA : 3.22 ms
         GDN : 1.27 ms  →  KDA/GDN = 2.53x
```

The method uses the cube unit and manages the overflow/underflow problem with a per-token offset:
```
b[t] = max_d g_cs[t,d]                          (per-token offset, TROWMAX)
A[t,d] = k[t,d]·exp(g_cs[t,d] − b[t])           (≤ k, never overflows)
B[t,d] = k[t,d]·exp(b[t] − g_cs[t,d])           (clamped at 80 — saturating exp)
M = A @ Bᵀ                                      (Cube fp32 GEMM)
L[r,c] = beta[r]·exp(min(b[r]−b[c],0))·M[r,c]   (residual correction, strict-lower)
```

The factorization is exact if the within-token cross-channel spread max_d g_cs[t,d] − min_d g_cs[t,d] < ~88. This condition can sometimes be unsatisfied. In that case the channel contribution of heavily decayed channels is lost. This slightly affects E2E accuracy:
<img width="808" height="219" alt="image" src="https://github.com/user-attachments/assets/9a236b1b-1913-4f64-a2d8-55082e6820f8" />

