### PR TITLE
Support dynamic head counts in the GDN mega-kernel

### DIFF
--- a/kernels/pto/chunk_cumsum.cpp
+++ b/kernels/pto/chunk_cumsum.cpp
@@ -61,30 +61,44 @@ using namespace pto;
 #endif
 
 // ── Recurrent prefix-sum chain synchronization ──────────────────────────────
-// The recurrent chain alternates TADD(acc,acc,g_i) and TMOV(s_i,acc) on a fixed
-// acc_ub address. Both lower to Vec-domain ops (TMOV(UB→UB) → TCopy →
-// pto_copy_ubuf_to_ubuf, scheduled on the V queue by bisheng), so the RAW/WAR
-// hazards on acc_ub are Vec-vs-Vec and must be ordered with a Vec barrier.
+// The recurrent chain alternates TADD(acc,acc,g_i) (Vec) and TMOV(s_i,acc) (Vec)
+// with TASSIGN address/descriptor setup on each row. TADD/TMOV lower to PIPE_V,
+// but TASSIGN is a SCALAR op (PIPE_S, see opPipeList in pto/common/event.hpp), and
+// on this core the scalar unit ISSUES the vec instructions. So the ordering edge
+// that actually matters is Vec→Scalar: without it, the scalar issuer launches the
+// next TADD/TMOV before the previous vec write to acc_ub has committed → a RAW race
+// on acc_ub.
 //
-// In isolation a pipe_barrier(PIPE_V) is sufficient and correct. But under the
-// fused mega-kernel's codegen a pipe_barrier(PIPE_V) here is NOT enough: the
-// recurrence races and corrupts the last rows of each chunk non-deterministically
-// (surfaced at H=64, whose wider tile lengthens the race window). WHY PIPE_V is
-// insufficient under fusion is unverified — the same barrier that is correct
-// standalone fails once inlined into the MIX kernel, and we have NOT inspected the
-// emitted IR/assembly to confirm the cause (e.g. whether the fused scheduler
-// reorders or elides the fence). The verified facts are purely behavioral.
+// pipe_barrier(PIPE_V) only fences Vec-vs-Vec and never enforces this V↔S edge, so
+// it is insufficient under the fused kernel — the recurrence races and corrupts the
+// last rows of each chunk non-deterministically (surfaced at H=64, whose wider tile
+// lengthens the race window). It happens to be harmless standalone because the
+// scheduler there doesn't reorder across the boundary the same way.
 //
-// A cross-pipe set_flag/wait_flag cannot help regardless of the mechanism: flags
-// only synchronize two DIFFERENT pipes, and this is a same-pipe (Vec) dependency —
-// wiring a V↔MTE3 flag around it leaves the real ordering unenforced and produces
-// deterministic-but-WRONG output (~20% frobenius error), which the run-to-run
-// determinism test cannot detect.
+// The fix is an explicit Vec→Scalar sync: set_flag(PIPE_V, PIPE_S) + wait_flag,
+// here via PtoSetWaitFlag<PIPE_V, PIPE_S>(). This stalls the scalar issuer until the
+// vec pipe drains, serializing the recurrence correctly. EVENT_ID2 is used to avoid
+// colliding with the EVENT_ID0 V↔MTE3 flags already live in this stage.
 //
-// pipe_barrier(PIPE_ALL) is the fix: it is the strongest available fence and
-// empirically orders the Vec recurrence (correct AND deterministic across all H)
-// whatever is defeating PIPE_V. It is heavier than a PIPE_V barrier, but cumsum is
-// a small, bandwidth-light stage so the cost is negligible.
+// MINIMAL placement (per-site bisection, H=64, 50-run determinism + e2e + partial
+// chunks): the V↔S sync is needed at EXACTLY ONE site — immediately after the
+// per-row TADD(acc,acc,g_i) write inside the main loop (in both the fixed-length
+// and varlen paths). That single sync serializes the whole recurrence; every other
+// site (the row-0 prologue, the per-row TMOV(s_i,acc) read, and the partial-chunk
+// tail zero-fill) is fine as a plain pipe_barrier(PIPE_V). Verified: bit2-only is
+// correct AND deterministic for full and partial chunks; all-PIPE_V or
+// prologue-only-V↔S races. (The post-read TMOV site is an equally-valid single
+// choice; we sync after the write because it orders acc before every consumer.)
+//
+// Two things that do NOT work, for the record:
+//   • pipe_barrier(PIPE_ALL) also fixes it, but only incidentally — it is a superset
+//     fence that happens to include the V↔S edge. It is heavier and obscures the
+//     real cause, so we use the targeted V↔S sync instead.
+//   • set_flag(PIPE_V, PIPE_MTE3) does NOT help: it targets the wrong pipe pair
+//     (store-DMA, not the scalar issuer), leaving the real edge unenforced and
+//     producing deterministic-but-WRONG output (~20% frob error) that the run-to-run
+//     determinism test cannot detect — always run the cumsum *correctness* test.
+
 
 // ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
 // UB tile in row-major (ND) layout, used by Vec engine.
@@ -248,16 +262,13 @@ AICORE void cumsum_kernel(
       UbND<float, 1, HTC> g_row_0;
       TASSIGN(g_row_0, GUbAddr);
       // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
-      // The recurrence on acc_ub is Vec-vs-Vec; pipe_barrier(PIPE_ALL) is the
-      // strongest fence and empirically orders it under fusion (see the chain-sync
-      // note above for why PIPE_V is insufficient here and set_flag cannot substitute).
       TMOV(acc_ub, g_row_0);
-      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_V);
 
       UbND<float, 1, HTC> s_row_0;
       TASSIGN(s_row_0, SUbAddr);
       TMOV(s_row_0, acc_ub);
-      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_V);
 
       // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
       for (int32_t i = 1; i < valid; ++i) {
@@ -265,25 +276,28 @@ AICORE void cumsum_kernel(
         TASSIGN(g_row_i, GUbAddr + i * RowBytes);
         // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
         // Operates on all HTC elements in parallel (SIMD).
+        // *** The one load-bearing sync (see chain-sync note above): Vec→Scalar
+        // after this per-row write to acc_ub, ordering it before the scalar issuer
+        // launches the next row. Every other barrier in this chain is plain PIPE_V.
         TADD(acc_ub, acc_ub, g_row_i);
-        pipe_barrier(PIPE_ALL);
+        PtoSetWaitFlag<PIPE_V, PIPE_S>(EVENT_ID2, EVENT_ID2);
 
         UbND<float, 1, HTC> s_row_i;
         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
         TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_ALL);
+        pipe_barrier(PIPE_V);
       }
 
       // Zero-fill rows beyond valid (tail padding for downstream kernels)
       // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
       // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
       TEXPANDS(acc_ub, 0.0f);
-      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_V);
       for (int32_t i = valid; i < ChunkSize; ++i) {
         UbND<float, 1, HTC> s_row_i;
         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
         TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_ALL);
+        pipe_barrier(PIPE_V);
       }
 
       // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
@@ -355,34 +369,36 @@ AICORE void cumsum_kernel(
           UbND<float, 1, HTC> g_row_0;
           TASSIGN(g_row_0, GUbAddr);
           TMOV(acc_ub, g_row_0);
-          pipe_barrier(PIPE_ALL);
+          pipe_barrier(PIPE_V);
 
           UbND<float, 1, HTC> s_row_0;
           TASSIGN(s_row_0, SUbAddr);
           TMOV(s_row_0, acc_ub);
-          pipe_barrier(PIPE_ALL);
+          pipe_barrier(PIPE_V);
 
           // acc += g[i]; g_sum[i] = acc
           for (int32_t i = 1; i < valid; ++i) {
             UbND<float, 1, HTC> g_row_i;
             TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+            // The one load-bearing sync (see chain-sync note above): Vec→Scalar
+            // after this per-row write to acc_ub. All other barriers here are PIPE_V.
             TADD(acc_ub, acc_ub, g_row_i);
-            pipe_barrier(PIPE_ALL);
+            PtoSetWaitFlag<PIPE_V, PIPE_S>(EVENT_ID2, EVENT_ID2);
 
             UbND<float, 1, HTC> s_row_i;
             TASSIGN(s_row_i, SUbAddr + i * RowBytes);
             TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_ALL);
+            pipe_barrier(PIPE_V);
           }
 
           // Zero-fill padding rows
           TEXPANDS(acc_ub, 0.0f);
-          pipe_barrier(PIPE_ALL);
+          pipe_barrier(PIPE_V);
           for (int32_t i = valid; i < ChunkSize; ++i) {
             UbND<float, 1, HTC> s_row_i;
             TASSIGN(s_row_i, SUbAddr + i * RowBytes);
             TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_ALL);
+            pipe_barrier(PIPE_V);
           }
 
           // Store g_sum to GM

--- a/kernels/pto/chunk_cumsum.cpp
+++ b/kernels/pto/chunk_cumsum.cpp
@@ -60,6 +60,15 @@ using namespace pto;
 #define GDN_C 128
 #endif
 
+// GDN_MAX_HEADS: compile-time ceiling on the value-head count. NumHeads is now a
+// RUNTIME argument (one .so serves every head count), but the UB tiles must still
+// be sized at compile time, so they are sized for the worst case HTC=align(MAX,8).
+// Any NumHeads <= GDN_MAX_HEADS works; the unused columns are zero-padded and ride
+// along the SIMD lanes harmlessly. Must match the host-side _MAX_HEADS guard.
+#ifndef GDN_MAX_HEADS
+#define GDN_MAX_HEADS 64
+#endif
+
 // ── Recurrent prefix-sum chain synchronization ──────────────────────────────
 // The recurrent chain alternates TADD(acc,acc,g_i) (Vec) and TMOV(s_i,acc) (Vec)
 // with TASSIGN address/descriptor setup on each row. TADD/TMOV lower to PIPE_V,
@@ -117,11 +126,12 @@ using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
                        RV, CV, pto::SLayout::NoneBox, 512, P>;
 #endif
 
-template <int32_t NumHeads, int32_t ChunkSize>
+template <int32_t ChunkSize>
 AICORE void cumsum_kernel(
     __gm__ float *g_ptr, __gm__ float *g_sum_ptr,
     __gm__ int32_t *cu_seqlens,
     int64_t batch_size, int64_t seq_len,
+    int32_t NumHeads,
     uint64_t ffts_addr)
 {
   // get_block_idx(): Returns this AI core's index (0..block_num-1).
@@ -153,14 +163,14 @@ AICORE void cumsum_kernel(
   set_mask_norm();
   set_vector_mask(-1, -1);
 
-  // HeadTileCols: NumHeads rounded up to 8-element alignment (32B for float)
-  // HTC = NumHeads rounded up to nearest multiple of 8.
-  // Why? The Vec engine processes data in 32-byte granularity.
-  // For float (4 bytes), that's 8 elements per SIMD "word".
-  // Rounding up ensures every row is a whole number of SIMD words,
-  // avoiding partial-lane issues. The extra columns are zero-padded.
-  // Example: NumHeads=16 → HTC=16 (already aligned), NumHeads=13 → HTC=16.
-  constexpr int32_t HTC = ((NumHeads + 7) / 8) * 8;
+  // HeadTileCols: worst-case head count rounded up to 8-element alignment (32B
+  // for float). NumHeads is a runtime value, so the UB tiles are sized for the
+  // compile-time ceiling GDN_MAX_HEADS; the actual NumHeads columns are used and
+  // the padding columns (NumHeads..HTC) are zero-filled, so the prefix sum over
+  // them stays zero and only rides the SIMD lanes at no correctness cost.
+  // Why 8-alignment? The Vec engine processes data in 32-byte granularity;
+  // for float (4 bytes) that's 8 elements per SIMD "word".
+  constexpr int32_t HTC = ((GDN_MAX_HEADS + 7) / 8) * 8;
   constexpr int32_t BlockBytes = ChunkSize * HTC *
                                  static_cast<int32_t>(sizeof(float));
   constexpr int32_t RowBytes = HTC * static_cast<int32_t>(sizeof(float));
@@ -186,8 +196,10 @@ AICORE void cumsum_kernel(
   // This is equivalent to:
   //   g_gm = torch.as_strided(g_ptr, size=[valid, NumHeads], stride=[NumHeads, 1])
   using GmShape  = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-  using GmStride = Stride<1, 1, 1, NumHeads, 1>;
+  using GmStride = Stride<1, 1, 1, DYNAMIC, 1>;
   using GmFloat  = GlobalTensor<float, GmShape, GmStride>;
+  // Runtime row pitch = NumHeads elements (BSND: token t at offset t*NumHeads).
+  GmStride g_stride(NumHeads);
 
   // Pre-assign row accumulator at fixed UB address
   // TASSIGN(tile, address): Binds a tile descriptor to a fixed byte address in UB.
@@ -224,7 +236,7 @@ AICORE void cumsum_kernel(
       // NumHeads up to the 8-aligned HTC) so downstream Vec ops see zeros.
       {
         GmShape gs; gs.shape[3] = valid; gs.shape[4] = NumHeads;
-        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs, g_stride);
         UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
             g_load(valid, NumHeads);
         TASSIGN(g_load, GUbAddr);
@@ -311,7 +323,7 @@ AICORE void cumsum_kernel(
 
       {
         GmShape ss; ss.shape[3] = valid; ss.shape[4] = NumHeads;
-        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss, g_stride);
         UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC>
             s_store(valid, NumHeads);
         TASSIGN(s_store, SUbAddr);
@@ -350,7 +362,7 @@ AICORE void cumsum_kernel(
           // Load g chunk from GM → UB, zero-padded
           {
             GmShape gs; gs.shape[3] = valid; gs.shape[4] = NumHeads;
-            GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+            GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs, g_stride);
             UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
                 g_load(valid, NumHeads);
             TASSIGN(g_load, GUbAddr);
@@ -407,7 +419,7 @@ AICORE void cumsum_kernel(
 
           {
             GmShape ss; ss.shape[3] = valid; ss.shape[4] = NumHeads;
-            GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+            GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss, g_stride);
             UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC>
                 s_store(valid, NumHeads);
             TASSIGN(s_store, SUbAddr);
@@ -435,26 +447,16 @@ extern "C" __global__ AICORE void launch_cumsum(
     uint32_t num_heads,
     uint64_t ffts_addr)
 {
-#define DISPATCH_CUMSUM_H(H)                                      \
-  case H:                                                         \
-    cumsum_kernel<H, GDN_C>(                                      \
-        reinterpret_cast<__gm__ float *>(g_ptr),                  \
-        reinterpret_cast<__gm__ float *>(g_sum_ptr),              \
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens),           \
-        batch_size, seq_len, ffts_addr);                          \
-    return
-
-  switch (num_heads) {
-    DISPATCH_CUMSUM_H(16);
-    DISPATCH_CUMSUM_H(24);
-    DISPATCH_CUMSUM_H(32);
-    DISPATCH_CUMSUM_H(48);
-    DISPATCH_CUMSUM_H(64);
-    default:
-      return;
+  // NumHeads is a runtime kernel argument (one .so serves every head count).
+  // Guard the compile-time UB ceiling; host also validates before launch.
+  if (num_heads == 0 || num_heads > GDN_MAX_HEADS) {
+    return;
   }
-
-#undef DISPATCH_CUMSUM_H
+  cumsum_kernel<GDN_C>(
+      reinterpret_cast<__gm__ float *>(g_ptr),
+      reinterpret_cast<__gm__ float *>(g_sum_ptr),
+      reinterpret_cast<__gm__ int32_t *>(cu_seqlens),
+      batch_size, seq_len, static_cast<int32_t>(num_heads), ffts_addr);
 }
 
 // ── Host-side launcher (called from Python via ctypes) ────────────

--- a/kernels/pto/chunk_cumsum.cpp
+++ b/kernels/pto/chunk_cumsum.cpp
@@ -60,6 +60,32 @@ using namespace pto;
 #define GDN_C 128
 #endif
 
+// ── Recurrent prefix-sum chain synchronization ──────────────────────────────
+// The recurrent chain alternates TADD(acc,acc,g_i) and TMOV(s_i,acc) on a fixed
+// acc_ub address. Both lower to Vec-domain ops (TMOV(UB→UB) → TCopy →
+// pto_copy_ubuf_to_ubuf, scheduled on the V queue by bisheng), so the RAW/WAR
+// hazards on acc_ub are Vec-vs-Vec and must be ordered with a Vec barrier.
+//
+// In isolation a pipe_barrier(PIPE_V) is sufficient and correct. But under the
+// fused mega-kernel's codegen a pipe_barrier(PIPE_V) here is NOT enough: the
+// recurrence races and corrupts the last rows of each chunk non-deterministically
+// (surfaced at H=64, whose wider tile lengthens the race window). WHY PIPE_V is
+// insufficient under fusion is unverified — the same barrier that is correct
+// standalone fails once inlined into the MIX kernel, and we have NOT inspected the
+// emitted IR/assembly to confirm the cause (e.g. whether the fused scheduler
+// reorders or elides the fence). The verified facts are purely behavioral.
+//
+// A cross-pipe set_flag/wait_flag cannot help regardless of the mechanism: flags
+// only synchronize two DIFFERENT pipes, and this is a same-pipe (Vec) dependency —
+// wiring a V↔MTE3 flag around it leaves the real ordering unenforced and produces
+// deterministic-but-WRONG output (~20% frobenius error), which the run-to-run
+// determinism test cannot detect.
+//
+// pipe_barrier(PIPE_ALL) is the fix: it is the strongest available fence and
+// empirically orders the Vec recurrence (correct AND deterministic across all H)
+// whatever is defeating PIPE_V. It is heavier than a PIPE_V barrier, but cumsum is
+// a small, bandwidth-light stage so the cost is negligible.
+
 // ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
 // UB tile in row-major (ND) layout, used by Vec engine.
 // T=dtype, R×C=static shape, RV×CV=valid region, P=pad value for TLOAD.
@@ -222,18 +248,16 @@ AICORE void cumsum_kernel(
       UbND<float, 1, HTC> g_row_0;
       TASSIGN(g_row_0, GUbAddr);
       // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
+      // The recurrence on acc_ub is Vec-vs-Vec; pipe_barrier(PIPE_ALL) is the
+      // strongest fence and empirically orders it under fusion (see the chain-sync
+      // note above for why PIPE_V is insufficient here and set_flag cannot substitute).
       TMOV(acc_ub, g_row_0);
-      // pipe_barrier(PIPE_V): Ensures all pending Vec (SIMD) operations complete
-      // before the next Vec instruction begins. Needed because Vec ops are pipelined
-      // and may not finish in order. Think of it as a local __syncthreads() for the
-      // Vec engine only. Much lighter than set_flag/wait_flag (which sync across
-      // different hardware units).
-      pipe_barrier(PIPE_V);
+      pipe_barrier(PIPE_ALL);
 
       UbND<float, 1, HTC> s_row_0;
       TASSIGN(s_row_0, SUbAddr);
       TMOV(s_row_0, acc_ub);
-      pipe_barrier(PIPE_V);
+      pipe_barrier(PIPE_ALL);
 
       // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
       for (int32_t i = 1; i < valid; ++i) {
@@ -242,24 +266,24 @@ AICORE void cumsum_kernel(
         // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
         // Operates on all HTC elements in parallel (SIMD).
         TADD(acc_ub, acc_ub, g_row_i);
-        pipe_barrier(PIPE_V);
+        pipe_barrier(PIPE_ALL);
 
         UbND<float, 1, HTC> s_row_i;
         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
         TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_V);
+        pipe_barrier(PIPE_ALL);
       }
 
       // Zero-fill rows beyond valid (tail padding for downstream kernels)
       // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
       // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
       TEXPANDS(acc_ub, 0.0f);
-      pipe_barrier(PIPE_V);
+      pipe_barrier(PIPE_ALL);
       for (int32_t i = valid; i < ChunkSize; ++i) {
         UbND<float, 1, HTC> s_row_i;
         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
         TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_V);
+        pipe_barrier(PIPE_ALL);
       }
 
       // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
@@ -331,34 +355,34 @@ AICORE void cumsum_kernel(
           UbND<float, 1, HTC> g_row_0;
           TASSIGN(g_row_0, GUbAddr);
           TMOV(acc_ub, g_row_0);
-          pipe_barrier(PIPE_V);
+          pipe_barrier(PIPE_ALL);
 
           UbND<float, 1, HTC> s_row_0;
           TASSIGN(s_row_0, SUbAddr);
           TMOV(s_row_0, acc_ub);
-          pipe_barrier(PIPE_V);
+          pipe_barrier(PIPE_ALL);
 
           // acc += g[i]; g_sum[i] = acc
           for (int32_t i = 1; i < valid; ++i) {
             UbND<float, 1, HTC> g_row_i;
             TASSIGN(g_row_i, GUbAddr + i * RowBytes);
             TADD(acc_ub, acc_ub, g_row_i);
-            pipe_barrier(PIPE_V);
+            pipe_barrier(PIPE_ALL);
 
             UbND<float, 1, HTC> s_row_i;
             TASSIGN(s_row_i, SUbAddr + i * RowBytes);
             TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_V);
+            pipe_barrier(PIPE_ALL);
           }
 
           // Zero-fill padding rows
           TEXPANDS(acc_ub, 0.0f);
-          pipe_barrier(PIPE_V);
+          pipe_barrier(PIPE_ALL);
           for (int32_t i = valid; i < ChunkSize; ++i) {
             UbND<float, 1, HTC> s_row_i;
             TASSIGN(s_row_i, SUbAddr + i * RowBytes);
             TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_V);
+            pipe_barrier(PIPE_ALL);
           }
 
           // Store g_sum to GM

--- a/kernels/pto/mega_kernel.cpp
+++ b/kernels/pto/mega_kernel.cpp
@@ -19,6 +19,14 @@
 #ifndef GDN_C
 #define GDN_C 128
 #endif
+// GDN_MAX_HEADS: compile-time ceiling on the value-head count. num_heads is a
+// RUNTIME argument (one .so serves every head count), so the transpose/cumsum UB
+// tiles are sized for this worst case; any num_heads <= GDN_MAX_HEADS works with
+// the unused columns zero-padded. Must match the host-side _MAX_HEADS guard and
+// the GDN_MAX_HEADS in chunk_cumsum.cpp.
+#ifndef GDN_MAX_HEADS
+#define GDN_MAX_HEADS 64
+#endif
 #ifndef MEMORY_BASE
 #define MEMORY_BASE
 #endif
@@ -67,9 +75,9 @@ AICORE inline void SyncAllImpl()
 #endif
 }
 
-template <typename T, int32_t H_val>
+template <typename T>
 AICORE void mega_transpose_TH_to_HT(
-    __gm__ T *src, __gm__ T *dst, int64_t T_len)
+    __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
 {
 #if defined(__DAV_C220_VEC__)
     if (get_subblockid() != 0) return;
@@ -80,11 +88,13 @@ AICORE void mega_transpose_TH_to_HT(
     auto block_num = get_block_num();
 
     constexpr int32_t BLOCK = 128;
-    constexpr int32_t H = static_cast<int32_t>(H_val);
     constexpr int32_t ES = static_cast<int32_t>(sizeof(T));
     constexpr int32_t MinTransposeCols = 16;
     constexpr int32_t AlignElems = ((32 / ES) > MinTransposeCols) ? (32 / ES) : MinTransposeCols;
-    constexpr int32_t HP = ((H + AlignElems - 1) / AlignElems) * AlignElems;
+    // H is runtime; size the UB tiles for the worst-case head count. TTRANS always
+    // processes the full BLOCK×HP tile (unused cols H..HP are zero-padded), and the
+    // store loop below writes only the first H transposed rows.
+    constexpr int32_t HP = ((GDN_MAX_HEADS + AlignElems - 1) / AlignElems) * AlignElems;
     constexpr int32_t SRC_UB = 0;
     constexpr int32_t DST_UB = SRC_UB + BLOCK * HP * ES;
     constexpr int32_t TMP_UB = DST_UB + HP * BLOCK * ES;
@@ -107,8 +117,9 @@ AICORE void mega_transpose_TH_to_HT(
 
     using Gm2D      = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
     using Gm1D      = Shape<1, 1, 1, 1, DYNAMIC>;
-    using GmSrcS    = Stride<1, 1, 1, H, 1>;
+    using GmSrcS    = Stride<1, 1, 1, DYNAMIC, 1>;
     using GmS1      = Stride<1, 1, 1, 1, 1>;
+    GmSrcS src_stride(H);  // runtime row pitch = H elements (skip other heads)
 
     UBSrcFull ub_src; TASSIGN(ub_src, SRC_UB);
     UBDst     ub_dst; TASSIGN(ub_dst, DST_UB);
@@ -125,7 +136,7 @@ AICORE void mega_transpose_TH_to_HT(
 
         {
             Gm2D gs; gs.shape[3] = valid; gs.shape[4] = H;
-            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs);
+            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs, src_stride);
             UBSrcDyn ld(valid, H);
             TASSIGN(ld, SRC_UB);
             TLOAD(ld, gm);
@@ -276,7 +287,6 @@ AICORE void mega_solve_tril(
             num_bsnd_heads, cu_seqlens, is_lower);
 }
 
-template <int32_t H>
 AICORE inline void mega_kernel_impl(
     __gm__ uint8_t *q_ptr,
     __gm__ uint8_t *k_ptr,
@@ -308,6 +318,7 @@ AICORE inline void mega_kernel_impl(
     __gm__ uint8_t *o_ws_qk_ptr,
     __gm__ uint8_t *o_ws_qs_ptr,
     __gm__ uint8_t *o_ws_gated_ptr,
+    int32_t H,
     uint32_t num_key_heads,
     int64_t batch_size,
     int64_t seq_len,
@@ -324,11 +335,11 @@ AICORE inline void mega_kernel_impl(
         return;
     }
 
-    mk_cumsum::cumsum_kernel<H, C>(
+    mk_cumsum::cumsum_kernel<C>(
         reinterpret_cast<__gm__ float *>(g_in_ptr),
         reinterpret_cast<__gm__ float *>(g_sum_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, ffts_addr);
+        batch_size, seq_len, H, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_CUMSUM
     pipe_barrier(PIPE_ALL);
@@ -341,14 +352,14 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    mega_transpose_TH_to_HT<float, H>(
+    mega_transpose_TH_to_HT<float>(
         reinterpret_cast<__gm__ float *>(g_sum_ptr),
         reinterpret_cast<__gm__ float *>(g_t_ptr),
-        total_tokens);
-    mega_transpose_TH_to_HT<half, H>(
+        total_tokens, H);
+    mega_transpose_TH_to_HT<half>(
         reinterpret_cast<__gm__ half *>(beta_ptr),
         reinterpret_cast<__gm__ half *>(beta_t_ptr),
-        total_tokens);
+        total_tokens, H);
 
 #ifdef MEGA_STOP_AFTER_TRANSPOSE
     pipe_barrier(PIPE_ALL);
@@ -520,26 +531,17 @@ extern "C" __global__ AICORE void launch_mega_kernel(
     uint32_t num_matrices,
     uint64_t ffts_addr)
 {
-#define DISPATCH_MEGA_H(H)                                                                                         \
-    case H:                                                                                                        \
-        mega_kernel_impl<H>(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr, msk_full_ptr, minus_id_ptr,    \
-                            cu_seqlens_ptr, o_ptr, g_sum_ptr, g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr, \
-                            w_ptr, u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state, kkt_ws_ptr,          \
-                            wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr, o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,         \
-                            num_key_heads, batch_size, seq_len, total_tokens, num_matrices, ffts_addr);            \
-        return
-
-    switch (num_heads) {
-        DISPATCH_MEGA_H(16);
-        DISPATCH_MEGA_H(24);
-        DISPATCH_MEGA_H(32);
-        DISPATCH_MEGA_H(48);
-        DISPATCH_MEGA_H(64);
-        default:
-            return;
+    // num_heads is a runtime kernel argument (one .so serves every head count).
+    // Guard the compile-time UB ceiling; the host validates before launch too.
+    if (num_heads == 0 || num_heads > GDN_MAX_HEADS) {
+        return;
     }
-
-#undef DISPATCH_MEGA_H
+    mega_kernel_impl(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr, msk_full_ptr, minus_id_ptr,
+                     cu_seqlens_ptr, o_ptr, g_sum_ptr, g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr,
+                     w_ptr, u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state, kkt_ws_ptr,
+                     wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr, o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,
+                     static_cast<int32_t>(num_heads), num_key_heads, batch_size, seq_len, total_tokens,
+                     num_matrices, ffts_addr);
 }
 
 extern "C" void call_kernel(

--- a/megagdn_pto/kernel_libs.py
+++ b/megagdn_pto/kernel_libs.py
@@ -43,14 +43,17 @@ def _ensure_int32(cu: torch.Tensor | None) -> torch.Tensor | None:
     return cu if cu.dtype == torch.int32 else cu.to(torch.int32)
 
 
-_SUPPORTED_HEADS = frozenset({16, 24, 32, 48, 64})
+# The head count is a runtime kernel argument, so any value up to the compile-time
+# UB ceiling works (one .so serves all head counts). _MAX_HEADS must match
+# GDN_MAX_HEADS in kernels/pto/{mega_kernel,chunk_cumsum}.cpp.
+_MAX_HEADS = 64
 
 
 def _check_supported_heads(value_heads: int, key_heads: int | None = None) -> None:
-    if value_heads not in _SUPPORTED_HEADS:
+    if value_heads < 1 or value_heads > _MAX_HEADS:
         raise ValueError(
-            f"H={value_heads} is not supported by the compiled dispatch binary; "
-            f"choose one of {_SUPPORTED_HEADS}"
+            f"H={value_heads} is out of range; the kernels support "
+            f"1..{_MAX_HEADS} value heads (compile-time UB ceiling)."
         )
     if key_heads is not None and value_heads % key_heads != 0:
         raise ValueError(f"H={value_heads} must be divisible by key_heads={key_heads}")


### PR DESCRIPTION
## Summary

The GDN kernels previously accepted only a **fixed set** of value-head counts — `H ∈ {16, 24, 32, 48, 64}` — enforced by a `switch(num_heads)` with a silent `default: return` in the device code and a `_SUPPORTED_HEADS` frozenset on the host. Any other head count was silently dropped (mega-kernel) or rejected (host guard).

This PR makes the head count a **runtime parameter**, so a single compiled `.so` serves any `1 ≤ H ≤ 64` with `H % Hg == 0`, without recompilation.

`H` was previously a C++ template parameter, but only **two** device functions actually needed it at compile time (they size UB tiles by head count); every heavy stage already took `H` at runtime. This follows the same runtime-head pattern already used by the KDA kernel.

## Changes

- **`kernels/pto/chunk_cumsum.cpp`** — `cumsum_kernel` de-templatized on head count. UB tile width `HTC` is now sized from a compile-time ceiling `GDN_MAX_HEADS = 64` (the already-proven footprint), while `NumHeads` flows as a runtime argument with a dynamic row-pitch stride. Dispatch `switch` replaced with a direct call plus a `1 ≤ H ≤ GDN_MAX_HEADS` range guard.
- **`kernels/pto/mega_kernel.cpp`** — `mega_transpose_TH_to_HT` and `mega_kernel_impl` de-templatized on `H`; UB sized to the worst-case ceiling (`HP`/`HTC` = 64), real GM strides use the runtime `H`. Dispatch `switch` replaced with a direct call + range guard.
- **`megagdn_pto/kernel_libs.py`** — the fixed-set `_SUPPORTED_HEADS` guard replaced with a centralized range check (`1 ≤ H ≤ 64`, `H % key_heads == 0`) used by all staged stages, the mega-kernel wrapper, and the determinism harness.

The UB footprint is now identical for every head count (padded to `HP = HTC = 64`), so the `H = 64` recurrence — historically the worst case for the cumsum determinism issue — is now the *universal* case. The existing cumsum V→S determinism fix (from `megagdn_cumsum_fix`, this PR's base) holds across all head counts.

No change to `GDN_D` / `GDN_C`: the kernel is still compiled per hidden/chunk size only, so one `mega_kernel_D128_C128.so` covers all head counts.

## Constraints

- **`1 ≤ H ≤ 64`** — `GDN_MAX_HEADS` is the compile-time UB ceiling. Raising it later means bumping that constant and re-checking the transpose UB budget (H-tiling would be needed well above 64).
- **`H % Hg == 0`** — value heads must be an integer multiple of key heads. This is inherent to grouped-query attention (each KV head is shared by an integer group of query heads), so it never rejects a valid model config — only arithmetically invalid ones.

## Validation

All results bit-checked against the CPU reference on Ascend 910B4 (`dav-c220`), over multiple fixed sequence lengths and variable-length batches (including partial chunks).

**Staged kernels** (kkt, solve_tril, wy_fast, chunk_h, chunk_o, cumsum), 19 cases each — **ALL PASS**:
- `1:1, 2:1, 3:1, 4:1, 5:1, 7:1, 3:3, 5:5, 7:7, 6:2, 9:3, 15:5`

**Fused mega-kernel** (`mega_vs_cpu`), 7 sequence configs each — **ALL PASS**:
- Small / odd, Hg=1: `1, 2, 3, 4, 5, 7`
- GQA groups: `3:3, 7:7, 6:2, 6:3, 9:3, 15:5`

This spans single-head (`H=1`), tiny even (`2, 4, 6`), odd non-power-of-2 (`3, 5, 7, 9, 15`), odd key-head counts, and grouped-value GQA — confirming there is no hidden assumption that `H` be a multiple of 8/16 or a power of 2.

**Determinism** (`test_mega_nondeterminism.py`): `H ∈ {16, 32, 48, 64}` deterministic over 30 runs (`max_frob_rel = 0`); new `H=40, Hg=8` with partial chunks deterministic over 25 runs.

### Qwen 3.5 relevance

The largest Qwen 3.5 model's Gated DeltaNet layers use `H=64` (V) / `Hg=16` (QK) / `D=128` — which lands exactly on the supported envelope (`64:16` is validated and proven deterministic).

Under **tensor parallelism**, TP shards along the head axis (`D=128` stays whole, same `.so` on every worker). The per-worker shards for this model were all validated against the CPU reference (staged + fused, 7/7 each):

| TP degree | Per-worker shard | Result |
|---:|---|:--:|
| 1  | `H=64, Hg=16` | ✅ (also determinism-checked, 30 runs) |
| 2  | `H=32, Hg=8`  | ✅ |
| 4  | `H=16, Hg=4`  | ✅ |
| 8  | `H=8, Hg=2`   | ✅ |
| 16 | `H=4, Hg=1`   | ✅ |

Notably, the TP=8 (`H=8`) and TP=16 (`H=4`) shards were **rejected by the old fixed set**, so this change is what makes TP ≥ 8 deployable for this model. TP is bounded by `Hg=16`; beyond that, KV-head replication applies (a framework-side decision, not a kernel constraint).