### PR TITLE
fix(A5): make pipe_barrier(PIPE_V) noop in A5

### DIFF
--- a/kernels/pto/chunk_cumsum.cpp
+++ b/kernels/pto/chunk_cumsum.cpp
@@ -51,7 +51,10 @@
 #include <pto/pto-inst.hpp>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 // GDN_C: Compile-time chunk size injected by the build system.
 // Using compile-time constants allows the compiler to optimize tile sizes,
@@ -275,12 +278,12 @@ AICORE void cumsum_kernel(
       TASSIGN(g_row_0, GUbAddr);
       // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
       TMOV(acc_ub, g_row_0);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       UbND<float, 1, HTC> s_row_0;
       TASSIGN(s_row_0, SUbAddr);
       TMOV(s_row_0, acc_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
       for (int32_t i = 1; i < valid; ++i) {
@@ -297,19 +300,19 @@ AICORE void cumsum_kernel(
         UbND<float, 1, HTC> s_row_i;
         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
         TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
       }
 
       // Zero-fill rows beyond valid (tail padding for downstream kernels)
       // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
       // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
       TEXPANDS(acc_ub, 0.0f);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       for (int32_t i = valid; i < ChunkSize; ++i) {
         UbND<float, 1, HTC> s_row_i;
         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
         TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
       }
 
       // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
@@ -381,12 +384,12 @@ AICORE void cumsum_kernel(
           UbND<float, 1, HTC> g_row_0;
           TASSIGN(g_row_0, GUbAddr);
           TMOV(acc_ub, g_row_0);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
 
           UbND<float, 1, HTC> s_row_0;
           TASSIGN(s_row_0, SUbAddr);
           TMOV(s_row_0, acc_ub);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
 
           // acc += g[i]; g_sum[i] = acc
           for (int32_t i = 1; i < valid; ++i) {
@@ -400,17 +403,17 @@ AICORE void cumsum_kernel(
             UbND<float, 1, HTC> s_row_i;
             TASSIGN(s_row_i, SUbAddr + i * RowBytes);
             TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
           }
 
           // Zero-fill padding rows
           TEXPANDS(acc_ub, 0.0f);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           for (int32_t i = valid; i < ChunkSize; ++i) {
             UbND<float, 1, HTC> s_row_i;
             TASSIGN(s_row_i, SUbAddr + i * RowBytes);
             TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
           }
 
           // Store g_sum to GM

--- a/kernels/pto/chunk_h.cpp
+++ b/kernels/pto/chunk_h.cpp
@@ -92,7 +92,10 @@
 #include <type_traits>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -710,9 +713,9 @@ AICORE void chunk_h_kernel(
       // Torch-like:
       //   coeff = exp(g_last - g_rows_owned_by_this_subblock)
       TADDS(coeff_ub, g_v_ub, -g_last);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TSUB(coeff_ub, zero_ub, coeff_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TEXP(coeff_ub, coeff_ub);
 
       TEXP(g_ub, g_ub);
@@ -728,10 +731,10 @@ AICORE void chunk_h_kernel(
       // Broadcast one decay scalar per token row across the D feature columns:
       //   coeff_2d[row, :] = coeff[row]
       TROWEXPAND(coeff_2d_ub, coeff_col_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       // `k_ub` now holds k_tilde = exp(g_last - g_i) * K_i.
       TMUL(k_ub, k_ub, coeff_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       wait_flag_dev(0);
       {

--- a/kernels/pto/chunk_h_kda.cpp
+++ b/kernels/pto/chunk_h_kda.cpp
@@ -46,7 +46,10 @@
 #include <type_traits>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -580,7 +583,7 @@ AICORE void chunk_h_kda_kernel(
           TileUbDataND<half, HalfC, K_DIM, HalfC, K_DIM> k_stg_cvt;
           TASSIGN(k_stg_cvt, K_UB_HALF);
           TCVT(k_ub, k_stg_cvt, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
         {
           GmShape2D g_shape(valid_rows, K_DIM);
@@ -621,15 +624,15 @@ AICORE void chunk_h_kda_kernel(
       // ── 3. coeff_2d = exp(g_total - g_cs)  [HalfC, K] ─────────────────
       // Broadcast g_total [1, K] across HalfC rows: 2d[i,j] = row[j] (TCOLEXPAND).
       TCOLEXPAND(coeff_2d_ub, gtotal_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TSUB(coeff_2d_ub, coeff_2d_ub, gcs_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TEXP(coeff_2d_ub, coeff_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       // K_rest = K * coeff_2d (element-wise).
       TMUL(k_ub, k_ub, coeff_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TCVT(k_ub_half, k_ub, pto::RoundMode::CAST_NONE);
 
       // ── 4. Reuse GCS_UB region to load U (g_cs is now dead) ────────────
@@ -660,7 +663,7 @@ AICORE void chunk_h_kda_kernel(
           TileUbDataND<half, HalfC, V_DIM, HalfC, V_DIM> u_stg_cvt;
           TASSIGN(u_stg_cvt, U_UB_HALF);
           TCVT(u_ub, u_stg_cvt, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
       } else {
         TEXPANDS(u_ub, 0.0f);
@@ -685,9 +688,9 @@ AICORE void chunk_h_kda_kernel(
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
       // Cast WS to fp32 into the broadcast/scratch buffer at WS_UB.
       TCVT(ws_ub, u_ub_half, pto::RoundMode::CAST_NONE);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TSUB(u_ub, u_ub, ws_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       // V_corr fp16 → U_UB_HALF (overwrites WS bytes).
       TCVT(u_ub_half, u_ub, pto::RoundMode::CAST_NONE);
 
@@ -733,7 +736,7 @@ AICORE void chunk_h_kda_kernel(
       set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
       wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
       TEXP(gtotal_ub, gtotal_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       // This sub-block owns K-rows [vid*HalfC, (vid+1)*HalfC) of the state.
       // Reinterpret that slice of gtotal_ub as a [HalfC, 1] DN-column vector,
@@ -745,9 +748,9 @@ AICORE void chunk_h_kda_kernel(
                     static_cast<int32_t>(sizeof(float)));
         TROWEXPAND(exp_gt_2d_ub, exp_gt_col);
       }
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TMUL(s_ub, s_ub, exp_gt_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       // ── 8. Wait Cube KV ready, S += KV ─────────────────────────────────
       wait_flag_dev(2);
@@ -772,7 +775,7 @@ AICORE void chunk_h_kda_kernel(
         TASSIGN(kv_load_view, KV_LOAD_UB);
         TCVT(kv_ub, kv_load_view, pto::RoundMode::CAST_NONE);
       }
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TADD(s_ub, s_ub, kv_ub);
 
       // ── 9. Write fp16(S) to workspace WS_S for next chunk's W @ S ──────

--- a/kernels/pto/chunk_o.cpp
+++ b/kernels/pto/chunk_o.cpp
@@ -81,7 +81,10 @@
 #include <pto/pto-inst.hpp>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 // ── Compile-time configuration (overridable at build time via -D flags) ──
 // D/C stay compile-time because tile shapes depend on them. H/Hg are runtime.
@@ -830,13 +833,13 @@ AICORE void chunk_o_kernel(
         TROWEXPAND(g_r_2d, g_v_col);       // g_r_2d[i,j] = g_row[i]
         TCOLEXPAND(coeff_ub, g_ub);        // coeff[i,j] = g_col[j]
         TSUB(coeff_ub, g_r_2d, coeff_ub);  // d = g_row - g_col
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMINS(coeff_ub, coeff_ub, 0.0f);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TEXP(coeff_ub, coeff_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMUL(coeff_ub, coeff_ub, msk_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TEXP(g_v_ub, g_v_ub);              // exp(g_row) for QS scaling
       }
 
@@ -923,7 +926,7 @@ AICORE void chunk_o_kernel(
       UbDN<float, HalfChunk, 1> g_v_col2;
       TASSIGN(g_v_col2, GvUbAddr);
       TROWEXPAND(g_exp_2d, g_v_col2);    // broadcast exp(g_row) across columns
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TMUL(qs_ub, qs_ub, g_exp_2d);      // QS_gated = QS * exp(g_row)
 
       // ── Wait for Cube→Vec flag 2: QKV ready ─────────────────────────
@@ -1040,13 +1043,13 @@ AICORE void chunk_o_kernel(
               TROWEXPAND(g_r_2d_v, g_v_col_v);
               TCOLEXPAND(coeff_ub, g_ub);
               TSUB(coeff_ub, g_r_2d_v, coeff_ub);  // d = g_row - g_col
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMINS(coeff_ub, coeff_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TEXP(coeff_ub, coeff_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(coeff_ub, coeff_ub, msk_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TEXP(g_v_ub, g_v_ub);
             }
 
@@ -1126,7 +1129,7 @@ AICORE void chunk_o_kernel(
               UbDN<float, HalfChunk, 1> g_v_col2_v;
               TASSIGN(g_v_col2_v, GvUbAddr);
               TROWEXPAND(g_exp_2d_v, g_v_col2_v);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(qs_ub, qs_ub, g_exp_2d_v);
 
               wait_flag_dev(2);

--- a/kernels/pto/chunk_o_kda.cpp
+++ b/kernels/pto/chunk_o_kda.cpp
@@ -63,7 +63,10 @@
 #include <type_traits>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -518,7 +521,7 @@ AICORE void chunk_o_kda_kernel(
           TileUbDataND<half, HalfC, K_DIM, HalfC, K_DIM> q_stg_cvt;
           TASSIGN(q_stg_cvt, SLOT_D_ADDR);
           TCVT(q_ub, q_stg_cvt, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
         {
           GmShape2D g_shape(valid_rows, K_DIM);
@@ -546,11 +549,11 @@ AICORE void chunk_o_kda_kernel(
       // exp(g_cs) ≤ 1 (g_cs ≤ 0) so q_eff is bounded; kept fp32 to match the
       // fp32 GEMM (k_eff below overflows fp16).
       TEXP(exp_ub, g_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       // q_eff into exp_ub (SLOT_C) so q_ub (SLOT_B) keeps the raw scaled Q,
       // which the Aqk element-wise pass below needs as its row factor.
       TMUL(exp_ub, q_ub, exp_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       // Store q_eff fp32 → WS_Q (full HalfC rows; padded zeros for invalid).
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -585,7 +588,7 @@ AICORE void chunk_o_kda_kernel(
           TileUbDataND<float, HalfC, C, HalfC, C> zero_ub;
           TASSIGN(zero_ub, SLOT_C_ADDR);
           TEXPANDS(zero_ub, 0.0f);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
           wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
           GmShape2D z_shape(HalfC, C);
@@ -619,7 +622,7 @@ AICORE void chunk_o_kda_kernel(
             TileUbDataND<half, 1, K_DIM, 1, K_DIM> kc_h; TASSIGN(kc_h, AQK_KCH);
             TileUbDataND<float, 1, K_DIM, 1, K_DIM> kc_f; TASSIGN(kc_f, AQK_KC);
             TCVT(kc_f, kc_h, pto::RoundMode::CAST_NONE);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
           }
           TileUbDataND<float, 1, K_DIM, 1, K_DIM> gc; TASSIGN(gc, AQK_GC);
           TileUbDataND<float, 1, K_DIM, 1, K_DIM> kc; TASSIGN(kc, AQK_KC);
@@ -627,12 +630,12 @@ AICORE void chunk_o_kda_kernel(
           TileUbDataND<float, HalfC, K_DIM, HalfC, K_DIM> tmp;  TASSIGN(tmp, SLOT_D_ADDR);
           TileUbDataND<float, HalfC, 16, HalfC, 1> colsum; TASSIGN(colsum, AQK_COL);
 
-          TCOLEXPANDSUB(diff, g_ub, gc);  pipe_barrier(PIPE_V);   // g_cs[r]-g_cs[c]
-          TMINS(diff, diff, 0.0f);        pipe_barrier(PIPE_V);   // <= 0
-          TEXP(diff, diff);               pipe_barrier(PIPE_V);
-          TCOLEXPANDMUL(diff, diff, kc);  pipe_barrier(PIPE_V);   // * k[c]
-          TMUL(diff, diff, q_ub);         pipe_barrier(PIPE_V);   // * q[r] (raw scaled Q)
-          TROWSUM(colsum, diff, tmp);     pipe_barrier(PIPE_V);
+          TCOLEXPANDSUB(diff, g_ub, gc);  PipeBarrierVec();   // g_cs[r]-g_cs[c]
+          TMINS(diff, diff, 0.0f);        PipeBarrierVec();   // <= 0
+          TEXP(diff, diff);               PipeBarrierVec();
+          TCOLEXPANDMUL(diff, diff, kc);  PipeBarrierVec();   // * k[c]
+          TMUL(diff, diff, q_ub);         PipeBarrierVec();   // * q[r] (raw scaled Q)
+          TROWSUM(colsum, diff, tmp);     PipeBarrierVec();
           {  // inclusive mask: zero rows (my_off+r) < c
             TileUbDataND<float, HalfC, 16, HalfC, 1> mk; TASSIGN(mk, AQK_MSK);
             GmShape2D ms(HalfC, 1); GmStride2D mst(C);
@@ -641,7 +644,7 @@ AICORE void chunk_o_kda_kernel(
             TLOAD(mk, mk_gm);
             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            TMUL(colsum, colsum, mk);  pipe_barrier(PIPE_V);
+            TMUL(colsum, colsum, mk);  PipeBarrierVec();
           }
           set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
           wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -690,10 +693,10 @@ AICORE void chunk_o_kda_kernel(
           set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
           wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
           TCVT(v_f_ub, vh_ub, pto::RoundMode::CAST_NONE);  // fp16 → fp32
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         } else {
           TEXPANDS(v_f_ub, 0.0f);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -735,7 +738,7 @@ AICORE void chunk_o_kda_kernel(
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         TCVT(s_f_ub, sh_ub, pto::RoundMode::CAST_NONE);  // fp16 → fp32
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -796,13 +799,13 @@ AICORE void chunk_o_kda_kernel(
 
         // O = QS + QKV  (both bounded; fp32).
         TADD(qs_ub, qs_ub, qkv_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         // Convert O fp32 → fp16, store to GM (BSND).
         TileUbDataND<half, HalfC, V_DIM, HalfC, V_DIM> oh_ub;
         TASSIGN(oh_ub, SLOT_D_ADDR);
         TCVT(oh_ub, qs_ub, pto::RoundMode::CAST_NONE);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         int64_t o_offset = (chunk_start * H + head) * V_DIM +

--- a/kernels/pto/gate_cumsum_kda.cpp
+++ b/kernels/pto/gate_cumsum_kda.cpp
@@ -47,7 +47,10 @@
 #include <pto/pto-inst.hpp>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -75,7 +78,7 @@ AICORE void cast_g_fp16_to_fp32(int32_t halfAddr, int32_t ubAddr)
   UbND<float, ChunkSize, CTC> g_f;
   TASSIGN(g_f, ubAddr);
   TCVT(g_f, g_h, pto::RoundMode::CAST_NONE);
-  pipe_barrier(PIPE_V);
+  PipeBarrierVec();
 }
 
 template <int32_t KDim, int32_t ChunkSize>
@@ -192,12 +195,12 @@ AICORE void gate_cumsum_kda_kernel(
         UbND<float, 1, CTC> g_row_0;
         TASSIGN(g_row_0, GUbAddr);
         TMOV(acc_ub, g_row_0);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         UbND<float, 1, CTC> s_row_0;
         TASSIGN(s_row_0, SUbAddr);
         TMOV(s_row_0, acc_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         // Rows 1..valid-1: acc += g[i]; g_sum[i] = acc
         for (int32_t i = 1; i < valid; ++i)
@@ -205,12 +208,12 @@ AICORE void gate_cumsum_kda_kernel(
           UbND<float, 1, CTC> g_row_i;
           TASSIGN(g_row_i, GUbAddr + i * RowBytes);
           TADD(acc_ub, acc_ub, g_row_i);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
 
           UbND<float, 1, CTC> s_row_i;
           TASSIGN(s_row_i, SUbAddr + i * RowBytes);
           TMOV(s_row_i, acc_ub);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         // ── V → MTE2 sync ───────────────────────────────────────────────
@@ -290,24 +293,24 @@ AICORE void gate_cumsum_kda_kernel(
             UbND<float, 1, CTC> g_row_0;
             TASSIGN(g_row_0, GUbAddr);
             TMOV(acc_ub, g_row_0);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
 
             UbND<float, 1, CTC> s_row_0;
             TASSIGN(s_row_0, SUbAddr);
             TMOV(s_row_0, acc_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
 
             for (int32_t i = 1; i < valid; ++i)
             {
               UbND<float, 1, CTC> g_row_i;
               TASSIGN(g_row_i, GUbAddr + i * RowBytes);
               TADD(acc_ub, acc_ub, g_row_i);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
 
               UbND<float, 1, CTC> s_row_i;
               TASSIGN(s_row_i, SUbAddr + i * RowBytes);
               TMOV(s_row_i, acc_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
             }
 
             // V → MTE2: prevent next iter's TLOAD from clobbering UB[GUbAddr]

--- a/kernels/pto/include/kernel_utils.h
+++ b/kernels/pto/include/kernel_utils.h
@@ -46,4 +46,14 @@ AICORE inline T1 CeilDiv(T1 value, T2 divisor) {
   return (value + divisor - 1) / divisor;
 }
 
+/**
+ * @brief Pipe in-core barrier for vector core that is a no-op for A5.
+ *
+ */
+AICORE inline void PipeBarrierVec() {
+#if __CCE_AICORE__ == 220
+  pipe_barrier(PIPE_V);
+#endif
+}
+
 }  // namespace kernel_utils

--- a/kernels/pto/kkt_kda.cpp
+++ b/kernels/pto/kkt_kda.cpp
@@ -76,7 +76,10 @@
 #include <pto/pto-inst.hpp>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -291,7 +294,7 @@ AICORE void kkt_kda_kernel(
                 UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> k_f(my_rows, KDim);
                 TASSIGN(k_f, MYK_ADDR);
                 TCVT(k_f, k_h, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
             }
             // ── Load my rows' beta (fp16 -> fp32) as a [1, my_rows] row, then
             //    re-view as a [my_rows, 1] column for the per-row scale. ───────
@@ -314,7 +317,7 @@ AICORE void kkt_kda_kernel(
                 UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_f(1, my_rows);
                 TASSIGN(b_f, BETA_ADDR);
                 TCVT(b_f, b_h, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
             }
 
             UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> myg(my_rows, KDim);
@@ -350,7 +353,7 @@ AICORE void kkt_kda_kernel(
                     UbND<float, 1, KTC, 1, KTC> kc_f;
                     TASSIGN(kc_f, KC_ADDR);
                     TCVT(kc_f, kc_h, pto::RoundMode::CAST_NONE);
-                    pipe_barrier(PIPE_V);
+                    PipeBarrierVec();
                 }
 
                 UbND<float, 1, KTC, 1, KTC> gc;
@@ -366,23 +369,23 @@ AICORE void kkt_kda_kernel(
 
                 // diff[r,d] = g_cs[my r, d] - g_cs[c, d]
                 TCOLEXPANDSUB(diff, myg, gc);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 // clamp to <= 0 so exp(.) is finite for masked (r<c) entries too
                 TMINS(diff, diff, 0.0f);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 TEXP(diff, diff);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 // *= k[c,d]  (per-dim broadcast), then *= k[my r, d]
                 TCOLEXPANDMUL(diff, diff, kc);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 TMUL(diff, diff, myk);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 // per-row beta scale (TMUL can't take a [R,1] column directly)
                 TROWEXPANDMUL(diff, diff, beta_col);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 // colsum[r] = beta[r] * sum_d diff[r,d]   (unmasked)
                 TROWSUM(colsum, diff, tmp);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
 
                 // Strict-lower mask: load mask[my_off+r, c] as a padded [my_rows,1]
                 // strip (row-strided gather, innermost contiguous) and zero the
@@ -399,7 +402,7 @@ AICORE void kkt_kda_kernel(
                     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                     TMUL(colsum, colsum, mk);
-                    pipe_barrier(PIPE_V);
+                    PipeBarrierVec();
                 }
 
                 // cvt colsum -> fp16 into a padded RowMajor [my_rows, 1] tile and
@@ -408,7 +411,7 @@ AICORE void kkt_kda_kernel(
                 UbND<half, HalfChunk, 16, DYNAMIC, DYNAMIC> col_h(my_rows, 1);
                 TASSIGN(col_h, COLH_ADDR);
                 TCVT(col_h, colsum, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
 
                 set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                 wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/kernels/pto/mega_kernel.cpp
+++ b/kernels/pto/mega_kernel.cpp
@@ -35,7 +35,10 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 // ===================================================================
 // Device-only helpers (shared with standard mega-kernel)

--- a/kernels/pto/mega_kernel_kda.cpp
+++ b/kernels/pto/mega_kernel_kda.cpp
@@ -33,7 +33,10 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 // ===================================================================
 // Device-only helpers

--- a/kernels/pto/scaled_dot_kkt.cpp
+++ b/kernels/pto/scaled_dot_kkt.cpp
@@ -71,7 +71,10 @@
 #include <pto/pto-inst.hpp>   // PTO (Performance Tile Operator): NPU kernel API
 #include "acl/acl.h"          // ACL (Ascend Computing Language): runtime API
 #include <runtime/rt_ffts.h>  // FFTS: cross-core synchronization primitives
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 // ── Compile-time constants (set by the JIT compiler from Python) ──────
 // D/C stay compile-time because tile shapes depend on them. H/Hg are runtime.
@@ -546,15 +549,15 @@ AICORE void kkt_kernel(
                 GUbAddr + row_offset *
                               static_cast<int32_t>(sizeof(float)));
         TMOV(g_v_ub, g_ub_temp);   // g_v = g[row_offset:row_offset+C/2]
-        pipe_barrier(PIPE_V);       // Wait for TMOV to complete
+        PipeBarrierVec();       // Wait for TMOV to complete
 
         TLOG(beta_ub, beta_ub);     // beta_ub = log(beta) in-place
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TADD(g_v_ub, g_v_ub, beta_ub);  // g_v = g_sub + log(beta) — the combined gate
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMOV(g_r_ub, g_v_ub);      // Copy to g_r for row-broadcast
         TMOV(g_c_ub, g_ub);        // Copy full g to g_c for col-broadcast
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         // Broadcast g_v to rows, g to columns → 2D gating matrix
         // coeff[i,j] = exp(min(g_v[i] - g[j], 0))
@@ -566,11 +569,11 @@ AICORE void kkt_kernel(
         TASSIGN(g_r_ub_temp, GRUbAddr);
         TROWEXPAND(g_r_2d_ub, g_r_ub_temp);  // g_r_2d[i,j] = g_v[i] for all j
         TCOLEXPAND(g_c_2d_ub, g_c_ub);       // g_c_2d[i,j] = g[j] for all i
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TSUB(coeff_ub, g_r_2d_ub, g_c_2d_ub);  // coeff[i,j] = g_v[i] - g[j]
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMINS(coeff_ub, coeff_ub, 0.0f);        // clamp to ≤ 0 (coeff will be ≤ 1 after exp)
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TEXP(coeff_ub, coeff_ub);                // coeff = exp(clamped_diff) ∈ (0, 1]
 
         // V→MTE2 sync: ensure gating computation is done before we start

--- a/kernels/pto/wy_fast.cpp
+++ b/kernels/pto/wy_fast.cpp
@@ -55,7 +55,10 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -459,7 +462,7 @@ AICORE void wy_fast_kernel(
               // Fully empty lower-half tail: materialize an all-zero tile so the
               // workspace still looks like a correctly padded HalfChunk block.
               TEXPANDS(a1_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -467,9 +470,9 @@ AICORE void wy_fast_kernel(
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
             TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(beta_r_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             // Replicate beta_j across rows so every column j of A gets the same beta.
             // PyTorch-like:
             //   beta_2d = beta[None, :].expand(HalfChunk, ChunkSize)
@@ -521,11 +524,11 @@ AICORE void wy_fast_kernel(
             // Torch-like:
             //   g_weight = exp(g) * beta
             TEXP(g_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMUL(g_ub, g_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(g_r_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TCOLEXPAND(g_2d_ub, g_r_ub);
             // A1 keeps the same A columns but multiplies each one by exp(g_j) * beta_j.
             //   a1_ub = a1_ub * g_weight[None, :]
@@ -622,7 +625,7 @@ AICORE void wy_fast_kernel(
               // Empty stripe for this sub-block: write zeros so the downstream
               // full-tile Cube GEMM sees valid padding rather than old workspace.
               TEXPANDS(a1_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -630,9 +633,9 @@ AICORE void wy_fast_kernel(
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
             TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(beta_r_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TCOLEXPAND(beta_2d_ub, beta_r_ub);
 
             TCVT(a1_ub, a1_ub_half, pto::RoundMode::CAST_NONE);
@@ -678,11 +681,11 @@ AICORE void wy_fast_kernel(
 
             // Build the g-based column weights before forming the W = A1 * K branch.
             TEXP(g_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMUL(g_ub, g_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(g_r_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TCOLEXPAND(g_2d_ub, g_r_ub);
             TMUL(a1_ub, a1_ub, g_2d_ub);
             TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);

--- a/kernels/pto/wy_kda.cpp
+++ b/kernels/pto/wy_kda.cpp
@@ -67,7 +67,10 @@
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
 #include <type_traits>
+#include "kernel_utils.h"
+
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -460,7 +463,7 @@ AICORE void wy_kda_kernel(
               // Fully empty lower-half stripe: emit zeros so the workspace tile
               // for this sub-block stays well-defined.
               TEXPANDS(a2_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -469,12 +472,12 @@ AICORE void wy_kda_kernel(
 
             if (local_rows > 0) {
               TCVT(beta_r_ub, beta_ub, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TileUbDataND<half, HalfChunk, ChunkSize,
                            HalfChunk, ChunkSize> a_stg_cvt;
               TASSIGN(a_stg_cvt, A2HalfUbAddr);
               TCVT(inv_ub, a_stg_cvt, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               // Replicate beta_j across rows: beta_2d[i,j] = beta[j].
               TCOLEXPAND(beta_2d_ub, beta_r_ub);
               // A2 = INV * beta_2d (column-scale).
@@ -532,7 +535,7 @@ AICORE void wy_kda_kernel(
                              HalfChunk, HiddenSize> k_stg_cvt;
                 TASSIGN(k_stg_cvt, KeffHalfUbAddr);
                 TCVT(k_ub, k_stg_cvt, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
               }
               {
                 GmShape2D g_shape(local_rows, HiddenSize);
@@ -555,13 +558,13 @@ AICORE void wy_kda_kernel(
               wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
               // exp(g_cs) in-place over gcs_ub, then K_eff = k * exp(g_cs).
               TEXP(gcs_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(keff_ub, k_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             } else {
               TEXPANDS(keff_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -651,7 +654,7 @@ AICORE void wy_kda_kernel(
               }
             } else {
               TEXPANDS(a2_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -660,12 +663,12 @@ AICORE void wy_kda_kernel(
 
             if (local_rows > 0) {
               TCVT(beta_r_ub, beta_ub, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TileUbDataND<half, HalfChunk, ChunkSize,
                            HalfChunk, ChunkSize> a_stg_cvt;
               TASSIGN(a_stg_cvt, A2HalfUbAddr);
               TCVT(inv_ub, a_stg_cvt, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCOLEXPAND(beta_2d_ub, beta_r_ub);
               TMUL(a2_ub, inv_ub, beta_2d_ub);
               TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
@@ -719,7 +722,7 @@ AICORE void wy_kda_kernel(
                              HalfChunk, HiddenSize> k_stg_cvt;
                 TASSIGN(k_stg_cvt, KeffHalfUbAddr);
                 TCVT(k_ub, k_stg_cvt, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
               }
               {
                 GmShape2D g_shape(local_rows, HiddenSize);
@@ -741,13 +744,13 @@ AICORE void wy_kda_kernel(
               set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
               wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
               TEXP(gcs_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(keff_ub, k_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             } else {
               TEXPANDS(keff_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             }
 


### PR DESCRIPTION
This pull request refactors several kernel implementation files to replace the usage of the `pipe_barrier(PIPE_V)` macro with a new function, `PipeBarrierVec()`, and introduces a new utility header, `kernel_utils.h`, to support this change. The update is applied consistently across multiple kernels, improving code clarity and maintainability.

### Synchronization Refactor

* Replaced all instances of `pipe_barrier(PIPE_V)` with the new `PipeBarrierVec()` function in the following kernel files: `chunk_cumsum.cpp`, `chunk_h.cpp`, `chunk_h_kda.cpp`, `chunk_o.cpp`, and `chunk_o_kda.cpp`. This affects all places where vector pipeline synchronization is needed. [[1]](diffhunk://#diff-5971437c146de8bf65701547f1adb2257ba2f1a6a5556657873368dbd61d9a5dL278-R286) [[2]](diffhunk://#diff-7af9b264177e0101e1af22aa16797ea30b20e56ef76078ec061bb0425dbd207dL713-R718) [[3]](diffhunk://#diff-0c30c995210481aa66a039e63e31a4cb7a7930b89d3befe4c8305f53758fdc03L583-R586) [[4]](diffhunk://#diff-60b1347467eb48740870101eb5ac1e13d4a4ea88a6ca602fb0e518c26c4afd0eL833-R842) [[5]](diffhunk://#diff-0ea2dece1e2160c757a488c29dc3a3a98c44fbfd9d7f1f479de1d787bcc2dcacL622-R638)