### PR TITLE
fix(A5): support L0A cube layout on A5

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install -e '.[eval,plot]'
 
 ```bash
 # accuracy tests
-python tests/test_single_kernels.py --H-list 16,32,48,64
+python tests/test_gdn_single_kernels.py --H-list 16,32,48,64
 python tests/test_e2e.py --no-triton
 
 # performance benchmark

--- a/kernels/pto/chunk_h.cpp
+++ b/kernels/pto/chunk_h.cpp
@@ -90,6 +90,8 @@
 
 #include <pto/pto-inst.hpp>
 #include <type_traits>
+
+#include "kernel_utils.h"
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 using namespace pto;
@@ -142,17 +144,17 @@ using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols>
-using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::RowMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0A =
+    pto::Tile<pto::TileType::Left, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/true), RowValid,
+              ColValid, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols>
-using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::ColMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0B =
+    pto::Tile<pto::TileType::Right, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/false), RowValid,
+              ColValid, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols,

--- a/kernels/pto/chunk_h_kda.cpp
+++ b/kernels/pto/chunk_h_kda.cpp
@@ -44,6 +44,8 @@
 
 #include <pto/pto-inst.hpp>
 #include <type_traits>
+
+#include "kernel_utils.h"
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 using namespace pto;
@@ -115,17 +117,17 @@ using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols>
-using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::RowMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0A =
+    pto::Tile<pto::TileType::Left, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/true), RowValid,
+              ColValid, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols>
-using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::ColMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0B =
+    pto::Tile<pto::TileType::Right, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/false), RowValid,
+              ColValid, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols,

--- a/kernels/pto/chunk_o_kda.cpp
+++ b/kernels/pto/chunk_o_kda.cpp
@@ -61,6 +61,8 @@
 
 #include <pto/pto-inst.hpp>
 #include <type_traits>
+
+#include "kernel_utils.h"
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 using namespace pto;
@@ -129,17 +131,17 @@ using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols>
-using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::RowMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0A =
+    pto::Tile<pto::TileType::Left, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/true), RowValid,
+              ColValid, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols>
-using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::ColMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0B =
+    pto::Tile<pto::TileType::Right, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/false), RowValid,
+              ColValid, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows,
           int32_t ColValid = Cols,

--- a/kernels/pto/include/kernel_utils.h
+++ b/kernels/pto/include/kernel_utils.h
@@ -46,4 +46,25 @@ AICORE inline T1 CeilDiv(T1 value, T2 divisor) {
   return (value + divisor - 1) / divisor;
 }
 
+/**
+ * @brief Returns the outer matrix layout based on the target architecture and
+ * matrix orientation.
+ *
+ * On DAV C310 targets, the layout depends on whether the matrix is "left-sided"
+ * (L0A). DAV C310: L0A is NZ, L0B is ZN. Older: L0A is ZZ, L0B is ZN.
+ *
+ * Link:
+ * https://pto-isa.github.io/docs/isa/cube/nz-fractal-layout/#per-buffer-nz-layouts
+ *
+ * @param is_left Whether the matrix is on the left side (L0A) or not (L0B).
+ * @return The appropriate @c BLayout for the target architecture.
+ */
+constexpr pto::BLayout GetOuterLayout(bool is_left) {
+#ifdef __DAV_C310__
+  return is_left ? pto::BLayout::ColMajor : pto::BLayout::RowMajor;
+#else
+  return pto::BLayout::RowMajor;
+#endif
+}
+
 }  // namespace kernel_utils

--- a/kernels/pto/include/kernel_utils.h
+++ b/kernels/pto/include/kernel_utils.h
@@ -59,7 +59,7 @@ AICORE inline T1 CeilDiv(T1 value, T2 divisor) {
  * @param is_left Whether the matrix is on the left side (L0A) or not (L0B).
  * @return The appropriate @c BLayout for the target architecture.
  */
-constexpr pto::BLayout GetOuterLayout(bool is_left) {
+constexpr inline pto::BLayout GetOuterLayout(bool is_left) {
 #ifdef __DAV_C310__
   return is_left ? pto::BLayout::ColMajor : pto::BLayout::RowMajor;
 #else

--- a/kernels/pto/mega_kernel.cpp
+++ b/kernels/pto/mega_kernel.cpp
@@ -35,6 +35,11 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+
+// Must be included at global scope: the sub-kernels below are #include'd into
+// separate namespaces, and #pragma once would otherwise trap kernel_utils
+// inside whichever namespace pulled it in first.
+#include "kernel_utils.h"
 using namespace pto;
 
 // ===================================================================

--- a/kernels/pto/mega_kernel_kda.cpp
+++ b/kernels/pto/mega_kernel_kda.cpp
@@ -33,6 +33,11 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+
+// Must be included at global scope: the sub-kernels below are #include'd into
+// separate namespaces, and #pragma once would otherwise trap kernel_utils
+// inside whichever namespace pulled it in first.
+#include "kernel_utils.h"
 using namespace pto;
 
 // ===================================================================

--- a/kernels/pto/tri_inverse_impl.cpp
+++ b/kernels/pto/tri_inverse_impl.cpp
@@ -93,9 +93,10 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
   constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
+  constexpr BLayout OuterLayout = kernel_utils::GetOuterLayout(is_left);
 
-  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
-       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize,
+       FractalSize, InnerLayout, TileConfig::fractalABSize>
       fractals[NumFractals];
   const std::uintptr_t starting_address =
       reinterpret_cast<std::uintptr_t>(dst.data());
@@ -137,6 +138,7 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
+  constexpr BLayout OuterLayout = kernel_utils::GetOuterLayout(is_left);
 
   // Default: left→even(0), right→odd(1). swap_parity flips this.
   const uint32_t starting_block_index = (is_left ? 0u : 1u) ^ (swap_parity ? 1u : 0u);
@@ -145,8 +147,8 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   const uint32_t num_fractals_per_block = block_size / FractalSize;
 
   // might need fewer fractals if block_size < FractalSize
-  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
-       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize,
+       FractalSize, InnerLayout, TileConfig::fractalABSize>
       fractals[MatrixSize / FractalSize];
 
   const std::uintptr_t starting_address =
@@ -154,10 +156,17 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   for (uint32_t i = 0; i < num_fractals_per_block; ++i) {
     for (uint32_t j = 0; j < num_fractals_per_block; ++j) {
       for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
+#ifdef __DAV_C310__
+        const uint32_t row_stride = is_left ? FractalSize : MatrixSize;
+        const uint32_t col_stride = is_left ? MatrixSize : FractalSize;
+#else
+        const uint32_t row_stride = MatrixSize;
+        const uint32_t col_stride = FractalSize;
+#endif
         const uint32_t offset =
             b * (MatrixSize + FractalSize) * block_size /* block_offset */ +
-            i * MatrixSize * FractalSize /* col_fractal_offset */ +
-            j * FractalSize * FractalSize /* row_fractal_offset */;
+            j * col_stride * FractalSize /* col_fractal_offset */ +
+            i * row_stride * FractalSize /* row_fractal_offset */;
         TASSIGN(fractals[b], starting_address + offset * sizeof(InputT));
         TEXTRACT(fractals[b], src, b * block_size + i * FractalSize,
                  b * block_size + j * FractalSize);

--- a/kernels/pto/wy_fast.cpp
+++ b/kernels/pto/wy_fast.cpp
@@ -55,6 +55,8 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+
+#include "kernel_utils.h"
 using namespace pto;
 
 #ifndef GDN_D
@@ -84,17 +86,17 @@ using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
 
 template <typename T, int Rows, int Cols, int RowValid = Rows,
           int ColValid = Cols>
-using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::RowMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0A =
+    pto::Tile<pto::TileType::Left, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/true), RowValid,
+              ColValid, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int Rows, int Cols, int RowValid = Rows,
           int ColValid = Cols>
-using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::ColMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0B =
+    pto::Tile<pto::TileType::Right, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/false), RowValid,
+              ColValid, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int Rows, int Cols, int RowValid = Rows,
           int ColValid = Cols, pto::PadValue PadVal = pto::PadValue::Null>

--- a/kernels/pto/wy_kda.cpp
+++ b/kernels/pto/wy_kda.cpp
@@ -67,6 +67,8 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+
+#include "kernel_utils.h"
 using namespace pto;
 
 #ifndef GDN_D
@@ -117,17 +119,17 @@ using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
 
 template <typename T, int Rows, int Cols, int RowValid = Rows,
           int ColValid = Cols>
-using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::RowMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0A =
+    pto::Tile<pto::TileType::Left, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/true), RowValid,
+              ColValid, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int Rows, int Cols, int RowValid = Rows,
           int ColValid = Cols>
-using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
-                             pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::ColMajor, 512,
-                             pto::PadValue::Zero>;
+using TileMatL0B =
+    pto::Tile<pto::TileType::Right, T, Rows, Cols,
+              kernel_utils::GetOuterLayout(/*is_left=*/false), RowValid,
+              ColValid, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int Rows, int Cols, int RowValid = Rows,
           int ColValid = Cols, pto::PadValue PadVal = pto::PadValue::Null>


### PR DESCRIPTION
This pull request introduces a new utility function to select the correct matrix layout for different hardware architectures and refactors several kernel files to use this function, improving code maintainability and correctness across platforms. It also updates the test command in the documentation for clarity.

**Matrix layout selection and kernel refactoring:**

* Added `kernel_utils::GetOuterLayout` to `kernel_utils.h`, which determines the correct outer matrix layout (`BLayout`) based on the target architecture and matrix orientation (left or right). This ensures that kernels use the appropriate layout for both DAV C310 and older hardware.
* Refactored all kernel files (`chunk_h.cpp`, `chunk_h_kda.cpp`, `chunk_o_kda.cpp`, `wy_fast.cpp`, `wy_kda.cpp`) to use `kernel_utils::GetOuterLayout` instead of hardcoded `BLayout` values in `TileMatL0A` and `TileMatL0B` definitions. This change ensures layout correctness and reduces code duplication. [[1]](diffhunk://#diff-7af9b264177e0101e1af22aa16797ea30b20e56ef76078ec061bb0425dbd207dL145-R157) [[2]](diffhunk://#diff-0c30c995210481aa66a039e63e31a4cb7a7930b89d3befe4c8305f53758fdc03L118-R130) [[3]](diffhunk://#diff-0ea2dece1e2160c757a488c29dc3a3a98c44fbfd9d7f1f479de1d787bcc2dcacL132-R144) [[4]](diffhunk://#diff-80f4dde18a98e6b138597572e4665ed264613b0758dc0b148a448af0edcc4e71L87-R99) [[5]](diffhunk://#diff-496804250404576a07a85fed4c9d6bdf700530caab3ace883ab0fb70bc5c5a20L120-R132)
* Updated `tri_inverse_impl.cpp` to use the new layout utility in tile definitions and fractal copy logic, including architecture-specific stride calculations for correct memory access. [[1]](diffhunk://#diff-3599c9b5d77f0b05368f54408c0ffa6fc126a0fbe2a786093b8b100a95dab87fR96-R99) [[2]](diffhunk://#diff-3599c9b5d77f0b05368f54408c0ffa6fc126a0fbe2a786093b8b100a95dab87fR141) [[3]](diffhunk://#diff-3599c9b5d77f0b05368f54408c0ffa6fc126a0fbe2a786093b8b100a95dab87fL148-R169)