### PR TITLE
fix(kda): remove unecessary sync_all() from KDA kernels

### DIFF
--- a/kernels/pto/chunk_h_kda.cpp
+++ b/kernels/pto/chunk_h_kda.cpp
@@ -22,9 +22,6 @@
 //   - v_corr (fp16 copy) lives in a dedicated workspace slot (WS_V) so the
 //     Cube K_rest^T @ V_corr GEMM has an fp16 source — the BSND output is fp32.
 //
-// Cross-core sync: same data-flow flags as GDN chunk_h (0-3), plus sync_all
-// on entry/exit using reserved IDs 6-9 (matches wy_kda.cpp:89-104).
-//
 // Inputs:
 //   K   [HV, T, K]              fp32  — keys (head-major)
 //   W   [B, T, HV, K]           fp16  — wy_kda output, cast to fp16 in wrapper
@@ -62,25 +59,6 @@ using namespace kernel_utils;
 #endif
 
 #ifdef __CCE_AICORE__
-
-// Global all-core barrier — drains stale FFTS counters from prior launches.
-// Mirrors wy_kda.cpp:89-104.
-AICORE inline void sync_all()
-{
-    pipe_barrier(PIPE_ALL);
-#if defined(__DAV_C220_CUBE__)
-    ffts_cross_core_sync(PIPE_FIX, 1 | (0 << 4) | (7 << 8));
-    wait_flag_dev(7);
-    ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (8 << 8));
-    wait_flag_dev(9);
-#elif defined(__DAV_C220_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (0 << 4) | (6 << 8));
-    wait_flag_dev(6);
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (9 << 8));
-    wait_flag_dev(8);
-#endif
-    pipe_barrier(PIPE_ALL);
-}
 
 namespace {
 
@@ -359,8 +337,6 @@ AICORE void chunk_h_kda_kernel(
   int64_t total_work = num_seqs * H;
 
 #if defined(__DAV_C220_CUBE__)
-  sync_all();
-
   for (int64_t wi = 0; wi < (total_work + block_num - 1) / block_num; ++wi) {
     int64_t pid = wi * block_num + cid;
     if (pid >= total_work) break;
@@ -474,15 +450,11 @@ AICORE void chunk_h_kda_kernel(
       ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
     }
   }
-
-  sync_all();
 #endif
 
 #if defined(__DAV_C220_VEC__)
   set_mask_norm();
   set_vector_mask(-1, -1);
-
-  sync_all();
 
   for (int64_t wi = 0; wi < (total_work + block_num - 1) / block_num; ++wi) {
     int64_t pid = wi * block_num + cid;
@@ -803,8 +775,6 @@ AICORE void chunk_h_kda_kernel(
       }
     }
   }
-
-  sync_all();
 #endif
 }
 

--- a/kernels/pto/chunk_o_kda.cpp
+++ b/kernels/pto/chunk_o_kda.cpp
@@ -29,9 +29,6 @@
 // its own s_snapshots entry).  Cube/Vec still process them sequentially per
 // work item to keep the per-core 4-flag protocol simple.
 //
-// Cross-core sync: same data-flow flags as chunk_h_kda (0-3), plus sync_all
-// on entry/exit using reserved IDs 6-9.
-//
 // Inputs:
 //   Q       [HV, T, K]               fp32  — queries (head-major), scale pre-applied
 //   K       [HV, T, K]               fp32  — keys    (head-major)
@@ -79,25 +76,6 @@ using namespace kernel_utils;
 #endif
 
 #ifdef __CCE_AICORE__
-
-// Global all-core barrier — drains stale FFTS counters from prior launches.
-// Mirrors chunk_h_kda.cpp:67-82.
-AICORE inline void sync_all()
-{
-    pipe_barrier(PIPE_ALL);
-#if defined(__DAV_C220_CUBE__)
-    ffts_cross_core_sync(PIPE_FIX, 1 | (0 << 4) | (7 << 8));
-    wait_flag_dev(7);
-    ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (8 << 8));
-    wait_flag_dev(9);
-#elif defined(__DAV_C220_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (0 << 4) | (6 << 8));
-    wait_flag_dev(6);
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (9 << 8));
-    wait_flag_dev(8);
-#endif
-    pipe_barrier(PIPE_ALL);
-}
 
 namespace {
 
@@ -312,8 +290,6 @@ AICORE void chunk_o_kda_kernel(
   int64_t total_work = bh_work * split;
 
 #if defined(__DAV_C220_CUBE__)
-  sync_all();
-
   for (int64_t wi = 0; wi < (total_work + block_num - 1) / block_num; ++wi) {
     int64_t pid = wi * block_num + cid;
     if (pid >= total_work) break;
@@ -420,15 +396,11 @@ AICORE void chunk_o_kda_kernel(
       ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (1 << 8));
     }
   }
-
-  sync_all();
 #endif
 
 #if defined(__DAV_C220_VEC__)
   set_mask_norm();
   set_vector_mask(-1, -1);
-
-  sync_all();
 
   auto vid = get_subblockid();
   int32_t my_row_offset = static_cast<int32_t>(vid) * HalfC;
@@ -826,8 +798,6 @@ AICORE void chunk_o_kda_kernel(
       pipe_barrier(PIPE_ALL);
     }
   }
-
-  sync_all();
 #endif
 }
 

--- a/kernels/pto/kkt_kda.cpp
+++ b/kernels/pto/kkt_kda.cpp
@@ -90,26 +90,6 @@ using namespace kernel_utils;
 #endif
 
 #ifdef __CCE_AICORE__
-// Global barrier across ALL AI cores: every Cube and every Vec sub-block must
-// reach this point before any of them proceeds.  Uses four reserved FFTS flag
-// IDs (6, 7, 8, 9).
-AICORE inline void sync_all()
-{
-    pipe_barrier(PIPE_ALL);
-#if defined(__DAV_C220_CUBE__)
-    ffts_cross_core_sync(PIPE_FIX, 1 | (0 << 4) | (7 << 8));
-    wait_flag_dev(7);
-    ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (8 << 8));
-    wait_flag_dev(9);
-#elif defined(__DAV_C220_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (0 << 4) | (6 << 8));
-    wait_flag_dev(6);
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (9 << 8));
-    wait_flag_dev(8);
-#endif
-    pipe_barrier(PIPE_ALL);
-}
-
 template <typename T, int R, int C, int RV = R, int CV = C,
           pto::PadValue P = pto::PadValue::Null>
 using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor,
@@ -188,17 +168,9 @@ AICORE void kkt_kda_kernel(
     // (innermost stride 1).  Independent of head count, so a compile-time stride.
     using GmFloatMaskColRow = GlobalTensor<float, GmShapeDyn, Stride<1, 1, 1, ChunkSize, 1>>;
 
-#if defined(__DAV_C220_CUBE__)
-    // Cube does no compute here; it only participates in the entry/exit barriers
-    // so the Vec-side sync_all() handshakes complete.
-    sync_all();
-    sync_all();
-#endif
-
 #if defined(__DAV_C220_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
-    sync_all();
 
     // ── UB layout (per vid) ──────────────────────────────────────────────────
     constexpr int32_t MYG_ADDR = 0;                               // [HalfChunk, K] fp32
@@ -436,8 +408,6 @@ AICORE void kkt_kda_kernel(
             }
         }
     }
-
-    sync_all();
 #endif // __DAV_C220_VEC__
 }
 

--- a/kernels/pto/wy_kda.cpp
+++ b/kernels/pto/wy_kda.cpp
@@ -44,10 +44,6 @@
 //   11 : V→C reduce "ws_keff ready"
 //   12 : C→V broadcast "ws_a2 free"
 //   13 : C→V broadcast "ws_keff free"
-// Sync_all uses 6-9 (matches kkt_kda).  We pick data-flow IDs ≥ 10 so they
-// don't collide with kkt_kda / tri_inverse / gate_cumsum_kda (which all use
-// IDs 0-5 for data flow + 6-9 for sync_all).
-//
 // Layout (matches Python kda_kernel_libs convention; v cast to fp16 wrap-side):
 //   k       head-major [HV, T, K]    fp32
 //   v       BSND       [B, T, HV, V] fp16   (V == K in current setup)
@@ -81,27 +77,6 @@ using namespace kernel_utils;
 #endif
 
 #ifdef __CCE_AICORE__
-
-// Global barrier across ALL AI cores: drains any leftover FFTS state from
-// prior kernel launches and balances the trailing data-flow signals on
-// exit.  Uses four reserved FFTS flag IDs (6, 7, 8, 9) — distinct from the
-// data-flow flags 1-4 used by this kernel.  Pattern matches kkt_kda.cpp.
-AICORE inline void sync_all()
-{
-    pipe_barrier(PIPE_ALL);
-#if defined(__DAV_C220_CUBE__)
-    ffts_cross_core_sync(PIPE_FIX, 1 | (0 << 4) | (7 << 8));
-    wait_flag_dev(7);
-    ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (8 << 8));
-    wait_flag_dev(9);
-#elif defined(__DAV_C220_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (0 << 4) | (6 << 8));
-    wait_flag_dev(6);
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (9 << 8));
-    wait_flag_dev(8);
-#endif
-    pipe_barrier(PIPE_ALL);
-}
 
 namespace {
 
@@ -384,12 +359,6 @@ AICORE void wy_kda_kernel(
 #if defined(__DAV_C220_VEC__)
   set_mask_norm();
   set_vector_mask(-1, -1);
-
-  // Global all-core barrier at kernel start: drains any stale FFTS counters
-  // left by previous launches (this kernel's Cube emits flags 3/4 N times
-  // per block while Vec only waits N-1 times, so without this entry/exit
-  // pair the trailing signal would leak into the next launch).
-  sync_all();
 
   // Vec prepares the two workspaces (ws_a2 holding A2 = INV*beta_2d, and
   // ws_keff holding K_eff = k*exp(g_cs)) that the Cube phase then consumes.
@@ -785,16 +754,9 @@ AICORE void wy_kda_kernel(
     wait_flag_dev(12);
     wait_flag_dev(13);
   }
-
-  // Global all-core barrier at kernel exit: matches the entry sync_all so
-  // the next launch starts with clean FFTS state.
-  sync_all();
 #endif
 
 #if defined(__DAV_C220_CUBE__)
-  // Global all-core barrier at kernel start (matches Vec side).
-  sync_all();
-
   // Cube reads V from BSND and the two Vec-produced workspaces, then issues
   // U = A2 @ V and W = A2 @ K_eff.  a2_l1 stays resident in L1 across both
   // GEMMs so the second matmul is just a different B-side load away.
@@ -994,9 +956,6 @@ AICORE void wy_kda_kernel(
       }
     }
   }
-
-  // Global all-core barrier at kernel exit (matches Vec side).
-  sync_all();
 #endif
 }
 


### PR DESCRIPTION
```
git push
Enumerating objects: 15, done.
Counting objects: 100% (15/15), done.
Delta compression using up to 192 threads
Compressing objects: 100% (8/8), done.
Writing objects: 100% (8/8), 793 bytes | 793.00 KiB/s, done.
Total 8 (delta 6), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.
To https://github.com/huawei-csl/megagdn-pto.git
   0cc8853..1e3cdf6  48-kda-remove-unecessary-sync_all-from-kernels -> 48-kda-remove-unecessary-sync_all-from-kernels
zouzias@bz-vnl-910b:~/github-repos/megagdn-pto$ python tests/test_kda_single_kernels.py 
device=npu:0  H=4  K=128  V=128  CHUNK=128  cases=19

============================================================
Stage: Gate cumsum
============================================================
  [ 1/19] PASS  fixed T=128  (0.88s)
  [ 2/19] PASS  fixed T=256  (0.01s)
  [ 3/19] PASS  fixed T=385  (0.01s)
  [ 4/19] PASS  fixed T=512  (0.01s)
  [ 5/19] PASS  fixed T=1024  (0.02s)
  [ 6/19] PASS  varlen [128]  (0.00s)
  [ 7/19] PASS  varlen [256]  (0.01s)
  [ 8/19] PASS  varlen [384]  (0.01s)
  [ 9/19] PASS  varlen [512]  (0.01s)
  [10/19] PASS  varlen [256, 256]  (0.01s)
  [11/19] PASS  varlen [128, 256]  (0.01s)
  [12/19] PASS  varlen [384, 128]  (0.01s)
  [13/19] PASS  varlen [128, 128, 128]  (0.01s)
  [14/19] PASS  varlen [256, 128, 384]  (0.02s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.02s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.03s)
  [17/19] PASS  varlen rand 3seq T=896  (0.02s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.03s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.05s)

============================================================
Stage: KKT NPU kernel
============================================================
  [ 1/19] PASS  fixed T=128  (1.18s)
  [ 2/19] PASS  fixed T=256  (0.01s)
  [ 3/19] PASS  fixed T=385  (0.02s)
  [ 4/19] PASS  fixed T=512  (0.02s)
  [ 5/19] PASS  fixed T=1024  (0.04s)
  [ 6/19] PASS  varlen [128]  (0.01s)
  [ 7/19] PASS  varlen [256]  (0.01s)
  [ 8/19] PASS  varlen [384]  (0.01s)
  [ 9/19] PASS  varlen [512]  (0.02s)
  [10/19] PASS  varlen [256, 256]  (0.02s)
  [11/19] PASS  varlen [128, 256]  (0.02s)
  [12/19] PASS  varlen [384, 128]  (0.02s)
  [13/19] PASS  varlen [128, 128, 128]  (0.01s)
  [14/19] PASS  varlen [256, 128, 384]  (0.03s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.04s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.06s)
  [17/19] PASS  varlen rand 3seq T=896  (0.04s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.07s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.09s)

============================================================
Stage: Linalg (I+L)^{-1}
============================================================
  [ 1/19] PASS  fixed T=128  (0.04s)
  [ 2/19] PASS  fixed T=256  (0.03s)
  [ 3/19] PASS  fixed T=385  (0.05s)
  [ 4/19] PASS  fixed T=512  (0.07s)
  [ 5/19] PASS  fixed T=1024  (0.12s)
  [ 6/19] PASS  varlen [128]  (0.02s)
  [ 7/19] PASS  varlen [256]  (0.03s)
  [ 8/19] PASS  varlen [384]  (0.05s)
  [ 9/19] PASS  varlen [512]  (0.07s)
  [10/19] PASS  varlen [256, 256]  (0.07s)
  [11/19] PASS  varlen [128, 256]  (0.05s)
  [12/19] PASS  varlen [384, 128]  (0.07s)
  [13/19] PASS  varlen [128, 128, 128]  (0.05s)
  [14/19] PASS  varlen [256, 128, 384]  (0.10s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.11s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.16s)
  [17/19] PASS  varlen rand 3seq T=896  (0.11s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.22s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.31s)

============================================================
Stage: WY transform (u, w)
============================================================
  [ 1/19] PASS  fixed T=128  (1.14s)
  [ 2/19] PASS  fixed T=256  (0.04s)
  [ 3/19] PASS  fixed T=385  (0.06s)
  [ 4/19] PASS  fixed T=512  (0.08s)
  [ 5/19] PASS  fixed T=1024  (0.15s)
  [ 6/19] PASS  varlen [128]  (0.02s)
  [ 7/19] PASS  varlen [256]  (0.04s)
  [ 8/19] PASS  varlen [384]  (0.06s)
  [ 9/19] PASS  varlen [512]  (0.07s)
  [10/19] PASS  varlen [256, 256]  (0.07s)
  [11/19] PASS  varlen [128, 256]  (0.06s)
  [12/19] PASS  varlen [384, 128]  (0.07s)
  [13/19] PASS  varlen [128, 128, 128]  (0.05s)
  [14/19] PASS  varlen [256, 128, 384]  (0.11s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.13s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.20s)
  [17/19] PASS  varlen rand 3seq T=896  (0.13s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.25s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.33s)

============================================================
Stage: chunk_h_kda (snapshots)
============================================================
  [ 1/19] PASS  fixed T=128  (1.19s)
  [ 2/19] PASS  fixed T=256  (0.05s)
  [ 3/19] PASS  fixed T=385  (0.07s)
  [ 4/19] PASS  fixed T=512  (0.08s)
  [ 5/19] PASS  fixed T=1024  (0.17s)
  [ 6/19] PASS  varlen [128]  (0.03s)
  [ 7/19] PASS  varlen [256]  (0.05s)
  [ 8/19] PASS  varlen [384]  (0.07s)
  [ 9/19] PASS  varlen [512]  (0.09s)
  [10/19] PASS  varlen [256, 256]  (0.08s)
  [11/19] PASS  varlen [128, 256]  (0.06s)
  [12/19] PASS  varlen [384, 128]  (0.08s)
  [13/19] PASS  varlen [128, 128, 128]  (0.06s)
  [14/19] PASS  varlen [256, 128, 384]  (0.13s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.16s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.23s)
  [17/19] PASS  varlen rand 3seq T=896  (0.14s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.29s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.38s)

============================================================
Stage: chunk_o_kda (output)
============================================================
  [ 1/19] PASS  fixed T=128  (1.20s)
  [ 2/19] PASS  fixed T=256  (0.05s)
  [ 3/19] PASS  fixed T=385  (0.08s)
  [ 4/19] PASS  fixed T=512  (0.10s)
  [ 5/19] PASS  fixed T=1024  (0.19s)
  [ 6/19] PASS  varlen [128]  (0.03s)
  [ 7/19] PASS  varlen [256]  (0.05s)
  [ 8/19] PASS  varlen [384]  (0.08s)
  [ 9/19] PASS  varlen [512]  (0.10s)
  [10/19] PASS  varlen [256, 256]  (0.10s)
  [11/19] PASS  varlen [128, 256]  (0.07s)
  [12/19] PASS  varlen [384, 128]  (0.10s)
  [13/19] PASS  varlen [128, 128, 128]  (0.07s)
  [14/19] PASS  varlen [256, 128, 384]  (0.15s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.19s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.27s)
  [17/19] PASS  varlen rand 3seq T=896  (0.16s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.32s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.44s)

ALL PASS
zouzias@bz-vnl-910b:~/github-repos/megagdn-pto$ python tests/test_kda_e2e.py 
device=npu:0  H=4  HV=4  K=128  V=128  CHUNK=128
NPU stages: [1] gate_cumsum_kda  [2] kkt_kda  [3] solve_tril  [4] wy_kda  [5] chunk_h_kda  [6] chunk_o_kda

============================================================
[megagdn_pto] Compiling mega_kernel_kda (K=128 C=128) …
[megagdn_pto] Compiled → /home/zouzias/github-repos/megagdn-pto/kernels/pto/compiled_lib/mega_kernel_kda_D128_C128.so
  [ 1/7] PASS  T=256  [staged=ok mega=ok mega~staged=ok]  (9.43s)
  [ 2/7] PASS  T=512  [staged=ok mega=ok mega~staged=ok]  (0.11s)
  [ 3/7] PASS  T=1024  [staged=ok mega=ok mega~staged=ok]  (0.20s)
  [ 4/7] PASS  varlen [0, 256, 512]  [staged=ok mega=ok mega~staged=ok]  (0.10s)
  [ 5/7] PASS  varlen [0, 128, 384, 768]  [staged=ok mega=ok mega~staged=ok]  (0.16s)
  [ 6/7] PASS  varlen [0, 384, 512]  [staged=ok mega=ok mega~staged=ok]  (0.10s)
  [ 7/7] PASS  varlen [0, 128, 256, 512]  [staged=ok mega=ok mega~staged=ok]  (0.10s)

ALL PASS

```