### PR TITLE
fix(a5): enable A5 compilation on all kernels

### DIFF
--- a/kernels/pto/chunk_o.cpp
+++ b/kernels/pto/chunk_o.cpp
@@ -155,6 +155,9 @@ AICORE void chunk_o_kernel(
     uint32_t num_key_heads,
     uint64_t ffts_addr)
 {
+  // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
+  using pto::Stride;
+
   // Half the chunk — each Vec sub-block handles C/2 rows independently.
   constexpr int32_t HalfChunk = ChunkSize / 2;
   // KTail / CTail: the number of valid elements in the last 128-element tile

--- a/kernels/pto/gate_cumsum_kda.cpp
+++ b/kernels/pto/gate_cumsum_kda.cpp
@@ -88,6 +88,9 @@ AICORE void gate_cumsum_kda_kernel(
     int64_t batch_size, int64_t seq_len,
     int32_t num_heads, uint64_t ffts_addr)
 {
+  // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
+  using pto::Stride;
+
   auto cid = get_block_idx();
   auto block_num = get_block_num();
   auto vid = get_subblockid();

--- a/kernels/pto/include/kernel_utils.h
+++ b/kernels/pto/include/kernel_utils.h
@@ -98,4 +98,75 @@ AICORE inline void PipeBarrierVec() {
 #endif
 }
 
+
+AICORE inline uint16_t GetffstMsg(uint16_t mode, uint16_t flagId)
+{
+    constexpr uint16_t SYNC_MODE_SHIFT_VALUE = 4;
+    constexpr uint16_t SYNC_FLAG_SHIFT_VALUE = 8;
+    return (0x1 + ((mode & 0x3) << SYNC_MODE_SHIFT_VALUE) +
+            ((flagId & 0xf) << SYNC_FLAG_SHIFT_VALUE));
+}
+
+template <bool isAIVOnly = true>
+AICORE inline void SyncAllA2A3()
+{
+// These constants are defined on A5
+#if __CCE_AICORE__ == 220
+    constexpr uint16_t SYNC_AIV_FLAG = 12;
+    constexpr uint16_t SYNC_AIC_FLAG = 11;
+    constexpr uint16_t SYNC_AIC_AIV_FLAG = 13;
+    constexpr uint16_t SYNC_AIV_ONLY_ALL = 14;
+    pipe_barrier(PIPE_ALL);
+    if constexpr (isAIVOnly) {
+        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, SYNC_AIV_ONLY_ALL));
+        wait_flag_dev(SYNC_AIV_ONLY_ALL);
+        return;
+    }
+#if defined(__DAV_CUBE__)
+    wait_flag_dev(SYNC_AIV_FLAG);
+    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, SYNC_AIC_FLAG));
+    wait_flag_dev(SYNC_AIC_FLAG);
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIC_AIV_FLAG));
+#elif defined(__DAV_VEC__)
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIV_FLAG));
+    wait_flag_dev(SYNC_AIC_AIV_FLAG);
+#endif
+#endif
+}
+
+// ── A5 ── mirrors include/pto/npu/a5/SyncAll.hpp:101-111
+  // Requires: getFFTSMsg from <pto/npu/a5/SyncAll.hpp> (A5 defines its own)
+AICORE inline void SyncAllMixA5()
+{
+#if __CCE_AICORE__ != 220
+      pipe_barrier(PIPE_ALL);
+#if defined(__DAV_CUBE__)
+      // 1. Wait for both paired AIVs: one flag ID per subblock (base, base + SYNC_FLAG_ID_MAX).
+      wait_intra_block(PIPE_S, SYNC_AIV_FLAG);
+      wait_intra_block(PIPE_S, SYNC_AIV_FLAG + SYNC_FLAG_ID_MAX);
+      // 2. Global all-AIC barrier.
+      ffts_cross_core_sync(PIPE_FIX, getFFTSMsg(0x0, SYNC_AIC_FLAG));
+      wait_flag_dev(PIPE_S, SYNC_AIC_FLAG);
+      // 3. Release both paired AIVs.
+      set_intra_block(PIPE_S, SYNC_AIC_AIV_FLAG);
+      set_intra_block(PIPE_S, SYNC_AIC_AIV_FLAG + SYNC_FLAG_ID_MAX);
+#elif defined(__DAV_VEC__)
+      // Set on MTE3 so prior stores drain; wait on PIPE_S.
+      set_intra_block(PIPE_MTE3, SYNC_AIV_FLAG);
+      wait_intra_block(PIPE_S, SYNC_AIC_AIV_FLAG);
+#endif
+#endif
+}
+
+template <bool isAIVOnly = true>
+AICORE inline void SyncAllMegaKernel()
+{
+#if __CCE_AICORE__ == 220
+	SyncAllA2A3<isAIVOnly>();
+#else
+	static_assert(isAIVOnly == false, "No support for AIV only global sync");
+	SyncAllMixA5();
+#endif
+}
+
 }  // namespace kernel_utils

--- a/kernels/pto/kkt_kda.cpp
+++ b/kernels/pto/kkt_kda.cpp
@@ -115,6 +115,9 @@ AICORE void kkt_kda_kernel(
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
     int32_t num_heads, uint64_t ffts_addr)
 {
+    // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
+    using pto::Stride;
+
     auto cid = get_block_idx();
     auto block_num = get_block_num();
     auto vid = get_subblockid();

--- a/kernels/pto/kkt_kda.cpp
+++ b/kernels/pto/kkt_kda.cpp
@@ -130,6 +130,12 @@ AICORE void kkt_kda_kernel(
 
     constexpr int32_t HalfChunk = ChunkSize / 2;
     constexpr int32_t KTC = ((KDim + 7) / 8) * 8;
+    // A RowMajor/NoneBox tile needs its column byte-width 32-byte aligned, and a
+    // ColMajor/NoneBox one its row byte-width: 16 halves / 8 floats.  HalfChunk
+    // itself is only 8 at ChunkSize=16, so the [1, HalfChunk] beta tiles must use
+    // padded widths (both collapse to HalfChunk at ChunkSize=128).
+    constexpr int32_t HalfChunkH = ((HalfChunk + 15) / 16) * 16; // fp16 cols
+    constexpr int32_t HalfChunkF = ((HalfChunk + 7) / 8) * 8;    // fp32 cols/rows
 
     int64_t num_seqs = batch_size;
 
@@ -187,9 +193,9 @@ AICORE void kkt_kda_kernel(
     constexpr int32_t KCH_ADDR = KC_ADDR + KTC * 4;               // [1, K] fp16 (k_c staging)
     constexpr int32_t COL_ADDR = KCH_ADDR + KTC * 2;              // [HalfChunk, 16] fp32 (colsum, RowMajor padded)
     constexpr int32_t COLH_ADDR = COL_ADDR + HalfChunk * 16 * 4;  // [HalfChunk, 16] fp16 (padded store, RowMajor)
-    constexpr int32_t BETA_ADDR = COLH_ADDR + HalfChunk * 16 * 2; // [1, HalfChunk] fp32 (beta)
-    constexpr int32_t BETAH_ADDR = BETA_ADDR + HalfChunk * 4;     // [1, HalfChunk] fp16 (beta staging)
-    constexpr int32_t MSKC_ADDR = BETAH_ADDR + HalfChunk * 2;     // [1, HalfChunk] fp32 (mask col)
+    constexpr int32_t BETA_ADDR = COLH_ADDR + HalfChunk * 16 * 2; // [1, HalfChunkF] fp32 (beta)
+    constexpr int32_t BETAH_ADDR = BETA_ADDR + HalfChunkF * 4;    // [1, HalfChunkH] fp16 (beta staging)
+    constexpr int32_t MSKC_ADDR = BETAH_ADDR + HalfChunkH * 2;    // [HalfChunk, 16] fp32 (mask col)
 
     int32_t my_off = static_cast<int32_t>(vid) * HalfChunk;
 
@@ -281,16 +287,16 @@ AICORE void kkt_kda_kernel(
                 GmHalf_1 b_gm(beta_ptr + static_cast<int64_t>(head_idx) * total_tokens +
                                   my_first,
                               gs);
-                UbND<half, 1, HalfChunk, DYNAMIC, DYNAMIC> b_ld(1, my_rows);
+                UbND<half, 1, HalfChunkH, DYNAMIC, DYNAMIC> b_ld(1, my_rows);
                 TASSIGN(b_ld, BETAH_ADDR);
                 TLOAD(b_ld, b_gm);
             }
             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             {
-                UbND<half, 1, HalfChunk, DYNAMIC, DYNAMIC> b_h(1, my_rows);
+                UbND<half, 1, HalfChunkH, DYNAMIC, DYNAMIC> b_h(1, my_rows);
                 TASSIGN(b_h, BETAH_ADDR);
-                UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_f(1, my_rows);
+                UbND<float, 1, HalfChunkF, DYNAMIC, DYNAMIC> b_f(1, my_rows);
                 TASSIGN(b_f, BETA_ADDR);
                 TCVT(b_f, b_h, pto::RoundMode::CAST_NONE);
                 PipeBarrierVec();
@@ -300,7 +306,7 @@ AICORE void kkt_kda_kernel(
             TASSIGN(myg, MYG_ADDR);
             UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> myk(my_rows, KDim);
             TASSIGN(myk, MYK_ADDR);
-            UbDN<float, HalfChunk, 1, DYNAMIC, DYNAMIC> beta_col(my_rows, 1);
+            UbDN<float, HalfChunkF, 1, DYNAMIC, DYNAMIC> beta_col(my_rows, 1);
             TASSIGN(beta_col, BETA_ADDR);
 
             // ── Column loop ──────────────────────────────────────────────────

--- a/kernels/pto/mega_kernel.cpp
+++ b/kernels/pto/mega_kernel.cpp
@@ -79,6 +79,9 @@ template <typename T>
 AICORE void mega_transpose_TH_to_HT(
     __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
 {
+    // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
+    using pto::Stride;
+
 #if defined(__DAV_VEC__)
     if (get_subblockid() != 0) return;
     set_mask_norm();
@@ -168,6 +171,9 @@ AICORE void mega_cast_fp32_to_fp16_bsnd(
     __gm__ float *src, __gm__ half *dst,
     uint32_t num_matrices, int64_t total_tokens)
 {
+    // See mega_transpose_TH_to_HT above — hides the global `enum class Stride`.
+    using pto::Stride;
+
 #if defined(__DAV_VEC__)
     if (get_subblockid() != 0) return;
     set_mask_norm();

--- a/kernels/pto/mega_kernel.cpp
+++ b/kernels/pto/mega_kernel.cpp
@@ -1,8 +1,9 @@
-// mega_kernel.cpp — GDN Mega-Kernel (group-value / GQA): all PTO stages in one launch
+// mega_kernel.cpp — GDN Mega-Kernel (group-value / GQA): all PTO stages in one
+// launch
 //
-// Same pipeline as pto_mega_kernel, but scaled_dot_kkt / wy_fast / chunk_h / chunk_o use
-// runtime H/Hg dispatch from dynamic_bsnd_groupvalue; cumsum still uses H
-// (value heads) like dynamic_bsnd.
+// Same pipeline as pto_mega_kernel, but scaled_dot_kkt / wy_fast / chunk_h /
+// chunk_o use runtime H/Hg dispatch from dynamic_bsnd_groupvalue; cumsum still
+// uses H (value heads) like dynamic_bsnd.
 //
 // Stages:
 //   1. cumsum      (Vec)
@@ -20,18 +21,20 @@
 #define GDN_C 128
 #endif
 // GDN_MAX_HEADS: compile-time ceiling on the value-head count. num_heads is a
-// RUNTIME argument (one .so serves every head count), so the transpose/cumsum UB
-// tiles are sized for this worst case; any num_heads <= GDN_MAX_HEADS works with
-// the unused columns zero-padded. Must match the host-side _MAX_HEADS guard and
-// the GDN_MAX_HEADS in chunk_cumsum.cpp.
+// RUNTIME argument (one .so serves every head count), so the transpose/cumsum
+// UB tiles are sized for this worst case; any num_heads <= GDN_MAX_HEADS works
+// with the unused columns zero-padded. Must match the host-side _MAX_HEADS
+// guard and the GDN_MAX_HEADS in chunk_cumsum.cpp.
 #ifndef GDN_MAX_HEADS
 #define GDN_MAX_HEADS 64
 #endif
 
-#include <pto/pto-inst.hpp>
-#include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+
+#include <pto/pto-inst.hpp>
 #include <type_traits>
+
+#include "acl/acl.h"
 #include "kernel_utils.h"
 
 using namespace pto;
@@ -43,164 +46,177 @@ using namespace kernel_utils;
 #ifdef __CCE_AICORE__
 
 template <typename T>
-AICORE void mega_transpose_TH_to_HT(
-    __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
-{
-    // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
-    using pto::Stride;
+AICORE void mega_transpose_TH_to_HT(__gm__ T* src, __gm__ T* dst, int64_t T_len,
+                                    int32_t H) {
+  // To avoid ambiguity with bisheng intrinsic header's global `enum class
+  // Stride`
+  using pto::Stride;
 
 #if defined(__DAV_VEC__)
-    if (get_subblockid() != 0) return;
-    set_mask_norm();
-    set_vector_mask(-1, -1);
+  if (get_subblockid() != 0) return;
+  set_mask_norm();
+  set_vector_mask(-1, -1);
 
-    auto cid = get_block_idx();
-    auto block_num = get_block_num();
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
 
-    constexpr int32_t BLOCK = 128;
-    constexpr int32_t ES = static_cast<int32_t>(sizeof(T));
-    constexpr int32_t MinTransposeCols = 16;
-    constexpr int32_t AlignElems = ((32 / ES) > MinTransposeCols) ? (32 / ES) : MinTransposeCols;
-    // H is runtime; size the UB tiles for the worst-case head count. TTRANS always
-    // processes the full BLOCK×HP tile (unused cols H..HP are zero-padded), and the
-    // store loop below writes only the first H transposed rows.
-    constexpr int32_t HP = ((GDN_MAX_HEADS + AlignElems - 1) / AlignElems) * AlignElems;
-    constexpr int32_t SRC_UB = 0;
-    constexpr int32_t DST_UB = SRC_UB + BLOCK * HP * ES;
-    constexpr int32_t TMP_UB = DST_UB + HP * BLOCK * ES;
+  constexpr int32_t BLOCK = 128;
+  constexpr int32_t ES = static_cast<int32_t>(sizeof(T));
+  constexpr int32_t MinTransposeCols = 16;
+  constexpr int32_t AlignElems =
+      ((32 / ES) > MinTransposeCols) ? (32 / ES) : MinTransposeCols;
+  // H is runtime; size the UB tiles for the worst-case head count. TTRANS
+  // always processes the full BLOCK×HP tile (unused cols H..HP are
+  // zero-padded), and the store loop below writes only the first H transposed
+  // rows.
+  constexpr int32_t HP =
+      ((GDN_MAX_HEADS + AlignElems - 1) / AlignElems) * AlignElems;
+  constexpr int32_t SRC_UB = 0;
+  constexpr int32_t DST_UB = SRC_UB + BLOCK * HP * ES;
+  constexpr int32_t TMP_UB = DST_UB + HP * BLOCK * ES;
 
-    using UBSrcFull = Tile<TileType::Vec, T, BLOCK, HP, BLayout::RowMajor,
-                           BLOCK, HP, SLayout::NoneBox, 512, PadValue::Zero>;
-    using UBSrcDyn  = Tile<TileType::Vec, T, BLOCK, HP, BLayout::RowMajor,
-                           DYNAMIC, DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
-    using UBDst     = Tile<TileType::Vec, T, HP, BLOCK, BLayout::RowMajor,
-                           HP, BLOCK, SLayout::NoneBox, 512>;
-    using UBDstDyn  = Tile<TileType::Vec, T, HP, BLOCK, BLayout::RowMajor,
-                           DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
-    using UBTmp     = Tile<TileType::Vec, T, BLOCK, HP, BLayout::RowMajor,
-                           BLOCK, HP, SLayout::NoneBox, 512>;
+  using UBSrcFull = Tile<TileType::Vec, T, BLOCK, HP, BLayout::RowMajor, BLOCK,
+                         HP, SLayout::NoneBox, 512, PadValue::Zero>;
+  using UBSrcDyn = Tile<TileType::Vec, T, BLOCK, HP, BLayout::RowMajor, DYNAMIC,
+                        DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
+  using UBDst = Tile<TileType::Vec, T, HP, BLOCK, BLayout::RowMajor, HP, BLOCK,
+                     SLayout::NoneBox, 512>;
+  using UBDstDyn = Tile<TileType::Vec, T, HP, BLOCK, BLayout::RowMajor, DYNAMIC,
+                        DYNAMIC, SLayout::NoneBox, 512>;
+  using UBTmp = Tile<TileType::Vec, T, BLOCK, HP, BLayout::RowMajor, BLOCK, HP,
+                     SLayout::NoneBox, 512>;
 
-    using UBRow     = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor,
-                           1, BLOCK, SLayout::NoneBox, 512>;
-    using UBRowDyn  = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor,
-                           DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
+  using UBRow = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor, 1, BLOCK,
+                     SLayout::NoneBox, 512>;
+  using UBRowDyn = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor, DYNAMIC,
+                        DYNAMIC, SLayout::NoneBox, 512>;
 
-    using Gm2D      = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-    using Gm1D      = Shape<1, 1, 1, 1, DYNAMIC>;
-    using GmSrcS    = Stride<1, 1, 1, DYNAMIC, 1>;
-    using GmS1      = Stride<1, 1, 1, 1, 1>;
-    GmSrcS src_stride(H);  // runtime row pitch = H elements (skip other heads)
+  using Gm2D = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using Gm1D = Shape<1, 1, 1, 1, DYNAMIC>;
+  using GmSrcS = Stride<1, 1, 1, DYNAMIC, 1>;
+  using GmS1 = Stride<1, 1, 1, 1, 1>;
+  GmSrcS src_stride(H);  // runtime row pitch = H elements (skip other heads)
 
-    UBSrcFull ub_src; TASSIGN(ub_src, SRC_UB);
-    UBDst     ub_dst; TASSIGN(ub_dst, DST_UB);
-    UBTmp     ub_tmp; TASSIGN(ub_tmp, TMP_UB);
+  UBSrcFull ub_src;
+  TASSIGN(ub_src, SRC_UB);
+  UBDst ub_dst;
+  TASSIGN(ub_dst, DST_UB);
+  UBTmp ub_tmp;
+  TASSIGN(ub_tmp, TMP_UB);
 
-    int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
+  int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
 
-    for (int64_t bi = static_cast<int64_t>(cid); bi < num_tok_blocks;
-         bi += static_cast<int64_t>(block_num)) {
-        int64_t t0 = bi * BLOCK;
-        int32_t valid = (t0 + BLOCK <= T_len)
-                            ? BLOCK
-                            : static_cast<int32_t>(T_len - t0);
+  for (int64_t bi = static_cast<int64_t>(cid); bi < num_tok_blocks;
+       bi += static_cast<int64_t>(block_num)) {
+    int64_t t0 = bi * BLOCK;
+    int32_t valid =
+        (t0 + BLOCK <= T_len) ? BLOCK : static_cast<int32_t>(T_len - t0);
 
-        {
-            Gm2D gs; gs.shape[3] = valid; gs.shape[4] = H;
-            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs, src_stride);
-            UBSrcDyn ld(valid, H);
-            TASSIGN(ld, SRC_UB);
-            TLOAD(ld, gm);
-            if (valid != BLOCK || H != HP) TFILLPAD_INPLACE(ub_src, ld);
-        }
-        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-
-        TTRANS(ub_dst, ub_src, ub_tmp);
-
-        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-
-        for (int32_t h = 0; h < H; ++h) {
-            Gm1D gs; gs.shape[4] = valid;
-            GlobalTensor<T, Gm1D, GmS1> gm(dst + h * T_len + t0, gs);
-            UBRowDyn st(1, valid);
-            TASSIGN(st, DST_UB + h * BLOCK * ES);
-            TSTORE(gm, st);
-        }
-        set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    {
+      Gm2D gs;
+      gs.shape[3] = valid;
+      gs.shape[4] = H;
+      GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs, src_stride);
+      UBSrcDyn ld(valid, H);
+      TASSIGN(ld, SRC_UB);
+      TLOAD(ld, gm);
+      if (valid != BLOCK || H != HP) TFILLPAD_INPLACE(ub_src, ld);
     }
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    TTRANS(ub_dst, ub_src, ub_tmp);
+
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    for (int32_t h = 0; h < H; ++h) {
+      Gm1D gs;
+      gs.shape[4] = valid;
+      GlobalTensor<T, Gm1D, GmS1> gm(dst + h * T_len + t0, gs);
+      UBRowDyn st(1, valid);
+      TASSIGN(st, DST_UB + h * BLOCK * ES);
+      TSTORE(gm, st);
+    }
+    set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  }
 #endif
 }
 
 template <int32_t H, int32_t C>
-AICORE void mega_cast_fp32_to_fp16_bsnd(
-    __gm__ float *src, __gm__ half *dst,
-    uint32_t num_matrices, int64_t total_tokens)
-{
-    // See mega_transpose_TH_to_HT above — hides the global `enum class Stride`.
-    using pto::Stride;
+AICORE void mega_cast_fp32_to_fp16_bsnd(__gm__ float* src, __gm__ half* dst,
+                                        uint32_t num_matrices,
+                                        int64_t total_tokens) {
+  // See mega_transpose_TH_to_HT above — hides the global `enum class Stride`.
+  using pto::Stride;
 
 #if defined(__DAV_VEC__)
-    if (get_subblockid() != 0) return;
-    set_mask_norm();
-    set_vector_mask(-1, -1);
+  if (get_subblockid() != 0) return;
+  set_mask_norm();
+  set_vector_mask(-1, -1);
 
-    auto cid = get_block_idx();
-    auto block_num = get_block_num();
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
 
-    constexpr int32_t F32_UB = 0;
-    constexpr int32_t F16_UB = C * static_cast<int32_t>(sizeof(float));
+  constexpr int32_t F32_UB = 0;
+  constexpr int32_t F16_UB = C * static_cast<int32_t>(sizeof(float));
 
-    using SrcUB    = Tile<TileType::Vec, float, 1, C, BLayout::RowMajor,
-                          1, C, SLayout::NoneBox, 512, PadValue::Zero>;
-    using DynSrcUB = Tile<TileType::Vec, float, 1, C, BLayout::RowMajor,
-                          DYNAMIC, DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
-    using DstUB    = Tile<TileType::Vec, half, 1, C, BLayout::RowMajor,
-                          1, C, SLayout::NoneBox, 512>;
-    using DynDstUB = Tile<TileType::Vec, half, 1, C, BLayout::RowMajor,
-                          DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
-    using Gm1D     = Shape<1, 1, 1, 1, DYNAMIC>;
-    using GmS1     = Stride<1, 1, 1, 1, 1>;
+  using SrcUB = Tile<TileType::Vec, float, 1, C, BLayout::RowMajor, 1, C,
+                     SLayout::NoneBox, 512, PadValue::Zero>;
+  using DynSrcUB = Tile<TileType::Vec, float, 1, C, BLayout::RowMajor, DYNAMIC,
+                        DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
+  using DstUB = Tile<TileType::Vec, half, 1, C, BLayout::RowMajor, 1, C,
+                     SLayout::NoneBox, 512>;
+  using DynDstUB = Tile<TileType::Vec, half, 1, C, BLayout::RowMajor, DYNAMIC,
+                        DYNAMIC, SLayout::NoneBox, 512>;
+  using Gm1D = Shape<1, 1, 1, 1, DYNAMIC>;
+  using GmS1 = Stride<1, 1, 1, 1, 1>;
 
-    SrcUB src_ub; TASSIGN(src_ub, F32_UB);
-    DstUB dst_ub; TASSIGN(dst_ub, F16_UB);
+  SrcUB src_ub;
+  TASSIGN(src_ub, F32_UB);
+  DstUB dst_ub;
+  TASSIGN(dst_ub, F16_UB);
 
-    for (uint32_t m = cid; m < num_matrices; m += block_num) {
-        uint32_t h = m % static_cast<uint32_t>(H);
-        uint32_t chunk_idx = m / static_cast<uint32_t>(H);
+  for (uint32_t m = cid; m < num_matrices; m += block_num) {
+    uint32_t h = m % static_cast<uint32_t>(H);
+    uint32_t chunk_idx = m / static_cast<uint32_t>(H);
 
-        for (int64_t t = 0; t < total_tokens; ++t) {
-            int64_t off = t * static_cast<int64_t>(H * C) +
-                          static_cast<int64_t>(h * C);
+    for (int64_t t = 0; t < total_tokens; ++t) {
+      int64_t off =
+          t * static_cast<int64_t>(H * C) + static_cast<int64_t>(h * C);
 
-            {
-                Gm1D gs; gs.shape[4] = C;
-                GlobalTensor<float, Gm1D, GmS1> gm(src + off, gs);
-                SrcUB ld; TASSIGN(ld, F32_UB);
-                TLOAD(ld, gm);
-            }
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      {
+        Gm1D gs;
+        gs.shape[4] = C;
+        GlobalTensor<float, Gm1D, GmS1> gm(src + off, gs);
+        SrcUB ld;
+        TASSIGN(ld, F32_UB);
+        TLOAD(ld, gm);
+      }
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-            TCVT(dst_ub, src_ub, RoundMode::CAST_NONE);
+      TCVT(dst_ub, src_ub, RoundMode::CAST_NONE);
 
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            {
-                Gm1D gs; gs.shape[4] = C;
-                GlobalTensor<half, Gm1D, GmS1> gm(dst + off, gs);
-                DstUB st; TASSIGN(st, F16_UB);
-                TSTORE(gm, st);
-            }
-            set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-            wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-        }
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      {
+        Gm1D gs;
+        gs.shape[4] = C;
+        GlobalTensor<half, Gm1D, GmS1> gm(dst + off, gs);
+        DstUB st;
+        TASSIGN(st, F16_UB);
+        TSTORE(gm, st);
+      }
+      set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
     }
+  }
 #endif
 }
 
-#endif // __CCE_AICORE__
+#endif  // __CCE_AICORE__
 
 // ===================================================================
 // Include original kernel implementations in separate namespaces.
@@ -240,342 +256,270 @@ namespace mk_o {
 }
 #undef call_kernel
 
-AICORE void mega_solve_tril(
-    __gm__ half *out, __gm__ half *in, __gm__ half *minus_id,
-    uint32_t matrix_size, uint32_t num_matrices,
-    uint32_t num_bsnd_heads,
-    __gm__ int32_t *cu_seqlens, uint32_t is_lower)
-{
-    if (num_matrices <= get_block_num())
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 1, true, half>(
-            out, in, minus_id, num_matrices,
-            num_bsnd_heads, cu_seqlens, is_lower);
-    else if (num_matrices <= 2u * get_block_num())
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 2, true, half>(
-            out, in, minus_id, num_matrices,
-            num_bsnd_heads, cu_seqlens, is_lower);
-    else
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 4, true, half>(
-            out, in, minus_id, num_matrices,
-            num_bsnd_heads, cu_seqlens, is_lower);
+AICORE void mega_solve_tril(__gm__ half* out, __gm__ half* in,
+                            __gm__ half* minus_id, uint32_t matrix_size,
+                            uint32_t num_matrices, uint32_t num_bsnd_heads,
+                            __gm__ int32_t* cu_seqlens, uint32_t is_lower) {
+  if (num_matrices <= get_block_num())
+    mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 1, true>(
+        out, in, minus_id, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+  else if (num_matrices <= 2u * get_block_num())
+    mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 2, true>(
+        out, in, minus_id, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+  else
+    mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 4, true>(
+        out, in, minus_id, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
 }
 
 AICORE inline void mega_kernel_impl(
-    __gm__ uint8_t *q_ptr,
-    __gm__ uint8_t *k_ptr,
-    __gm__ uint8_t *v_ptr,
-    __gm__ uint8_t *g_in_ptr,
-    __gm__ uint8_t *beta_ptr,
-    __gm__ uint8_t *msk_lower_ptr,
-    __gm__ uint8_t *msk_full_ptr,
-    __gm__ uint8_t *minus_id_ptr,
-    __gm__ uint8_t *cu_seqlens_ptr,
-    __gm__ uint8_t *o_ptr,
-    __gm__ uint8_t *g_sum_ptr,
-    __gm__ uint8_t *g_t_ptr,
-    __gm__ uint8_t *beta_t_ptr,
-    __gm__ uint8_t *A_ptr,
-    __gm__ uint8_t *A_inv_f32_ptr,
-    __gm__ uint8_t *A_inv_ptr,
-    __gm__ uint8_t *w_ptr,
-    __gm__ uint8_t *u_ptr,
-    __gm__ uint8_t *s_ptr,
-    __gm__ uint8_t *v_new_ptr,
-    __gm__ uint8_t *fs_ptr,
-    __gm__ uint8_t *h0_ptr,
-    int64_t has_initial_state,
-    __gm__ uint8_t *kkt_ws_ptr,
-    __gm__ uint8_t *wy_ws_a1_ptr,
-    __gm__ uint8_t *wy_ws_a2_ptr,
-    __gm__ uint8_t *h_ws_ptr,
-    __gm__ uint8_t *o_ws_qk_ptr,
-    __gm__ uint8_t *o_ws_qs_ptr,
-    __gm__ uint8_t *o_ws_gated_ptr,
-    int32_t H,
-    uint32_t num_key_heads,
-    int64_t batch_size,
-    int64_t seq_len,
-    int64_t total_tokens,
-    uint32_t num_matrices,
-    uint64_t ffts_addr)
-{
-    set_ffts_base_addr(ffts_addr);
+    __gm__ uint8_t* q_ptr, __gm__ uint8_t* k_ptr, __gm__ uint8_t* v_ptr,
+    __gm__ uint8_t* g_in_ptr, __gm__ uint8_t* beta_ptr,
+    __gm__ uint8_t* msk_lower_ptr, __gm__ uint8_t* msk_full_ptr,
+    __gm__ uint8_t* minus_id_ptr, __gm__ uint8_t* cu_seqlens_ptr,
+    __gm__ uint8_t* o_ptr, __gm__ uint8_t* g_sum_ptr, __gm__ uint8_t* g_t_ptr,
+    __gm__ uint8_t* beta_t_ptr, __gm__ uint8_t* A_ptr,
+    __gm__ uint8_t* A_inv_f32_ptr, __gm__ uint8_t* A_inv_ptr,
+    __gm__ uint8_t* w_ptr, __gm__ uint8_t* u_ptr, __gm__ uint8_t* s_ptr,
+    __gm__ uint8_t* v_new_ptr, __gm__ uint8_t* fs_ptr, __gm__ uint8_t* h0_ptr,
+    int64_t has_initial_state, __gm__ uint8_t* kkt_ws_ptr,
+    __gm__ uint8_t* wy_ws_a1_ptr, __gm__ uint8_t* wy_ws_a2_ptr,
+    __gm__ uint8_t* h_ws_ptr, __gm__ uint8_t* o_ws_qk_ptr,
+    __gm__ uint8_t* o_ws_qs_ptr, __gm__ uint8_t* o_ws_gated_ptr, int32_t H,
+    uint32_t num_key_heads, int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens, uint32_t num_matrices, uint64_t ffts_addr) {
+  set_ffts_base_addr(ffts_addr);
 
-    constexpr int32_t D = GDN_D;
-    constexpr int32_t C = GDN_C;
+  constexpr int32_t D = GDN_D;
+  constexpr int32_t C = GDN_C;
 
-    if (num_key_heads == 0 || (static_cast<uint32_t>(H) % num_key_heads) != 0) {
-        return;
-    }
+  if (num_key_heads == 0 || (static_cast<uint32_t>(H) % num_key_heads) != 0) {
+    return;
+  }
 
-    mk_cumsum::cumsum_kernel<C>(
-        reinterpret_cast<__gm__ float *>(g_in_ptr),
-        reinterpret_cast<__gm__ float *>(g_sum_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, H, ffts_addr);
+  mk_cumsum::cumsum_kernel<C>(reinterpret_cast<__gm__ float*>(g_in_ptr),
+                              reinterpret_cast<__gm__ float*>(g_sum_ptr),
+                              reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr),
+                              batch_size, seq_len, H, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_CUMSUM
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_SYNC1
-    return;
+  return;
 #endif
 
-    mega_transpose_TH_to_HT<float>(
-        reinterpret_cast<__gm__ float *>(g_sum_ptr),
-        reinterpret_cast<__gm__ float *>(g_t_ptr),
-        total_tokens, H);
-    mega_transpose_TH_to_HT<half>(
-        reinterpret_cast<__gm__ half *>(beta_ptr),
-        reinterpret_cast<__gm__ half *>(beta_t_ptr),
-        total_tokens, H);
+  mega_transpose_TH_to_HT<float>(reinterpret_cast<__gm__ float*>(g_sum_ptr),
+                                 reinterpret_cast<__gm__ float*>(g_t_ptr),
+                                 total_tokens, H);
+  mega_transpose_TH_to_HT<half>(reinterpret_cast<__gm__ half*>(beta_ptr),
+                                reinterpret_cast<__gm__ half*>(beta_t_ptr),
+                                total_tokens, H);
 
 #ifdef MEGA_STOP_AFTER_TRANSPOSE
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    mk_kkt::kkt_kernel<D, C>(
-        reinterpret_cast<__gm__ half *>(k_ptr),
-        reinterpret_cast<__gm__ half *>(beta_t_ptr),
-        reinterpret_cast<__gm__ float *>(g_t_ptr),
-        reinterpret_cast<__gm__ float *>(msk_lower_ptr),
-        reinterpret_cast<__gm__ half *>(kkt_ws_ptr),
-        reinterpret_cast<__gm__ half *>(A_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
-        num_key_heads, ffts_addr);
+  mk_kkt::kkt_kernel<D, C>(reinterpret_cast<__gm__ half*>(k_ptr),
+                           reinterpret_cast<__gm__ half*>(beta_t_ptr),
+                           reinterpret_cast<__gm__ float*>(g_t_ptr),
+                           reinterpret_cast<__gm__ float*>(msk_lower_ptr),
+                           reinterpret_cast<__gm__ half*>(kkt_ws_ptr),
+                           reinterpret_cast<__gm__ half*>(A_ptr),
+                           reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr),
+                           batch_size, seq_len, total_tokens,
+                           static_cast<uint32_t>(H), num_key_heads, ffts_addr);
 
 // Drain the kkt handshake: Vec released both workspace slots (flags 2/3) one
-// last time after Cube's final iteration, so consume them before the next stage.
-// A2: Vec is a separate core → FFTS cross-core flag.
-// A5: both Vec sub-blocks share Cube's core → each signals its own intra-block
+// last time after Cube's final iteration, so consume them before the next
+// stage. A2: Vec is a separate core → FFTS cross-core flag. A5: both Vec
+// sub-blocks share Cube's core → each signals its own intra-block
 //     flag (base, base + 16).
 #if defined(__DAV_CUBE__)
-    pipe_barrier(PIPE_ALL);
+  pipe_barrier(PIPE_ALL);
 #if __CCE_AICORE__ == 220
-    wait_flag_dev(2);
-    wait_flag_dev(3);
+  wait_flag_dev(2);
+  wait_flag_dev(3);
 #else
-    WaitBothVecOnA5<PIPE_MTE2>(2);
-    WaitBothVecOnA5<PIPE_MTE2>(3);
-    pipe_barrier(PIPE_ALL);
+  WaitBothVecOnA5<PIPE_MTE2>(2);
+  WaitBothVecOnA5<PIPE_MTE2>(3);
+  pipe_barrier(PIPE_ALL);
 #endif
 #endif
 
 #ifdef MEGA_STOP_AFTER_KKT
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    mega_solve_tril(
-        reinterpret_cast<__gm__ half *>(A_inv_ptr),
-        reinterpret_cast<__gm__ half *>(A_ptr),
-        reinterpret_cast<__gm__ half *>(minus_id_ptr),
-        C, num_matrices, H,
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), 1);
+  mega_solve_tril(reinterpret_cast<__gm__ half*>(A_inv_ptr),
+                  reinterpret_cast<__gm__ half*>(A_ptr),
+                  reinterpret_cast<__gm__ half*>(minus_id_ptr), C, num_matrices,
+                  H, reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), 1);
 
 #ifdef MEGA_STOP_AFTER_SOLVE
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_CAST
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_SYNC_BEFORE_WY
-    return;
+  return;
 #endif
 
-    mk_wy::wy_fast_kernel<D, C>(
-        reinterpret_cast<__gm__ half *>(k_ptr),
-        reinterpret_cast<__gm__ half *>(v_ptr),
-        reinterpret_cast<__gm__ half *>(beta_t_ptr),
-        reinterpret_cast<__gm__ float *>(g_t_ptr),
-        reinterpret_cast<__gm__ half *>(A_inv_ptr),
-        reinterpret_cast<__gm__ half *>(wy_ws_a1_ptr),
-        reinterpret_cast<__gm__ half *>(wy_ws_a2_ptr),
-        reinterpret_cast<__gm__ half *>(w_ptr),
-        reinterpret_cast<__gm__ half *>(u_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
-        num_key_heads, ffts_addr);
+  mk_wy::wy_fast_kernel<D, C>(
+      reinterpret_cast<__gm__ half*>(k_ptr),
+      reinterpret_cast<__gm__ half*>(v_ptr),
+      reinterpret_cast<__gm__ half*>(beta_t_ptr),
+      reinterpret_cast<__gm__ float*>(g_t_ptr),
+      reinterpret_cast<__gm__ half*>(A_inv_ptr),
+      reinterpret_cast<__gm__ half*>(wy_ws_a1_ptr),
+      reinterpret_cast<__gm__ half*>(wy_ws_a2_ptr),
+      reinterpret_cast<__gm__ half*>(w_ptr),
+      reinterpret_cast<__gm__ half*>(u_ptr),
+      reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), batch_size, seq_len,
+      total_tokens, static_cast<uint32_t>(H), num_key_heads, ffts_addr);
 
 // Drain the wy_fast handshake: Cube freed the A2/A1 slots (flags 3/4) one last
 // time after Vec's final iteration.
 // A5: Cube signalled both sub-blocks (base, base + 16); each sub-block waits on
 //     its own flag, so a plain intra-block wait is what mirrors the signal.
 #if defined(__DAV_VEC__)
-    if (get_block_idx() < num_matrices) {
-        pipe_barrier(PIPE_ALL);
+  if (get_block_idx() < num_matrices) {
+    pipe_barrier(PIPE_ALL);
 #if __CCE_AICORE__ == 220
-        wait_flag_dev(3);
-        wait_flag_dev(4);
+    wait_flag_dev(3);
+    wait_flag_dev(4);
 #else
-        wait_intra_block(PIPE_MTE3, 3);
-        wait_intra_block(PIPE_MTE3, 4);
-        pipe_barrier(PIPE_ALL);
+    wait_intra_block(PIPE_MTE3, 3);
+    wait_intra_block(PIPE_MTE3, 4);
+    pipe_barrier(PIPE_ALL);
 #endif
-    }
+  }
 #endif
 
 #ifdef MEGA_STOP_AFTER_WY
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    mk_h::chunk_h_kernel<D, C>(
-        reinterpret_cast<__gm__ half *>(k_ptr),
-        reinterpret_cast<__gm__ half *>(w_ptr),
-        reinterpret_cast<__gm__ half *>(u_ptr),
-        reinterpret_cast<__gm__ float *>(g_t_ptr),
-        reinterpret_cast<__gm__ half *>(s_ptr),
-        reinterpret_cast<__gm__ half *>(v_new_ptr),
-        reinterpret_cast<__gm__ half *>(fs_ptr),
-        reinterpret_cast<__gm__ half *>(h0_ptr),
-        has_initial_state,
-        1,
-        reinterpret_cast<__gm__ half *>(h_ws_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
-        num_key_heads, ffts_addr);
+  mk_h::chunk_h_kernel<D, C>(
+      reinterpret_cast<__gm__ half*>(k_ptr),
+      reinterpret_cast<__gm__ half*>(w_ptr),
+      reinterpret_cast<__gm__ half*>(u_ptr),
+      reinterpret_cast<__gm__ float*>(g_t_ptr),
+      reinterpret_cast<__gm__ half*>(s_ptr),
+      reinterpret_cast<__gm__ half*>(v_new_ptr),
+      reinterpret_cast<__gm__ half*>(fs_ptr),
+      reinterpret_cast<__gm__ half*>(h0_ptr), has_initial_state, 1,
+      reinterpret_cast<__gm__ half*>(h_ws_ptr),
+      reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), batch_size, seq_len,
+      total_tokens, static_cast<uint32_t>(H), num_key_heads, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_H
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    mk_o::chunk_o_kernel<D, C>(
-        reinterpret_cast<__gm__ half *>(q_ptr),
-        reinterpret_cast<__gm__ half *>(k_ptr),
-        reinterpret_cast<__gm__ half *>(v_new_ptr),
-        reinterpret_cast<__gm__ half *>(s_ptr),
-        reinterpret_cast<__gm__ float *>(g_t_ptr),
-        reinterpret_cast<__gm__ float *>(msk_full_ptr),
-        reinterpret_cast<__gm__ half *>(o_ws_qk_ptr),
-        reinterpret_cast<__gm__ half *>(o_ws_qs_ptr),
-        reinterpret_cast<__gm__ half *>(o_ws_gated_ptr),
-        reinterpret_cast<__gm__ half *>(o_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
-        num_key_heads, ffts_addr);
+  mk_o::chunk_o_kernel<D, C>(
+      reinterpret_cast<__gm__ half*>(q_ptr),
+      reinterpret_cast<__gm__ half*>(k_ptr),
+      reinterpret_cast<__gm__ half*>(v_new_ptr),
+      reinterpret_cast<__gm__ half*>(s_ptr),
+      reinterpret_cast<__gm__ float*>(g_t_ptr),
+      reinterpret_cast<__gm__ float*>(msk_full_ptr),
+      reinterpret_cast<__gm__ half*>(o_ws_qk_ptr),
+      reinterpret_cast<__gm__ half*>(o_ws_qs_ptr),
+      reinterpret_cast<__gm__ half*>(o_ws_gated_ptr),
+      reinterpret_cast<__gm__ half*>(o_ptr),
+      reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), batch_size, seq_len,
+      total_tokens, static_cast<uint32_t>(H), num_key_heads, ffts_addr);
 
 // Drain the chunk_o handshake: Vec's final "workspace free" (flag 3) is never
 // consumed by Cube's loop, so consume it here.
 #if defined(__DAV_CUBE__)
-    if (get_block_idx() < num_matrices) {
-        pipe_barrier(PIPE_ALL);
+  if (get_block_idx() < num_matrices) {
+    pipe_barrier(PIPE_ALL);
 #if __CCE_AICORE__ == 220
-        wait_flag_dev(3);
+    wait_flag_dev(3);
 #else
-        WaitBothVecOnA5<PIPE_MTE2>(3);
-        pipe_barrier(PIPE_ALL);
+    WaitBothVecOnA5<PIPE_MTE2>(3);
+    pipe_barrier(PIPE_ALL);
 #endif
-    }
+  }
 #endif
 }
 
 extern "C" __global__ AICORE void launch_mega_kernel(
-    __gm__ uint8_t *q_ptr,
-    __gm__ uint8_t *k_ptr,
-    __gm__ uint8_t *v_ptr,
-    __gm__ uint8_t *g_in_ptr,
-    __gm__ uint8_t *beta_ptr,
-    __gm__ uint8_t *msk_lower_ptr,
-    __gm__ uint8_t *msk_full_ptr,
-    __gm__ uint8_t *minus_id_ptr,
-    __gm__ uint8_t *cu_seqlens_ptr,
-    __gm__ uint8_t *o_ptr,
-    __gm__ uint8_t *g_sum_ptr,
-    __gm__ uint8_t *g_t_ptr,
-    __gm__ uint8_t *beta_t_ptr,
-    __gm__ uint8_t *A_ptr,
-    __gm__ uint8_t *A_inv_f32_ptr,
-    __gm__ uint8_t *A_inv_ptr,
-    __gm__ uint8_t *w_ptr,
-    __gm__ uint8_t *u_ptr,
-    __gm__ uint8_t *s_ptr,
-    __gm__ uint8_t *v_new_ptr,
-    __gm__ uint8_t *fs_ptr,
-    __gm__ uint8_t *h0_ptr,
-    int64_t has_initial_state,
-    __gm__ uint8_t *kkt_ws_ptr,
-    __gm__ uint8_t *wy_ws_a1_ptr,
-    __gm__ uint8_t *wy_ws_a2_ptr,
-    __gm__ uint8_t *h_ws_ptr,
-    __gm__ uint8_t *o_ws_qk_ptr,
-    __gm__ uint8_t *o_ws_qs_ptr,
-    __gm__ uint8_t *o_ws_gated_ptr,
-    uint32_t num_heads,
-    uint32_t num_key_heads,
-    int64_t batch_size,
-    int64_t seq_len,
-    int64_t total_tokens,
-    uint32_t num_matrices,
-    uint64_t ffts_addr)
-{
-    // num_heads is a runtime kernel argument (one .so serves every head count).
-    // Guard the compile-time UB ceiling; the host validates before launch too.
-    if (num_heads == 0 || num_heads > GDN_MAX_HEADS) {
-        return;
-    }
-    mega_kernel_impl(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr, msk_full_ptr, minus_id_ptr,
-                     cu_seqlens_ptr, o_ptr, g_sum_ptr, g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr,
-                     w_ptr, u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state, kkt_ws_ptr,
-                     wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr, o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,
-                     static_cast<int32_t>(num_heads), num_key_heads, batch_size, seq_len, total_tokens,
-                     num_matrices, ffts_addr);
+    __gm__ uint8_t* q_ptr, __gm__ uint8_t* k_ptr, __gm__ uint8_t* v_ptr,
+    __gm__ uint8_t* g_in_ptr, __gm__ uint8_t* beta_ptr,
+    __gm__ uint8_t* msk_lower_ptr, __gm__ uint8_t* msk_full_ptr,
+    __gm__ uint8_t* minus_id_ptr, __gm__ uint8_t* cu_seqlens_ptr,
+    __gm__ uint8_t* o_ptr, __gm__ uint8_t* g_sum_ptr, __gm__ uint8_t* g_t_ptr,
+    __gm__ uint8_t* beta_t_ptr, __gm__ uint8_t* A_ptr,
+    __gm__ uint8_t* A_inv_f32_ptr, __gm__ uint8_t* A_inv_ptr,
+    __gm__ uint8_t* w_ptr, __gm__ uint8_t* u_ptr, __gm__ uint8_t* s_ptr,
+    __gm__ uint8_t* v_new_ptr, __gm__ uint8_t* fs_ptr, __gm__ uint8_t* h0_ptr,
+    int64_t has_initial_state, __gm__ uint8_t* kkt_ws_ptr,
+    __gm__ uint8_t* wy_ws_a1_ptr, __gm__ uint8_t* wy_ws_a2_ptr,
+    __gm__ uint8_t* h_ws_ptr, __gm__ uint8_t* o_ws_qk_ptr,
+    __gm__ uint8_t* o_ws_qs_ptr, __gm__ uint8_t* o_ws_gated_ptr,
+    uint32_t num_heads, uint32_t num_key_heads, int64_t batch_size,
+    int64_t seq_len, int64_t total_tokens, uint32_t num_matrices,
+    uint64_t ffts_addr) {
+  // num_heads is a runtime kernel argument (one .so serves every head count).
+  // Guard the compile-time UB ceiling; the host validates before launch too.
+  if (num_heads == 0 || num_heads > GDN_MAX_HEADS) {
+    return;
+  }
+  mega_kernel_impl(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr,
+                   msk_full_ptr, minus_id_ptr, cu_seqlens_ptr, o_ptr, g_sum_ptr,
+                   g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr, w_ptr,
+                   u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state,
+                   kkt_ws_ptr, wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr,
+                   o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,
+                   static_cast<int32_t>(num_heads), num_key_heads, batch_size,
+                   seq_len, total_tokens, num_matrices, ffts_addr);
 }
 
 extern "C" void call_kernel(
-    uint32_t block_dim, void *stream,
-    uint8_t *q, uint8_t *k, uint8_t *v,
-    uint8_t *g_in, uint8_t *beta,
-    uint8_t *msk_lower, uint8_t *msk_full,
-    uint8_t *minus_id, uint8_t *cu_seqlens,
-    uint8_t *o,
-    uint8_t *g_sum, uint8_t *g_t, uint8_t *beta_t,
-    uint8_t *A, uint8_t *A_inv_f32, uint8_t *A_inv,
-    uint8_t *w, uint8_t *u, uint8_t *s, uint8_t *v_new, uint8_t *fs,
-    uint8_t *h0,
-    int64_t has_initial_state,
-    uint8_t *kkt_ws, uint8_t *wy_ws_a1, uint8_t *wy_ws_a2,
-    uint8_t *h_ws,
-    uint8_t *o_ws_qk, uint8_t *o_ws_qs, uint8_t *o_ws_gated,
-    uint32_t num_heads,
-    uint32_t num_key_heads,
-    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint32_t num_matrices)
-{
-    uint32_t fftsLen{0};
-    uint64_t fftsAddr{0};
-    rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
-    launch_mega_kernel<<<block_dim, nullptr, stream>>>(
-        q, k, v, g_in, beta, msk_lower, msk_full, minus_id, cu_seqlens,
-        o,
-        g_sum, g_t, beta_t, A, A_inv_f32, A_inv,
-        w, u, s, v_new, fs, h0, has_initial_state,
-        kkt_ws, wy_ws_a1, wy_ws_a2, h_ws,
-        o_ws_qk, o_ws_qs, o_ws_gated,
-        num_heads, num_key_heads,
-        batch_size, seq_len, total_tokens, num_matrices,
-        fftsAddr);
+    uint32_t block_dim, void* stream, uint8_t* q, uint8_t* k, uint8_t* v,
+    uint8_t* g_in, uint8_t* beta, uint8_t* msk_lower, uint8_t* msk_full,
+    uint8_t* minus_id, uint8_t* cu_seqlens, uint8_t* o, uint8_t* g_sum,
+    uint8_t* g_t, uint8_t* beta_t, uint8_t* A, uint8_t* A_inv_f32,
+    uint8_t* A_inv, uint8_t* w, uint8_t* u, uint8_t* s, uint8_t* v_new,
+    uint8_t* fs, uint8_t* h0, int64_t has_initial_state, uint8_t* kkt_ws,
+    uint8_t* wy_ws_a1, uint8_t* wy_ws_a2, uint8_t* h_ws, uint8_t* o_ws_qk,
+    uint8_t* o_ws_qs, uint8_t* o_ws_gated, uint32_t num_heads,
+    uint32_t num_key_heads, int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens, uint32_t num_matrices) {
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  launch_mega_kernel<<<block_dim, nullptr, stream>>>(
+      q, k, v, g_in, beta, msk_lower, msk_full, minus_id, cu_seqlens, o, g_sum,
+      g_t, beta_t, A, A_inv_f32, A_inv, w, u, s, v_new, fs, h0,
+      has_initial_state, kkt_ws, wy_ws_a1, wy_ws_a2, h_ws, o_ws_qk, o_ws_qs,
+      o_ws_gated, num_heads, num_key_heads, batch_size, seq_len, total_tokens,
+      num_matrices, fftsAddr);
 }

--- a/kernels/pto/mega_kernel.cpp
+++ b/kernels/pto/mega_kernel.cpp
@@ -42,39 +42,6 @@ using namespace kernel_utils;
 // ===================================================================
 #ifdef __CCE_AICORE__
 
-constexpr uint16_t SYNC_AIV_FLAG = 12;
-constexpr uint16_t SYNC_AIC_FLAG = 11;
-constexpr uint16_t SYNC_AIC_AIV_FLAG = 13;
-constexpr uint16_t SYNC_AIV_ONLY_ALL = 14;
-constexpr uint16_t SYNC_MODE_SHIFT_VALUE = 4;
-constexpr uint16_t SYNC_FLAG_SHIFT_VALUE = 8;
-
-AICORE inline uint16_t GetffstMsg(uint16_t mode, uint16_t flagId)
-{
-    return (0x1 + ((mode & 0x3) << SYNC_MODE_SHIFT_VALUE) +
-            ((flagId & 0xf) << SYNC_FLAG_SHIFT_VALUE));
-}
-
-template <bool isAIVOnly = true>
-AICORE inline void SyncAllImpl()
-{
-    pipe_barrier(PIPE_ALL);
-    if constexpr (isAIVOnly) {
-        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, SYNC_AIV_ONLY_ALL));
-        wait_flag_dev(SYNC_AIV_ONLY_ALL);
-        return;
-    }
-#if defined(__DAV_CUBE__)
-    wait_flag_dev(SYNC_AIV_FLAG);
-    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, SYNC_AIC_FLAG));
-    wait_flag_dev(SYNC_AIC_FLAG);
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIC_AIV_FLAG));
-#elif defined(__DAV_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIV_FLAG));
-    wait_flag_dev(SYNC_AIC_AIV_FLAG);
-#endif
-}
-
 template <typename T>
 AICORE void mega_transpose_TH_to_HT(
     __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
@@ -352,7 +319,7 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_SYNC1
     return;
@@ -372,7 +339,7 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     mk_kkt::kkt_kernel<D, C>(
         reinterpret_cast<__gm__ half *>(k_ptr),
@@ -385,10 +352,21 @@ AICORE inline void mega_kernel_impl(
         batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
         num_key_heads, ffts_addr);
 
+// Drain the kkt handshake: Vec released both workspace slots (flags 2/3) one
+// last time after Cube's final iteration, so consume them before the next stage.
+// A2: Vec is a separate core → FFTS cross-core flag.
+// A5: both Vec sub-blocks share Cube's core → each signals its own intra-block
+//     flag (base, base + 16).
 #if defined(__DAV_CUBE__)
     pipe_barrier(PIPE_ALL);
+#if __CCE_AICORE__ == 220
     wait_flag_dev(2);
     wait_flag_dev(3);
+#else
+    WaitBothVecOnA5<PIPE_MTE2>(2);
+    WaitBothVecOnA5<PIPE_MTE2>(3);
+    pipe_barrier(PIPE_ALL);
+#endif
 #endif
 
 #ifdef MEGA_STOP_AFTER_KKT
@@ -396,7 +374,7 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     mega_solve_tril(
         reinterpret_cast<__gm__ half *>(A_inv_ptr),
@@ -410,14 +388,14 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_CAST
     pipe_barrier(PIPE_ALL);
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_SYNC_BEFORE_WY
     return;
@@ -437,11 +415,21 @@ AICORE inline void mega_kernel_impl(
         batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
         num_key_heads, ffts_addr);
 
+// Drain the wy_fast handshake: Cube freed the A2/A1 slots (flags 3/4) one last
+// time after Vec's final iteration.
+// A5: Cube signalled both sub-blocks (base, base + 16); each sub-block waits on
+//     its own flag, so a plain intra-block wait is what mirrors the signal.
 #if defined(__DAV_VEC__)
     if (get_block_idx() < num_matrices) {
         pipe_barrier(PIPE_ALL);
+#if __CCE_AICORE__ == 220
         wait_flag_dev(3);
         wait_flag_dev(4);
+#else
+        wait_intra_block(PIPE_MTE3, 3);
+        wait_intra_block(PIPE_MTE3, 4);
+        pipe_barrier(PIPE_ALL);
+#endif
     }
 #endif
 
@@ -450,7 +438,7 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     mk_h::chunk_h_kernel<D, C>(
         reinterpret_cast<__gm__ half *>(k_ptr),
@@ -473,7 +461,7 @@ AICORE inline void mega_kernel_impl(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     mk_o::chunk_o_kernel<D, C>(
         reinterpret_cast<__gm__ half *>(q_ptr),
@@ -490,10 +478,17 @@ AICORE inline void mega_kernel_impl(
         batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
         num_key_heads, ffts_addr);
 
+// Drain the chunk_o handshake: Vec's final "workspace free" (flag 3) is never
+// consumed by Cube's loop, so consume it here.
 #if defined(__DAV_CUBE__)
     if (get_block_idx() < num_matrices) {
         pipe_barrier(PIPE_ALL);
+#if __CCE_AICORE__ == 220
         wait_flag_dev(3);
+#else
+        WaitBothVecOnA5<PIPE_MTE2>(3);
+        pipe_barrier(PIPE_ALL);
+#endif
     }
 #endif
 }

--- a/kernels/pto/mega_kernel_kda.cpp
+++ b/kernels/pto/mega_kernel_kda.cpp
@@ -85,6 +85,9 @@ template <typename T, int32_t KD>
 AICORE void mega_permute_THK_to_HTK(
     __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t HV)
 {
+    // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
+    using pto::Stride;
+
 #if defined(__DAV_VEC__)
     if (get_subblockid() != 0)
         return;

--- a/kernels/pto/mega_kernel_kda.cpp
+++ b/kernels/pto/mega_kernel_kda.cpp
@@ -2,7 +2,7 @@
 //
 // Fuses the six KDA stages into a single NPU launch, modelled on the GDN mega_kernel.cpp.
 // Sub-kernels are reused verbatim via namespaced #include (the `call_kernel` macro trick),
-// and their templated device functions are invoked in sequence with SyncAllImpl<false>()
+// and their templated device functions are invoked in sequence with SyncAllMegaKernel<false>()
 // barriers between stages.
 //
 // Stages:
@@ -40,49 +40,12 @@ using namespace kernel_utils;
 // ===================================================================
 #ifdef __CCE_AICORE__
 
-constexpr uint16_t SYNC_AIV_FLAG = 12;
-constexpr uint16_t SYNC_AIC_FLAG = 11;
-constexpr uint16_t SYNC_AIC_AIV_FLAG = 13;
-constexpr uint16_t SYNC_AIV_ONLY_ALL = 14;
-constexpr uint16_t SYNC_MODE_SHIFT_VALUE = 4;
-constexpr uint16_t SYNC_FLAG_SHIFT_VALUE = 8;
-
-AICORE inline uint16_t GetffstMsg(uint16_t mode, uint16_t flagId)
-{
-    return (0x1 + ((mode & 0x3) << SYNC_MODE_SHIFT_VALUE) +
-            ((flagId & 0xf) << SYNC_FLAG_SHIFT_VALUE));
-}
-
-// Full Cube+Vec all-core barrier.  Uses FFTS flags 11-14, distinct from the sub-kernels'
-// internal sync flags (6-9), so a sub-kernel's exit-sync immediately followed by this
-// barrier never reuses the same flag back-to-back.
-template <bool isAIVOnly = true>
-AICORE inline void SyncAllImpl()
-{
-    pipe_barrier(PIPE_ALL);
-    if constexpr (isAIVOnly)
-    {
-        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, SYNC_AIV_ONLY_ALL));
-        wait_flag_dev(SYNC_AIV_ONLY_ALL);
-        return;
-    }
-#if defined(__DAV_CUBE__)
-    wait_flag_dev(SYNC_AIV_FLAG);
-    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, SYNC_AIC_FLAG));
-    wait_flag_dev(SYNC_AIC_FLAG);
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIC_AIV_FLAG));
-#elif defined(__DAV_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIV_FLAG));
-    wait_flag_dev(SYNC_AIC_AIV_FLAG);
-#endif
-}
-
 // Strided GM->GM copy reordering a per-dimension tensor from BSND [T,HV,K] to head-major
 // [HV,T,K].  K stays innermost-contiguous; only the (T,HV) axes swap, so this is a pure
 // gather/scatter of K-contiguous rows (no element transpose).  Layout-only — independent
 // of cu_seqlens.
 template <typename T, int32_t KD>
-AICORE void mega_permute_THK_to_HTK(
+AICORE inline void mega_permute_THK_to_HTK(
     __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t HV)
 {
     // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
@@ -278,7 +241,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     // ── Stage 2: transpose g_sum -> head-major g_cs ──────────────────
     mega_permute_THK_to_HTK<float, KD>(
@@ -291,7 +254,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     // ── Stage 3: kkt (gated K·K^T lower-tri matrix) ──────────────────
     mk_kkt::kkt_kda_kernel<KD, C>(
@@ -310,7 +273,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     // ── Stage 4: solve_tril ((I + L)^{-1}) ───────────────────────────
     mega_solve_tril(
@@ -325,7 +288,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     // ── Stage 5: wy (auxiliaries u, w) ───────────────────────────────
     mk_wy::wy_kda_kernel<KD, C>(
@@ -346,7 +309,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     // ── Stage 6: chunk_h (state snapshots + v_corr) ──────────────────
     mk_h::chunk_h_kda_kernel<KD, C>(
@@ -365,7 +328,7 @@ extern "C" __global__ AICORE void launch_mega_kernel_kda(
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     // ── Stage 7: chunk_o (output) ────────────────────────────────────
     mk_o::chunk_o_kda_kernel<KD, C>(

--- a/kernels/pto/mega_kernel_kda.cpp
+++ b/kernels/pto/mega_kernel_kda.cpp
@@ -1,23 +1,27 @@
-// mega_kernel_kda.cpp — KDA (Kimi Delta Attention) Mega-Kernel: all PTO stages in one launch
+// mega_kernel_kda.cpp — KDA (Kimi Delta Attention) Mega-Kernel: all PTO stages
+// in one launch
 //
-// Fuses the six KDA stages into a single NPU launch, modelled on the GDN mega_kernel.cpp.
-// Sub-kernels are reused verbatim via namespaced #include (the `call_kernel` macro trick),
-// and their templated device functions are invoked in sequence with SyncAllMegaKernel<false>()
-// barriers between stages.
+// Fuses the six KDA stages into a single NPU launch, modelled on the GDN
+// mega_kernel.cpp. Sub-kernels are reused verbatim via namespaced #include (the
+// `call_kernel` macro trick), and their templated device functions are invoked
+// in sequence with SyncAllMegaKernel<false>() barriers between stages.
 //
 // Stages:
 //   1. gate_cumsum (Vec)             — within-chunk prefix sum of g  [B,T,HV,K]
-//   2. transpose   (Vec)             — g_sum BSND [T,HV,K] -> head-major [HV,T,K]
+//   2. transpose   (Vec)             — g_sum BSND [T,HV,K] -> head-major
+//   [HV,T,K]
 //   3. kkt         (Cube+Vec)        — gated K·K^T lower-tri matrix L
-//   4. solve_tril  (Cube)            — (I + L)^{-1}  (shared tri_inverse kernel)
+//   4. solve_tril  (Cube)            — (I + L)^{-1}  (shared tri_inverse
+//   kernel)
 //   5. wy          (Vec+Cube)        — WY auxiliaries u, w
 //   6. chunk_h     (Cube+Vec)        — recurrent state snapshots + v_corr
 //   7. chunk_o     (Cube+Vec)        — output
 //
-// KDA difference from GDN: gates are per-dimension [B,T,HV,K] (not scalar [B,T,H]), and
-// the sub-kernels read k/q/g_cs in head-major [HV,T,K] layout (beta in [HV,T]).  Static
-// inputs (q, k, beta) are permuted to head-major in Python; only g_sum — produced inside
-// the kernel by gate_cumsum — is transposed on-device here.
+// KDA difference from GDN: gates are per-dimension [B,T,HV,K] (not scalar
+// [B,T,H]), and the sub-kernels read k/q/g_cs in head-major [HV,T,K] layout
+// (beta in [HV,T]).  Static inputs (q, k, beta) are permuted to head-major in
+// Python; only g_sum — produced inside the kernel by gate_cumsum — is
+// transposed on-device here.
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -26,10 +30,12 @@
 #define GDN_C 128
 #endif
 
-#include <pto/pto-inst.hpp>
-#include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+
+#include <pto/pto-inst.hpp>
 #include <type_traits>
+
+#include "acl/acl.h"
 #include "kernel_utils.h"
 
 using namespace pto;
@@ -40,78 +46,76 @@ using namespace kernel_utils;
 // ===================================================================
 #ifdef __CCE_AICORE__
 
-// Strided GM->GM copy reordering a per-dimension tensor from BSND [T,HV,K] to head-major
-// [HV,T,K].  K stays innermost-contiguous; only the (T,HV) axes swap, so this is a pure
-// gather/scatter of K-contiguous rows (no element transpose).  Layout-only — independent
-// of cu_seqlens.
+// Strided GM->GM copy reordering a per-dimension tensor from BSND [T,HV,K] to
+// head-major [HV,T,K].  K stays innermost-contiguous; only the (T,HV) axes
+// swap, so this is a pure gather/scatter of K-contiguous rows (no element
+// transpose).  Layout-only — independent of cu_seqlens.
 template <typename T, int32_t KD>
-AICORE inline void mega_permute_THK_to_HTK(
-    __gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t HV)
-{
-    // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
-    using pto::Stride;
+AICORE inline void mega_permute_THK_to_HTK(__gm__ T* src, __gm__ T* dst,
+                                           int64_t T_len, int32_t HV) {
+  // To avoid ambiguity with bisheng intrinsic header's global `enum class
+  // Stride`
+  using pto::Stride;
 
 #if defined(__DAV_VEC__)
-    if (get_subblockid() != 0)
-        return;
-    set_mask_norm();
-    set_vector_mask(-1, -1);
+  if (get_subblockid() != 0) return;
+  set_mask_norm();
+  set_vector_mask(-1, -1);
 
-    auto cid = get_block_idx();
-    auto block_num = get_block_num();
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
 
-    constexpr int32_t BLOCK = 128; // tokens per UB tile
-    constexpr int32_t UB0 = 0;
+  constexpr int32_t BLOCK = 128;  // tokens per UB tile
+  constexpr int32_t UB0 = 0;
 
-    using UBTileDyn = Tile<TileType::Vec, T, BLOCK, KD, BLayout::RowMajor,
-                           DYNAMIC, DYNAMIC, SLayout::NoneBox, 512, PadValue::Zero>;
-    using Gm2D = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-    using GmSrcS = Stride<1, 1, 1, DYNAMIC, 1>; // row stride = HV*K (runtime; skip other heads)
-    using GmDstS = Stride<1, 1, 1, KD, 1>;      // contiguous
-    GmSrcS src_stride(HV * KD);
+  using UBTileDyn =
+      Tile<TileType::Vec, T, BLOCK, KD, BLayout::RowMajor, DYNAMIC, DYNAMIC,
+           SLayout::NoneBox, 512, PadValue::Zero>;
+  using Gm2D = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GmSrcS = Stride<1, 1, 1, DYNAMIC,
+                        1>;  // row stride = HV*K (runtime; skip other heads)
+  using GmDstS = Stride<1, 1, 1, KD, 1>;  // contiguous
+  GmSrcS src_stride(HV * KD);
 
-    int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
-    int64_t total = static_cast<int64_t>(HV) * num_tok_blocks;
+  int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
+  int64_t total = static_cast<int64_t>(HV) * num_tok_blocks;
 
-    for (int64_t wi = static_cast<int64_t>(cid); wi < total;
-         wi += static_cast<int64_t>(block_num))
+  for (int64_t wi = static_cast<int64_t>(cid); wi < total;
+       wi += static_cast<int64_t>(block_num)) {
+    int64_t h = wi / num_tok_blocks;
+    int64_t bi = wi % num_tok_blocks;
+    int64_t t0 = bi * BLOCK;
+    int32_t valid =
+        (t0 + BLOCK <= T_len) ? BLOCK : static_cast<int32_t>(T_len - t0);
+
     {
-        int64_t h = wi / num_tok_blocks;
-        int64_t bi = wi % num_tok_blocks;
-        int64_t t0 = bi * BLOCK;
-        int32_t valid = (t0 + BLOCK <= T_len)
-                            ? BLOCK
-                            : static_cast<int32_t>(T_len - t0);
-
-        {
-            Gm2D gs;
-            gs.shape[3] = valid;
-            gs.shape[4] = KD;
-            GlobalTensor<T, Gm2D, GmSrcS> gm(
-                src + (t0 * static_cast<int64_t>(HV) + h) * KD, gs, src_stride);
-            UBTileDyn ld(valid, KD);
-            TASSIGN(ld, UB0);
-            TLOAD(ld, gm);
-        }
-        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        {
-            Gm2D gs;
-            gs.shape[3] = valid;
-            gs.shape[4] = KD;
-            GlobalTensor<T, Gm2D, GmDstS> gm(
-                dst + (h * T_len + t0) * KD, gs);
-            UBTileDyn st(valid, KD);
-            TASSIGN(st, UB0);
-            TSTORE(gm, st);
-        }
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+      Gm2D gs;
+      gs.shape[3] = valid;
+      gs.shape[4] = KD;
+      GlobalTensor<T, Gm2D, GmSrcS> gm(
+          src + (t0 * static_cast<int64_t>(HV) + h) * KD, gs, src_stride);
+      UBTileDyn ld(valid, KD);
+      TASSIGN(ld, UB0);
+      TLOAD(ld, gm);
     }
+    set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    {
+      Gm2D gs;
+      gs.shape[3] = valid;
+      gs.shape[4] = KD;
+      GlobalTensor<T, Gm2D, GmDstS> gm(dst + (h * T_len + t0) * KD, gs);
+      UBTileDyn st(valid, KD);
+      TASSIGN(st, UB0);
+      TSTORE(gm, st);
+    }
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+  }
 #endif
 }
 
-#endif // __CCE_AICORE__
+#endif  // __CCE_AICORE__
 
 // ===================================================================
 // Include original KDA sub-kernel implementations in separate namespaces.
@@ -120,64 +124,53 @@ AICORE inline void mega_permute_THK_to_HTK(
 // ===================================================================
 
 #define call_kernel _mk_unused_kda_gc
-namespace mk_gc
-{
+namespace mk_gc {
 #include "gate_cumsum_kda.cpp"
 }
 #undef call_kernel
 
 #define call_kernel _mk_unused_kda_kkt
-namespace mk_kkt
-{
+namespace mk_kkt {
 #include "kkt_kda.cpp"
 }
 #undef call_kernel
 
-namespace mk_solve
-{
+namespace mk_solve {
 #include "tri_inverse_impl.cpp"
 }
 
 #define call_kernel _mk_unused_kda_wy
-namespace mk_wy
-{
+namespace mk_wy {
 #include "wy_kda.cpp"
 }
 #undef call_kernel
 
 #define call_kernel _mk_unused_kda_h
-namespace mk_h
-{
+namespace mk_h {
 #include "chunk_h_kda.cpp"
 }
 #undef call_kernel
 
 #define call_kernel _mk_unused_kda_o
-namespace mk_o
-{
+namespace mk_o {
 #include "chunk_o_kda.cpp"
 }
 #undef call_kernel
 
 // Shared triangular-inverse dispatch (identical to GDN mega_kernel.cpp).
-AICORE void mega_solve_tril(
-    __gm__ half *out, __gm__ half *in, __gm__ half *minus_id,
-    uint32_t matrix_size, uint32_t num_matrices,
-    uint32_t num_bsnd_heads,
-    __gm__ int32_t *cu_seqlens, uint32_t is_lower)
-{
-    if (num_matrices <= get_block_num())
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 1, true, half>(
-            out, in, minus_id, num_matrices,
-            num_bsnd_heads, cu_seqlens, is_lower);
-    else if (num_matrices <= 2u * get_block_num())
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 2, true, half>(
-            out, in, minus_id, num_matrices,
-            num_bsnd_heads, cu_seqlens, is_lower);
-    else
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 4, true, half>(
-            out, in, minus_id, num_matrices,
-            num_bsnd_heads, cu_seqlens, is_lower);
+AICORE void mega_solve_tril(__gm__ half* out, __gm__ half* in,
+                            __gm__ half* minus_id, uint32_t matrix_size,
+                            uint32_t num_matrices, uint32_t num_bsnd_heads,
+                            __gm__ int32_t* cu_seqlens, uint32_t is_lower) {
+  if (num_matrices <= get_block_num())
+    mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 1, true>(
+        out, in, minus_id, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+  else if (num_matrices <= 2u * get_block_num())
+    mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 2, true>(
+        out, in, minus_id, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+  else
+    mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 4, true>(
+        out, in, minus_id, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
 }
 
 // ===================================================================
@@ -185,186 +178,172 @@ AICORE void mega_solve_tril(
 // ===================================================================
 extern "C" __global__ AICORE void launch_mega_kernel_kda(
     // ── inputs ──────────────────────────────────────────────────────
-    __gm__ uint8_t *q_hm_ptr,    // [1, HV, T, K] fp16 (head-major, scaled)
-    __gm__ uint8_t *k_hm_ptr,    // [1, HV, T, K] fp16 (head-major)
-    __gm__ uint8_t *v_ptr,       // [1, T, HV, V] fp16 (BSND)
-    __gm__ uint8_t *g_in_ptr,    // [1, T, HV, K] fp16 (BSND, raw gate)
-    __gm__ uint8_t *beta_hm_ptr, // [1, HV, T]    fp16 (head-major)
+    __gm__ uint8_t* q_hm_ptr,     // [1, HV, T, K] fp16 (head-major, scaled)
+    __gm__ uint8_t* k_hm_ptr,     // [1, HV, T, K] fp16 (head-major)
+    __gm__ uint8_t* v_ptr,        // [1, T, HV, V] fp16 (BSND)
+    __gm__ uint8_t* g_in_ptr,     // [1, T, HV, K] fp16 (BSND, raw gate)
+    __gm__ uint8_t* beta_hm_ptr,  // [1, HV, T]    fp16 (head-major)
     // ── masks / constants ───────────────────────────────────────────
-    __gm__ uint8_t *mask_strict_ptr, // [C, C] fp32 (rows >  cols)
-    __gm__ uint8_t *mask_incl_ptr,   // [C, C] fp32 (rows >= cols)
-    __gm__ uint8_t *minus_id_ptr,    // [C, C] fp16 (-I)
-    __gm__ uint8_t *cu_seqlens_ptr,  // int32
+    __gm__ uint8_t* mask_strict_ptr,  // [C, C] fp32 (rows >  cols)
+    __gm__ uint8_t* mask_incl_ptr,    // [C, C] fp32 (rows >= cols)
+    __gm__ uint8_t* minus_id_ptr,     // [C, C] fp16 (-I)
+    __gm__ uint8_t* cu_seqlens_ptr,   // int32
     // ── output ──────────────────────────────────────────────────────
-    __gm__ uint8_t *o_ptr, // [1, T, HV, V] fp16 (BSND)
+    __gm__ uint8_t* o_ptr,  // [1, T, HV, V] fp16 (BSND)
     // ── intermediate buffers ────────────────────────────────────────
-    __gm__ uint8_t *g_sum_ptr,   // [1, T, HV, K] fp32 (BSND)
-    __gm__ uint8_t *g_cs_hm_ptr, // [1, HV, T, K] fp32 (head-major)
-    __gm__ uint8_t *L_ptr,       // [1, T, HV, C] fp16
-    __gm__ uint8_t *A_inv_ptr,   // [1, T, HV, C] fp16
-    __gm__ uint8_t *u_ptr,       // [1, T, HV, V] fp16
-    __gm__ uint8_t *w_ptr,       // [1, T, HV, K] fp16
-    __gm__ uint8_t *s_ptr,       // [tc, HV, K, V] fp16
-    __gm__ uint8_t *v_corr_ptr,  // [1, T, HV, V] fp16
+    __gm__ uint8_t* g_sum_ptr,    // [1, T, HV, K] fp32 (BSND)
+    __gm__ uint8_t* g_cs_hm_ptr,  // [1, HV, T, K] fp32 (head-major)
+    __gm__ uint8_t* L_ptr,        // [1, T, HV, C] fp16
+    __gm__ uint8_t* A_inv_ptr,    // [1, T, HV, C] fp16
+    __gm__ uint8_t* u_ptr,        // [1, T, HV, V] fp16
+    __gm__ uint8_t* w_ptr,        // [1, T, HV, K] fp16
+    __gm__ uint8_t* s_ptr,        // [tc, HV, K, V] fp16
+    __gm__ uint8_t* v_corr_ptr,   // [1, T, HV, V] fp16
     // ── per-core workspaces ─────────────────────────────────────────
-    __gm__ uint8_t *kkt_ws_in_ptr,  // [bd*2, 2C, K] fp32 (stages exp(±g_cs))
-    __gm__ uint8_t *kkt_ws_out_ptr, // [bd*2, C, C]  fp32 (unmasked gated K·K^T)
-    __gm__ uint8_t *wy_ws_a2_ptr,   // [bd, C, C]    fp16
-    __gm__ uint8_t *wy_ws_keff_ptr, // [bd, C, K]    fp16
-    __gm__ uint8_t *h_ws_ptr,       // [bd*5, K, K]  fp16
-    __gm__ uint8_t *o_ws_ptr,       // [bd*7, K, K]  fp32 (gated q/k + GEMM I/O)
+    __gm__ uint8_t* kkt_ws_in_ptr,  // [bd*2, 2C, K] fp32 (stages exp(±g_cs))
+    __gm__ uint8_t*
+        kkt_ws_out_ptr,            // [bd*2, C, C]  fp32 (unmasked gated K·K^T)
+    __gm__ uint8_t* wy_ws_a2_ptr,  // [bd, C, C]    fp16
+    __gm__ uint8_t* wy_ws_keff_ptr,  // [bd, C, K]    fp16
+    __gm__ uint8_t* h_ws_ptr,        // [bd*5, K, K]  fp16
+    __gm__ uint8_t* o_ws_ptr,  // [bd*7, K, K]  fp32 (gated q/k + GEMM I/O)
     // ── scalars ─────────────────────────────────────────────────────
-    int64_t batch_size,
-    int64_t seq_len,
-    int64_t total_tokens,
-    uint32_t num_matrices,
-    int32_t num_heads,
-    uint64_t ffts_addr)
-{
-    set_ffts_base_addr(ffts_addr);
+    int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+    uint32_t num_matrices, int32_t num_heads, uint64_t ffts_addr) {
+  set_ffts_base_addr(ffts_addr);
 
-    // Head count (HV) is a runtime argument; only GDN_D (K) and GDN_C (C) stay
-    // compile-time, so the fused .so is head-count-agnostic like the staged ones.
-    const int32_t HV = num_heads;
-    constexpr int32_t KD = GDN_D;
-    constexpr int32_t C = GDN_C;
+  // Head count (HV) is a runtime argument; only GDN_D (K) and GDN_C (C) stay
+  // compile-time, so the fused .so is head-count-agnostic like the staged ones.
+  const int32_t HV = num_heads;
+  constexpr int32_t KD = GDN_D;
+  constexpr int32_t C = GDN_C;
 
-    // ── Stage 1: gate_cumsum (BSND -> BSND) ──────────────────────────
-    mk_gc::gate_cumsum_kda_kernel<KD, C>(
-        reinterpret_cast<__gm__ half *>(g_in_ptr),
-        reinterpret_cast<__gm__ float *>(g_sum_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, HV, ffts_addr);
+  // ── Stage 1: gate_cumsum (BSND -> BSND) ──────────────────────────
+  mk_gc::gate_cumsum_kda_kernel<KD, C>(
+      reinterpret_cast<__gm__ half*>(g_in_ptr),
+      reinterpret_cast<__gm__ float*>(g_sum_ptr),
+      reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), batch_size, seq_len,
+      HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_CUMSUM
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    // ── Stage 2: transpose g_sum -> head-major g_cs ──────────────────
-    mega_permute_THK_to_HTK<float, KD>(
-        reinterpret_cast<__gm__ float *>(g_sum_ptr),
-        reinterpret_cast<__gm__ float *>(g_cs_hm_ptr),
-        total_tokens, HV);
+  // ── Stage 2: transpose g_sum -> head-major g_cs ──────────────────
+  mega_permute_THK_to_HTK<float, KD>(
+      reinterpret_cast<__gm__ float*>(g_sum_ptr),
+      reinterpret_cast<__gm__ float*>(g_cs_hm_ptr), total_tokens, HV);
 
 #ifdef MEGA_STOP_AFTER_TRANSPOSE
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    // ── Stage 3: kkt (gated K·K^T lower-tri matrix) ──────────────────
-    mk_kkt::kkt_kda_kernel<KD, C>(
-        reinterpret_cast<__gm__ half *>(k_hm_ptr),
-        reinterpret_cast<__gm__ float *>(g_cs_hm_ptr),
-        reinterpret_cast<__gm__ half *>(beta_hm_ptr),
-        reinterpret_cast<__gm__ float *>(mask_strict_ptr),
-        reinterpret_cast<__gm__ float *>(kkt_ws_in_ptr),
-        reinterpret_cast<__gm__ float *>(kkt_ws_out_ptr),
-        reinterpret_cast<__gm__ half *>(L_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, HV, ffts_addr);
+  // ── Stage 3: kkt (gated K·K^T lower-tri matrix) ──────────────────
+  mk_kkt::kkt_kda_kernel<KD, C>(
+      reinterpret_cast<__gm__ half*>(k_hm_ptr),
+      reinterpret_cast<__gm__ float*>(g_cs_hm_ptr),
+      reinterpret_cast<__gm__ half*>(beta_hm_ptr),
+      reinterpret_cast<__gm__ float*>(mask_strict_ptr),
+      reinterpret_cast<__gm__ float*>(kkt_ws_in_ptr),
+      reinterpret_cast<__gm__ float*>(kkt_ws_out_ptr),
+      reinterpret_cast<__gm__ half*>(L_ptr),
+      reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), batch_size, seq_len,
+      total_tokens, HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_KKT
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    // ── Stage 4: solve_tril ((I + L)^{-1}) ───────────────────────────
-    mega_solve_tril(
-        reinterpret_cast<__gm__ half *>(A_inv_ptr),
-        reinterpret_cast<__gm__ half *>(L_ptr),
-        reinterpret_cast<__gm__ half *>(minus_id_ptr),
-        C, num_matrices, HV,
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), 1);
+  // ── Stage 4: solve_tril ((I + L)^{-1}) ───────────────────────────
+  mega_solve_tril(reinterpret_cast<__gm__ half*>(A_inv_ptr),
+                  reinterpret_cast<__gm__ half*>(L_ptr),
+                  reinterpret_cast<__gm__ half*>(minus_id_ptr), C, num_matrices,
+                  HV, reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), 1);
 
 #ifdef MEGA_STOP_AFTER_SOLVE
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    // ── Stage 5: wy (auxiliaries u, w) ───────────────────────────────
-    mk_wy::wy_kda_kernel<KD, C>(
-        reinterpret_cast<__gm__ half *>(k_hm_ptr),
-        reinterpret_cast<__gm__ half *>(v_ptr),
-        reinterpret_cast<__gm__ half *>(beta_hm_ptr),
-        reinterpret_cast<__gm__ float *>(g_cs_hm_ptr),
-        reinterpret_cast<__gm__ half *>(A_inv_ptr),
-        reinterpret_cast<__gm__ half *>(wy_ws_a2_ptr),
-        reinterpret_cast<__gm__ half *>(wy_ws_keff_ptr),
-        reinterpret_cast<__gm__ half *>(u_ptr),
-        reinterpret_cast<__gm__ half *>(w_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, HV, ffts_addr);
+  // ── Stage 5: wy (auxiliaries u, w) ───────────────────────────────
+  mk_wy::wy_kda_kernel<KD, C>(reinterpret_cast<__gm__ half*>(k_hm_ptr),
+                              reinterpret_cast<__gm__ half*>(v_ptr),
+                              reinterpret_cast<__gm__ half*>(beta_hm_ptr),
+                              reinterpret_cast<__gm__ float*>(g_cs_hm_ptr),
+                              reinterpret_cast<__gm__ half*>(A_inv_ptr),
+                              reinterpret_cast<__gm__ half*>(wy_ws_a2_ptr),
+                              reinterpret_cast<__gm__ half*>(wy_ws_keff_ptr),
+                              reinterpret_cast<__gm__ half*>(u_ptr),
+                              reinterpret_cast<__gm__ half*>(w_ptr),
+                              reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr),
+                              batch_size, seq_len, total_tokens, HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_WY
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    // ── Stage 6: chunk_h (state snapshots + v_corr) ──────────────────
-    mk_h::chunk_h_kda_kernel<KD, C>(
-        reinterpret_cast<__gm__ half *>(k_hm_ptr),
-        reinterpret_cast<__gm__ half *>(w_ptr),
-        reinterpret_cast<__gm__ half *>(u_ptr),
-        reinterpret_cast<__gm__ float *>(g_cs_hm_ptr),
-        reinterpret_cast<__gm__ half *>(s_ptr),
-        reinterpret_cast<__gm__ half *>(v_corr_ptr),
-        reinterpret_cast<__gm__ half *>(h_ws_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, HV, ffts_addr);
+  // ── Stage 6: chunk_h (state snapshots + v_corr) ──────────────────
+  mk_h::chunk_h_kda_kernel<KD, C>(
+      reinterpret_cast<__gm__ half*>(k_hm_ptr),
+      reinterpret_cast<__gm__ half*>(w_ptr),
+      reinterpret_cast<__gm__ half*>(u_ptr),
+      reinterpret_cast<__gm__ float*>(g_cs_hm_ptr),
+      reinterpret_cast<__gm__ half*>(s_ptr),
+      reinterpret_cast<__gm__ half*>(v_corr_ptr),
+      reinterpret_cast<__gm__ half*>(h_ws_ptr),
+      reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), batch_size, seq_len,
+      total_tokens, HV, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_H
-    pipe_barrier(PIPE_ALL);
-    return;
+  pipe_barrier(PIPE_ALL);
+  return;
 #endif
 
-    SyncAllMegaKernel<false>();
+  SyncAllMegaKernel<false>();
 
-    // ── Stage 7: chunk_o (output) ────────────────────────────────────
-    mk_o::chunk_o_kda_kernel<KD, C>(
-        reinterpret_cast<__gm__ half *>(q_hm_ptr),
-        reinterpret_cast<__gm__ half *>(k_hm_ptr),
-        reinterpret_cast<__gm__ half *>(v_corr_ptr),
-        reinterpret_cast<__gm__ half *>(s_ptr),
-        reinterpret_cast<__gm__ float *>(g_cs_hm_ptr),
-        reinterpret_cast<__gm__ float *>(mask_incl_ptr),
-        reinterpret_cast<__gm__ float *>(o_ws_ptr),
-        reinterpret_cast<__gm__ half *>(o_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr),
-        batch_size, seq_len, total_tokens, HV, ffts_addr);
+  // ── Stage 7: chunk_o (output) ────────────────────────────────────
+  mk_o::chunk_o_kda_kernel<KD, C>(
+      reinterpret_cast<__gm__ half*>(q_hm_ptr),
+      reinterpret_cast<__gm__ half*>(k_hm_ptr),
+      reinterpret_cast<__gm__ half*>(v_corr_ptr),
+      reinterpret_cast<__gm__ half*>(s_ptr),
+      reinterpret_cast<__gm__ float*>(g_cs_hm_ptr),
+      reinterpret_cast<__gm__ float*>(mask_incl_ptr),
+      reinterpret_cast<__gm__ float*>(o_ws_ptr),
+      reinterpret_cast<__gm__ half*>(o_ptr),
+      reinterpret_cast<__gm__ int32_t*>(cu_seqlens_ptr), batch_size, seq_len,
+      total_tokens, HV, ffts_addr);
 }
 
 extern "C" void call_kernel(
-    uint32_t block_dim, void *stream,
-    uint8_t *q_hm, uint8_t *k_hm, uint8_t *v, uint8_t *g_in, uint8_t *beta_hm,
-    uint8_t *mask_strict, uint8_t *mask_incl, uint8_t *minus_id, uint8_t *cu_seqlens,
-    uint8_t *o,
-    uint8_t *g_sum, uint8_t *g_cs_hm, uint8_t *L, uint8_t *A_inv,
-    uint8_t *u, uint8_t *w, uint8_t *s, uint8_t *v_corr,
-    uint8_t *kkt_ws_in, uint8_t *kkt_ws_out, uint8_t *wy_ws_a2, uint8_t *wy_ws_keff,
-    uint8_t *h_ws, uint8_t *o_ws,
+    uint32_t block_dim, void* stream, uint8_t* q_hm, uint8_t* k_hm, uint8_t* v,
+    uint8_t* g_in, uint8_t* beta_hm, uint8_t* mask_strict, uint8_t* mask_incl,
+    uint8_t* minus_id, uint8_t* cu_seqlens, uint8_t* o, uint8_t* g_sum,
+    uint8_t* g_cs_hm, uint8_t* L, uint8_t* A_inv, uint8_t* u, uint8_t* w,
+    uint8_t* s, uint8_t* v_corr, uint8_t* kkt_ws_in, uint8_t* kkt_ws_out,
+    uint8_t* wy_ws_a2, uint8_t* wy_ws_keff, uint8_t* h_ws, uint8_t* o_ws,
     int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-    uint32_t num_matrices, uint32_t num_heads)
-{
-    uint32_t fftsLen{0};
-    uint64_t fftsAddr{0};
-    rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
-    launch_mega_kernel_kda<<<block_dim, nullptr, stream>>>(
-        q_hm, k_hm, v, g_in, beta_hm,
-        mask_strict, mask_incl, minus_id, cu_seqlens,
-        o,
-        g_sum, g_cs_hm, L, A_inv, u, w, s, v_corr,
-        kkt_ws_in, kkt_ws_out, wy_ws_a2, wy_ws_keff, h_ws, o_ws,
-        batch_size, seq_len, total_tokens, num_matrices,
-        static_cast<int32_t>(num_heads), fftsAddr);
+    uint32_t num_matrices, uint32_t num_heads) {
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  launch_mega_kernel_kda<<<block_dim, nullptr, stream>>>(
+      q_hm, k_hm, v, g_in, beta_hm, mask_strict, mask_incl, minus_id,
+      cu_seqlens, o, g_sum, g_cs_hm, L, A_inv, u, w, s, v_corr, kkt_ws_in,
+      kkt_ws_out, wy_ws_a2, wy_ws_keff, h_ws, o_ws, batch_size, seq_len,
+      total_tokens, num_matrices, static_cast<int32_t>(num_heads), fftsAddr);
 }

--- a/kernels/pto/scaled_dot_kkt.cpp
+++ b/kernels/pto/scaled_dot_kkt.cpp
@@ -136,7 +136,7 @@ using GmTensor2D = pto::GlobalTensor<T, GmShape2D, GmStride2D>;
 // __gm__: Marks pointers as Global Memory (HBM) — the NPU equivalent of
 // CUDA's device memory. All input/output tensors live in GM.
 template <int32_t HiddenSize, int32_t ChunkSize>
-AICORE void kkt_kernel(
+AICORE inline void kkt_kernel(
     __gm__ half *K_handle, __gm__ half *Beta_handle,
     __gm__ float *G_handle, __gm__ float *Msk_handle,
     __gm__ half *workspace_handle, __gm__ half *A_handle,
@@ -147,6 +147,8 @@ AICORE void kkt_kernel(
     uint32_t num_key_heads,
     uint64_t ffts_addr)
 {
+  // To avoid ambiguity with bisheng intrinsic header's global `enum class Stride`
+  using pto::Stride;
   constexpr int32_t HalfChunk = ChunkSize / 2;
   constexpr int32_t ChunkSquare = ChunkSize * ChunkSize;
   const int32_t H = static_cast<int32_t>(num_heads);

--- a/kernels/pto/tri_inverse_impl.cpp
+++ b/kernels/pto/tri_inverse_impl.cpp
@@ -65,7 +65,7 @@ AICORE inline BSNDVarlenTileInfo GetBSNDVarlenTileInfoFromCuSeqlens(
   }
 }
 
-/*
+/**
  * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.
  * The src matrix lies in L1, while the dst matrix lies either in L0A or L0B.
  * This kernel copies only the diagonal blocks (fractals) of size FractalSize *
@@ -104,7 +104,7 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
   }
 }
 
-/*
+/**
  * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each,
  * and an integer block_size. The src matrix lies in L1, while the dst matrix
  * either in L0A or L0B. This method copies some of the diagonal blocks from the
@@ -123,6 +123,10 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
  * @param src Tile in L1 memory.
  * @param dst Tile in L0A or L0B memory.
  * @param block_size Size of diagonal blocks. Needs: block_size >= FractalSize.
+ * @param swap_parity If true, then the parity of copied blocks is swapped: left
+ * tile gets odd blocks, while right tile gets even blocks. This is used in the
+ * unrolled recursion part of the algorithm, where we need to copy alternating
+ * blocks of X in each iteration.
  */
 template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
           typename SrcL1TileT, typename DstL0TileT>
@@ -135,9 +139,11 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
   constexpr BLayout OuterLayout = kernel_utils::GetOuterLayout(is_left);
-
+  // For left: copy even blocks 0, 2, 4, ... (starting_block=0)
+  // For right: copy odd blocks 1, 3, 5, ... (starting_block=1)
   // Default: left→even(0), right→odd(1). swap_parity flips this.
-  const uint32_t starting_block_index = (is_left ? 0u : 1u) ^ (swap_parity ? 1u : 0u);
+  const uint32_t starting_block_index =
+      (is_left ? 0u : 1u) ^ (swap_parity ? 1u : 0u);
 
   const uint32_t num_blocks = MatrixSize / block_size;
   const uint32_t num_fractals_per_block = block_size / FractalSize;
@@ -171,7 +177,7 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   }
 }
 
-/*
+/**
  * @brief: Prepares Identity and Zeros matrix.
  *
  * @tparam TileL1AB The type of the input tiles in L1.
@@ -218,7 +224,7 @@ AICORE inline void PrepareAuxiliaryMatrices(
   wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
 }
 
-/*
+/**
  * @brief: Inverts a single matrix / tile of the global tensor.
  * The first part of the algorithm inverts the FractalSize * FractalSize
  * diagonal blocks of the input matrix (inv_trick part). The second phase
@@ -244,6 +250,10 @@ AICORE inline void PrepareAuxiliaryMatrices(
  * @param b_l0_tile* Array of two tiles in L0B (for double-buffering).
  * @param c_l0_tile* Tile in L0C for matmuls.
  * @param tile_id Index of the current tile (used for sync).
+ * @param swap_parity If true, then the parity of copied blocks is swapped: left
+ * tile gets odd blocks, while right tile gets even blocks. This is used in the
+ * unrolled recursion part of the algorithm, where we need to copy alternating
+ * blocks of X in each iteration.
  */
 template <typename InputT, typename TileL1AB, typename TileL0A,
           typename TileL0B, typename TileL0C, uint32_t MatrixSize,
@@ -253,8 +263,7 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
                                     TileL1AB M_neg_l1_tile,
                                     TileL1AB Zero_l1_tile, TileL1AB Y_l1_tile,
                                     TileL0A* a_l0_tile, TileL0B* b_l0_tile,
-                                    TileL0C* c_l0_tile,
-                                    const uint32_t tile_id,
+                                    TileL0C* c_l0_tile, const uint32_t tile_id,
                                     const bool swap_parity = false) {
   const event_t event_0 = static_cast<event_t>(tile_id);
   const event_t event_1 = static_cast<event_t>(tile_id + NumTilesPerCubeIter);
@@ -392,6 +401,15 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
 
   /*
    * Unrolled recursion part:
+   * block_size = FractalSize
+   * while block_size < MatrixSize:
+   *     LX = even_blocks(X, block_size)
+   *     RX = odd_blocks(X, block_size)
+   *     Y = LX @ (-M) + I
+   *     X = Y @ RX + LX
+   *     block_size *= 2
+   *
+   * Comments:
    * Upper-tri (swap_parity=false):
    *   LX = even_blocks(X), RX = odd_blocks(X)
    *   Y = LX @ (-M) + I, X = Y @ RX + LX
@@ -420,7 +438,8 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
 
     wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // Wait to write last X
     CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
-        X_l1_tile, a_l0_tile[1], block_size, swap_parity);  // a_l0[1]: even(LX) or odd(RX)
+        X_l1_tile, a_l0_tile[1], block_size,
+        swap_parity);  // a_l0[1]: even(LX) or odd(RX)
     set_flag(PIPE_MTE1, PIPE_M, event_1);
 
     wait_flag(PIPE_MTE1, PIPE_M, event_0);
@@ -442,11 +461,13 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
     set_flag(PIPE_FIX, PIPE_MTE1, event_0);
     set_flag(PIPE_FIX, PIPE_M, event_0);
 
-    /* Load complementary blocks of X in L0B */
+    /* Load complementary blocks of X in L0B. If swap_parity = fase, "Load Odd
+     * Blocks Of X In L0B" */
     wait_flag(PIPE_M, PIPE_MTE1, event_1);
     TMOV(b_l0_tile[0], Zero_l1_tile);
     CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
-        X_l1_tile, b_l0_tile[0], block_size, swap_parity);  // b_l0[0]: odd(RX) or even(LX)
+        X_l1_tile, b_l0_tile[0], block_size,
+        swap_parity);  // b_l0[0]: odd(RX) or even(LX)
 
     wait_flag(PIPE_M, PIPE_MTE1, event_0);  // Wait for previous use of a_l0[1]
     wait_flag(PIPE_FIX, PIPE_MTE1, event_0);  // Wait for Y_l1
@@ -472,10 +493,10 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // Write c_l0[1] to X_l1
 }
 
-/*
+/**
  * @brief: Runs the main kernel (inverts all matrices in the tensor)
  *
- * @tparam InputT The type of the input elements.
+ * @tparam InputT The type of the input elements. Supports fp16 and bf16.
  * @tparam OutputT The type of the output elements.
  * @tparam MatrixSize Size of the entire input/output matrices.
  * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
@@ -493,18 +514,23 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
  * @param I_neg Pointer to global memory that contains the negative identity.
  * @param total_tiles The total number of matrices to invert.
  * @param num_bsnd_heads The number of heads, only for BSND format.
+ * @param is_lower If input matrices are lower-triangular (is_lower == 1) or
+ * upper-triangular (is_lower == 0). Default is upper triangular.
+ * @param num_bsnd_heads The number of heads, only for BSND format.
  */
 template <typename InputT, typename OutputT, uint32_t MatrixSize,
-          uint32_t NumTilesPerCubeIter, bool IsBSND, typename StoreT = OutputT>
-AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT* M_inv,
+          uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                          __gm__ InputT* M, __gm__ InputT* I_neg,
                                          uint32_t total_tiles,
                                          uint32_t num_bsnd_heads = 0,
-                                         __gm__ int32_t* cu_seqlens = nullptr,
-                                         uint32_t is_lower = 0) {
+                                         uint32_t is_lower = 0,
+                                         __gm__ int32_t* cu_seqlens = nullptr) {
+  using pto::Stride;
+
   /* Initializations */
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
-  constexpr uint32_t FractalSize = 16;  // fractal size for half
+  constexpr uint32_t FractalSize = 16;  // fractal size for half /bf16
   constexpr uint32_t NumFractalsRowWise = MatrixSize / FractalSize;
   constexpr uint32_t NumL0Buffers = 2;
 
@@ -529,14 +555,14 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT* M_inv,
                                       GlobalTileStridesINeg, Layout::ND>;
 
   using GlobalTileShapeOut =
-      TileShape2D<StoreT, MatrixSize, MatrixSize, Layout::ND>;
+      TileShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>;
   using GlobalTileStridesOut = typename std::conditional<
-      !IsBSND, BaseShape2D<StoreT, MatrixSize, MatrixSize, Layout::ND>,
+      !IsBSND, BaseShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>,
       pto::Stride<1, 1, 1, -1, 1>>::type;
-  using GlobalTileOut = GlobalTensor<StoreT, GlobalTileShapeOut,
+  using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
                                      GlobalTileStridesOut, Layout::ND>;
   using GlobalTileDynamicOut =
-      GlobalTensor<StoreT, GlobalTileDynamicShape, GlobalTileDynamicStride,
+      GlobalTensor<OutputT, GlobalTileDynamicShape, GlobalTileDynamicStride,
                    Layout::ND>;
   using TileL1AB =
       Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
@@ -548,9 +574,9 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT* M_inv,
   // L0 Memory
   using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
   using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
-  using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
+  using TileL0C = TileAcc<float, MatrixSize, MatrixSize>;
   using TileL0CDynamic =
-      TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
+      TileAcc<float, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
 
   GlobalTileINeg I_neg_global_in(I_neg);
 
@@ -577,8 +603,7 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT* M_inv,
   for (uint32_t buffer_num = 0; buffer_num < NumL0Buffers; ++buffer_num) {
     TASSIGN(a_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
     TASSIGN(b_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
-    TASSIGN(c_l0_tile[buffer_num],
-            0x0 + buffer_num * TileLen * sizeof(OutputT));
+    TASSIGN(c_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(float));
   }
   TLOAD(I_neg_l1_tile, I_neg_global_in);
   set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
@@ -678,7 +703,7 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT* M_inv,
         if (valid_size < MatrixSize) {
           TileL0CDynamic c_l0_tail_tile(valid_size, valid_size);
           TASSIGN(c_l0_tail_tile,
-                  0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+                  0x0 + final_c_buffer_index * TileLen * sizeof(float));
           GlobalTileDynamicOut M_inv_global_out_dyn(
               M_inv + bsnd_offset,
               {1, 1, 1, static_cast<int>(valid_size),
@@ -712,60 +737,73 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT* M_inv,
  * @brief: Computes the inverses of the blocks of tensor M
  */
 template <typename InputT, typename OutputT, uint32_t MatrixSize,
-          uint32_t NumTilesPerCubeIter, bool IsBSND, typename StoreT = OutputT>
-AICORE void runKernelTriInvRecUnroll(__gm__ StoreT* M_inv, __gm__ InputT* M,
+          uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
                                      __gm__ InputT* I_neg, uint32_t total_tiles,
                                      uint32_t num_bsnd_heads = 0,
-                                     __gm__ int32_t* cu_seqlens = nullptr,
-                                     uint32_t is_lower = 0) {
-#ifdef __DAV_CUBE__
+                                     uint32_t is_lower = 0,
+                                     __gm__ int32_t* cu_seqlens = nullptr) {
+#if defined(__DAV_CUBE__)  // Cube compilation
+
   TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
-                        IsBSND, StoreT>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
-                                cu_seqlens, is_lower);
+                        IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
+                                is_lower, cu_seqlens);
+#else
+// Nothing to do on AIV
 #endif
 }
 
-template <typename InputT, uint32_t NumTilesPerCubeIter, bool IsBSND>
-AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
+template <typename InputT, typename OutputT, uint32_t NumTilesPerCubeIter,
+          bool IsBSND>
+AICORE void run_tri_inv_rec_unroll(__gm__ OutputT* tensor_out,
                                    __gm__ InputT* tensor_in,
-                                   __gm__ InputT* minus_identity_in,
+                                   __gm__ InputT* minus_eye_in,
                                    uint32_t matrix_size, uint32_t num_matrices,
                                    uint32_t num_bsnd_heads,
-                                   __gm__ int32_t* cu_seqlens = nullptr,
-                                   uint32_t is_lower = 0) {
-  static_assert(std::is_same_v<InputT, half>,
-                "tri_inv_rec_unroll supports only fp16.");
+                                   uint32_t is_lower = 0,
+                                   __gm__ int32_t* cu_seqlens = nullptr) {
+  static_assert(
+      std::is_same_v<InputT, half> or std::is_same_v<InputT, bfloat16_t>,
+      "tri_inv_rec_unroll supports only fp16 or bf16.");
+
+  static_assert(
+      std::is_same_v<OutputT, half> or std::is_same_v<OutputT, bfloat16_t>,
+      "tri_inv_rec_unroll supports only fp16 or bf16.");
   switch (matrix_size) {
     case 16:
-      runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, cu_seqlens, is_lower);
+      runKernelTriInvRecUnroll<InputT, OutputT, 16, NumTilesPerCubeIter,
+                               IsBSND>(tensor_out, tensor_in, minus_eye_in,
+                                       num_matrices, num_bsnd_heads, is_lower,
+                                       cu_seqlens);
       break;
     case 32:
-      runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, cu_seqlens, is_lower);
+      runKernelTriInvRecUnroll<InputT, OutputT, 32, NumTilesPerCubeIter,
+                               IsBSND>(tensor_out, tensor_in, minus_eye_in,
+                                       num_matrices, num_bsnd_heads, is_lower,
+                                       cu_seqlens);
       break;
     case 64:
-      runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, cu_seqlens, is_lower);
+      runKernelTriInvRecUnroll<InputT, OutputT, 64, NumTilesPerCubeIter,
+                               IsBSND>(tensor_out, tensor_in, minus_eye_in,
+                                       num_matrices, num_bsnd_heads, is_lower,
+                                       cu_seqlens);
       break;
     case 128:
-      runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, cu_seqlens, is_lower);
+      runKernelTriInvRecUnroll<InputT, OutputT, 128, NumTilesPerCubeIter,
+                               IsBSND>(tensor_out, tensor_in, minus_eye_in,
+                                       num_matrices, num_bsnd_heads, is_lower,
+                                       cu_seqlens);
       break;
   }
 }
 
 /*
- * @brief: Wrapper for the kernel, "half" type (fp16).
+ * @brief: Wrapper for the kernel supporting fp16 and bfloat16 types.
  *
  * @param tensor_out pointer to the global memory to store the final inverse.
  * @param tensor_in Pointer to the global tensor matrix in global memory.
- * @param minus_identity_in Pointer to global memory that contains the negative
- * identity.
+ * @param minus_eye_in Pointer to the global tensor matrix containing the
+ * negative identity matrix.
  * @param matrix_size The size if each individual matrix / tile. Can take
  * values: {16, 32, 64, 128}.
  * @param num_matrices The total number of matrices / tiles in the global
@@ -775,51 +813,46 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
  * strided accesses. If each tile is stored consecutively (and row-wise) in
  * memory, then num_bsnd_heads=0.
  */
-extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
-    __gm__ void* tensor_out, __gm__ void* tensor_in,
-    __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
-    uint32_t num_bsnd_heads, __gm__ void* cu_seqlens) {
-  const uint32_t is_lower = (num_bsnd_heads >> 16) & 1u;
-  const uint32_t actual_heads = num_bsnd_heads & 0xFFFFu;
-  if (actual_heads == 0) {
+template <typename InputT, typename OutputT, uint32_t NumTilesPerCubeIter,
+          bool IsBSND>
+AICORE void run_tri_inv_rec_unroll_per_num_matrices(
+    __gm__ OutputT* tensor_out, __gm__ InputT* tensor_in,
+    __gm__ InputT* minus_eye_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, uint32_t is_lower = 0,
+    __gm__ int32_t* cu_seqlens = nullptr) {
+  if (num_bsnd_heads == 0) {
     if (num_matrices <= get_block_num()) {
-      run_tri_inv_rec_unroll<half, 1 /* NumTilesPerCubeIter */,
+      run_tri_inv_rec_unroll<InputT, OutputT, 1 /* NumTilesPerCubeIter */,
                              false /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+          tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices,
+          num_bsnd_heads, is_lower, cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
-      run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
+      run_tri_inv_rec_unroll<InputT, OutputT, 2 /* NumTilesPerCubeIter */,
                              false /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+          tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices,
+          num_bsnd_heads, is_lower, cu_seqlens);
     } else {
-      run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
+      run_tri_inv_rec_unroll<InputT, OutputT, 4 /* NumTilesPerCubeIter */,
                              false /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+          tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices,
+          num_bsnd_heads, is_lower, cu_seqlens);
     }
   } else {
     if (num_matrices <= get_block_num()) {
-      run_tri_inv_rec_unroll<half, 1 /* NumTilesPerCubeIter */,
+      run_tri_inv_rec_unroll<InputT, OutputT, 1 /* NumTilesPerCubeIter */,
                              true /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+          tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices,
+          num_bsnd_heads, is_lower, cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
-      run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
+      run_tri_inv_rec_unroll<InputT, OutputT, 2 /* NumTilesPerCubeIter */,
                              true /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+          tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices,
+          num_bsnd_heads, is_lower, cu_seqlens);
     } else {
-      run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
+      run_tri_inv_rec_unroll<InputT, OutputT, 4 /* NumTilesPerCubeIter */,
                              true /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, (__gm__ int32_t*)cu_seqlens, is_lower);
+          tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices,
+          num_bsnd_heads, is_lower, cu_seqlens);
     }
   }
 }

--- a/kernels/pto/tri_inverse_impl.cpp
+++ b/kernels/pto/tri_inverse_impl.cpp
@@ -766,6 +766,9 @@ AICORE void run_tri_inv_rec_unroll(__gm__ OutputT* tensor_out,
       std::is_same_v<InputT, half> or std::is_same_v<InputT, bfloat16_t>,
       "tri_inv_rec_unroll supports only fp16 or bf16.");
 
+  static_assert(
+      std::is_same_v<OutputT, float> or std::is_same_v<OutputT, bfloat16_t>,
+      "tri_inv_rec_unroll supports only fp32 or bf16.");
   switch (matrix_size) {
     case 16:
       runKernelTriInvRecUnroll<InputT, OutputT, 16, NumTilesPerCubeIter,
@@ -810,8 +813,7 @@ AICORE void run_tri_inv_rec_unroll(__gm__ OutputT* tensor_out,
  * strided accesses. If each tile is stored consecutively (and row-wise) in
  * memory, then num_bsnd_heads=0.
  */
-template <typename InputT, typename OutputT, uint32_t NumTilesPerCubeIter,
-          bool IsBSND>
+template <typename InputT, typename OutputT, uint32_t NumTilesPerCubeIter>
 AICORE void run_tri_inv_rec_unroll_per_num_matrices(
     __gm__ OutputT* tensor_out, __gm__ InputT* tensor_in,
     __gm__ InputT* minus_eye_in, uint32_t matrix_size, uint32_t num_matrices,
@@ -877,8 +879,8 @@ extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
   const uint32_t is_lower = (num_bsnd_heads >> 16) & 1u;
   const uint32_t actual_heads = num_bsnd_heads & 0xFFFFu;
 
-  run_tri_inv_rec_unroll_per_num_matrices<
-      half, float, 1 /* NumTilesPerCubeIter */, false /* IsBSND */>(
+  run_tri_inv_rec_unroll_per_num_matrices<half, float,
+                                          1 /* NumTilesPerCubeIter */>(
       (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
       (__gm__ half*)minus_identity_in, matrix_size, num_matrices, actual_heads,
       is_lower, (__gm__ int32_t*)cu_seqlens);

--- a/kernels/pto/tri_inverse_impl.cpp
+++ b/kernels/pto/tri_inverse_impl.cpp
@@ -876,45 +876,10 @@ extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
     uint32_t num_bsnd_heads, __gm__ void* cu_seqlens) {
   const uint32_t is_lower = (num_bsnd_heads >> 16) & 1u;
   const uint32_t actual_heads = num_bsnd_heads & 0xFFFFu;
-  if (actual_heads == 0) {
-    if (num_matrices <= get_block_num()) {
-      run_tri_inv_rec_unroll<half, float, 1 /* NumTilesPerCubeIter */,
-                             false /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
-    } else if (num_matrices <= 2 * get_block_num()) {
-      run_tri_inv_rec_unroll<half, float, 2 /* NumTilesPerCubeIter */,
-                             false /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
-    } else {
-      run_tri_inv_rec_unroll<half, float, 4 /* NumTilesPerCubeIter */,
-                             false /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
-    }
-  } else {
-    if (num_matrices <= get_block_num()) {
-      run_tri_inv_rec_unroll<half, float, 1 /* NumTilesPerCubeIter */,
-                             true /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
-    } else if (num_matrices <= 2 * get_block_num()) {
-      run_tri_inv_rec_unroll<half, float, 2 /* NumTilesPerCubeIter */,
-                             true /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
-    } else {
-      run_tri_inv_rec_unroll<half, float, 4 /* NumTilesPerCubeIter */,
-                             true /* IsBSND */>(
-          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
-          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
-    }
-  }
+
+  run_tri_inv_rec_unroll_per_num_matrices<
+      half, float, 1 /* NumTilesPerCubeIter */, false /* IsBSND */>(
+      (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+      (__gm__ half*)minus_identity_in, matrix_size, num_matrices, actual_heads,
+      is_lower, (__gm__ int32_t*)cu_seqlens);
 }

--- a/kernels/pto/tri_inverse_impl.cpp
+++ b/kernels/pto/tri_inverse_impl.cpp
@@ -766,9 +766,6 @@ AICORE void run_tri_inv_rec_unroll(__gm__ OutputT* tensor_out,
       std::is_same_v<InputT, half> or std::is_same_v<InputT, bfloat16_t>,
       "tri_inv_rec_unroll supports only fp16 or bf16.");
 
-  static_assert(
-      std::is_same_v<OutputT, half> or std::is_same_v<OutputT, bfloat16_t>,
-      "tri_inv_rec_unroll supports only fp16 or bf16.");
   switch (matrix_size) {
     case 16:
       runKernelTriInvRecUnroll<InputT, OutputT, 16, NumTilesPerCubeIter,
@@ -853,6 +850,71 @@ AICORE void run_tri_inv_rec_unroll_per_num_matrices(
                              true /* IsBSND */>(
           tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices,
           num_bsnd_heads, is_lower, cu_seqlens);
+    }
+  }
+}
+
+/*
+ * @brief: Wrapper for the kernel, "half" type (fp16).
+ *
+ * @param tensor_out pointer to the global memory to store the final inverse.
+ * @param tensor_in Pointer to the global tensor matrix in global memory.
+ * @param minus_identity_in Pointer to global memory that contains the negative
+ * identity.
+ * @param matrix_size The size if each individual matrix / tile. Can take
+ * values: {16, 32, 64, 128}.
+ * @param num_matrices The total number of matrices / tiles in the global
+ * tensor.
+ * @param num_bsnd_heads The number of heads, which is only greater than zero
+ * if the matrix is in BSND format, that is, the tiles need to be loaded with
+ * strided accesses. If each tile is stored consecutively (and row-wise) in
+ * memory, then num_bsnd_heads=0.
+ */
+extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
+    __gm__ void* tensor_out, __gm__ void* tensor_in,
+    __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, __gm__ void* cu_seqlens) {
+  const uint32_t is_lower = (num_bsnd_heads >> 16) & 1u;
+  const uint32_t actual_heads = num_bsnd_heads & 0xFFFFu;
+  if (actual_heads == 0) {
+    if (num_matrices <= get_block_num()) {
+      run_tri_inv_rec_unroll<half, float, 1 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
+    } else if (num_matrices <= 2 * get_block_num()) {
+      run_tri_inv_rec_unroll<half, float, 2 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
+    } else {
+      run_tri_inv_rec_unroll<half, float, 4 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
+    }
+  } else {
+    if (num_matrices <= get_block_num()) {
+      run_tri_inv_rec_unroll<half, float, 1 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
+    } else if (num_matrices <= 2 * get_block_num()) {
+      run_tri_inv_rec_unroll<half, float, 2 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
+    } else {
+      run_tri_inv_rec_unroll<half, float, 4 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          actual_heads, is_lower, (__gm__ int32_t*)cu_seqlens);
     }
   }
 }

--- a/kernels/pto/tri_inverse_impl.cpp
+++ b/kernels/pto/tri_inverse_impl.cpp
@@ -11,7 +11,6 @@ for the full License text.
 
 #include "kernel_utils.h"
 
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
 using namespace pto;
 using namespace kernel_utils;
 
@@ -719,14 +718,10 @@ AICORE void runKernelTriInvRecUnroll(__gm__ StoreT* M_inv, __gm__ InputT* M,
                                      uint32_t num_bsnd_heads = 0,
                                      __gm__ int32_t* cu_seqlens = nullptr,
                                      uint32_t is_lower = 0) {
-#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
-    (__CCE_AICORE__ == 220 && defined(__DAV_CUBE__))  // Cube compilation
-
+#ifdef __DAV_CUBE__
   TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
                         IsBSND, StoreT>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
                                 cu_seqlens, is_lower);
-#else
-// Nothing to do on AIV
 #endif
 }
 


### PR DESCRIPTION
To verify GDN/KDA E2E and per individual kernel:

```
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_gdn_e2e.py"
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_kda_e2e.py"
```

```
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_gdn_single_kernels.py"
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_kda_single_kernels.py"
```


## E2E
### GDN

```
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_gdn_e2e.py"
任务已提交: task_20260810_230619_2529183 (断开后可用 task-submit --wait task_20260810_230619_2529183 重连)
等待任务执行: task_20260810_230619_2529183 (Ctrl+C 终止任务)
[npu-lock] 获取设备 1 的锁 (无超时)...
[npu-lock] 已获取设备 1 的锁 (pid=2529211)
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/_path_manager.py:66: UserWarning: Permission mismatch: The owner of /home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/lib/libop_plugin_atb.so does not match.
  warnings.warn(f"Permission mismatch: The owner of {path} does not match.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/tests/test_gdn_e2e.py:92: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at ../torch_npu/csrc/aten/common/TensorFactories.cpp:340.)
  g_sum = torch.empty_like(g_in)
[W810 23:06:46.444269490 ToKernelNpu.cpp:41] Warning: Device do not support double dtype now, dtype cast replace with float. (function operator())
Device: npu:0  Hg=16  D=128  C_PTO=128  C_TRITON=64
Triton cross-check: disabled

============================================================
H=32  Hg=16
============================================================
[megagdn_pto] Compiling mega_kernel …
[megagdn_pto] Compiled → /home/zouzias/github-repos/megagdn-pto/kernels/pto/compiled_lib/mega_kernel_D128_C128_REGISTER_BASE.so
  PASS  T=256  pto_vs_cpu=PASS  mega_vs_cpu=PASS
  PASS  T=512  pto_vs_cpu=PASS  mega_vs_cpu=PASS
  PASS  T=1024  pto_vs_cpu=PASS  mega_vs_cpu=PASS
  PASS  varlen [0, 256, 512]  pto_vs_cpu=PASS  mega_vs_cpu=PASS
  PASS  varlen [0, 128, 384, 768]  pto_vs_cpu=PASS  mega_vs_cpu=PASS
  PASS  varlen [0, 384, 512]  pto_vs_cpu=PASS  mega_vs_cpu=PASS
  PASS  varlen [0, 128, 256, 512]  pto_vs_cpu=PASS  mega_vs_cpu=PASS

ALL PASS
[npu-lock] 已释放设备 1 的锁
=== 任务完成 (exit=0) ===
```

### KDA

```
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_kda_e2e.py"
任务已提交: task_20260810_230740_2531930 (断开后可用 task-submit --wait task_20260810_230740_2531930 重连)
等待任务执行: task_20260810_230740_2531930 (Ctrl+C 终止任务)
[npu-lock] 获取设备 1 的锁 (无超时)...
[npu-lock] 已获取设备 1 的锁 (pid=2532021)
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/_path_manager.py:66: UserWarning: Permission mismatch: The owner of /home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/lib/libop_plugin_atb.so does not match.
  warnings.warn(f"Permission mismatch: The owner of {path} does not match.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/megagdn_pto/fast_inverse.py:177: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at ../torch_npu/csrc/aten/common/TensorFactories.cpp:340.)
  tensor_out = torch.zeros_like(A_fp16, dtype=torch.float32)
device=npu:0  H=4  HV=4  K=128  V=128  CHUNK=128
NPU stages: [1] gate_cumsum_kda  [2] kkt_kda  [3] solve_tril  [4] wy_kda  [5] chunk_h_kda  [6] chunk_o_kda

============================================================
[megagdn_pto] Compiling mega_kernel_kda (K=128 C=128) …
[megagdn_pto] Compiled → /home/zouzias/github-repos/megagdn-pto/kernels/pto/compiled_lib/mega_kernel_kda_D128_C128_REGISTER_BASE.so
  [ 1/7] PASS  T=256  [staged=ok mega=ok mega~staged=ok]  (20.14s)
  [ 2/7] PASS  T=512  [staged=ok mega=ok mega~staged=ok]  (0.28s)
  [ 3/7] PASS  T=1024  [staged=ok mega=ok mega~staged=ok]  (0.48s)
  [ 4/7] PASS  varlen [0, 256, 512]  [staged=ok mega=ok mega~staged=ok]  (0.28s)
  [ 5/7] PASS  varlen [0, 128, 384, 768]  [staged=ok mega=ok mega~staged=ok]  (0.39s)
  [ 6/7] PASS  varlen [0, 384, 512]  [staged=ok mega=ok mega~staged=ok]  (0.27s)
  [ 7/7] PASS  varlen [0, 128, 256, 512]  [staged=ok mega=ok mega~staged=ok]  (0.27s)

ALL PASS
[npu-lock] 已释放设备 1 的锁
=== 任务完成 (exit=0) ===

```


## Single kernels

### GDN
```
git rev-parse  HEAD
5be80f3632d7446c22fa44d364eb785598ba9fc0
(venv) [zouzias@localhost megagdn-pto]$ git log -1
commit 5be80f3632d7446c22fa44d364eb785598ba9fc0 (HEAD -> 50-enable-a5-compilation-on-all-kernels, origin/50-enable-a5-compilation-on-all-kernels)
Author: anastasios <anastasios.zouzias@huawei.com>
Date:   Mon Aug 10 14:47:39 2026 +0000

    fix tri_inv

task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_gdn_single_kernels.py "
任务已提交: task_20260810_230023_2521863 (断开后可用 task-submit --wait task_20260810_230023_2521863 重连)
等待任务执行: task_20260810_230023_2521863 (Ctrl+C 终止任务)
[npu-lock] 获取设备 1 的锁 (无超时)...
[npu-lock] 已获取设备 1 的锁 (pid=2521891)
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/_path_manager.py:66: UserWarning: Permission mismatch: The owner of /home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/lib/libop_plugin_atb.so does not match.
  warnings.warn(f"Permission mismatch: The owner of {path} does not match.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/tests/test_gdn_single_kernels.py:359: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at ../torch_npu/csrc/aten/common/TensorFactories.cpp:340.)
  g_sum = torch.empty_like(g)
Device: npu:0  stages=['cumsum', 'kkt', 'solve_tril', 'chunk_h', 'wy_fast', 'chunk_o']  head_configs=[(16, 4), (16, 16), (24, 8), (32, 8), (48, 16), (64, 16)]  D=128  C=128

============================================================
Stage: chunk_cumsum
============================================================

  H=16 (Hg=4)
    [ 1/19] PASS  fixed T=128  (2.38s)
    [ 2/19] PASS  fixed T=256  (0.00s)
    [ 3/19] PASS  fixed T=385  (0.00s)
    [ 4/19] PASS  fixed T=512  (0.00s)
    [ 5/19] PASS  fixed T=1024  (0.00s)
    [ 6/19] PASS  varlen [128]  (0.00s)
    [ 7/19] PASS  varlen [256]  (0.00s)
    [ 8/19] PASS  varlen [384]  (0.00s)
    [ 9/19] PASS  varlen [512]  (0.00s)
    [10/19] PASS  varlen [256, 256]  (0.00s)
    [11/19] PASS  varlen [128, 256]  (0.00s)
    [12/19] PASS  varlen [384, 128]  (0.00s)
    [13/19] PASS  varlen [128, 128, 128]  (0.00s)
    [14/19] PASS  varlen [256, 128, 384]  (0.00s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.00s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.00s)
    [17/19] PASS  varlen rand 3seq T=896  (0.00s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.00s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.02s)

  H=16 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.00s)
    [ 2/19] PASS  fixed T=256  (0.00s)
    [ 3/19] PASS  fixed T=385  (0.00s)
    [ 4/19] PASS  fixed T=512  (0.00s)
    [ 5/19] PASS  fixed T=1024  (0.00s)
    [ 6/19] PASS  varlen [128]  (0.00s)
    [ 7/19] PASS  varlen [256]  (0.00s)
    [ 8/19] PASS  varlen [384]  (0.00s)
    [ 9/19] PASS  varlen [512]  (0.00s)
    [10/19] PASS  varlen [256, 256]  (0.00s)
    [11/19] PASS  varlen [128, 256]  (0.00s)
    [12/19] PASS  varlen [384, 128]  (0.00s)
    [13/19] PASS  varlen [128, 128, 128]  (0.00s)
    [14/19] PASS  varlen [256, 128, 384]  (0.00s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.00s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.00s)
    [17/19] PASS  varlen rand 3seq T=896  (0.00s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.00s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.01s)

  H=24 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.00s)
    [ 2/19] PASS  fixed T=256  (0.00s)
    [ 3/19] PASS  fixed T=385  (0.00s)
    [ 4/19] PASS  fixed T=512  (0.00s)
    [ 5/19] PASS  fixed T=1024  (0.00s)
    [ 6/19] PASS  varlen [128]  (0.00s)
    [ 7/19] PASS  varlen [256]  (0.00s)
    [ 8/19] PASS  varlen [384]  (0.00s)
    [ 9/19] PASS  varlen [512]  (0.00s)
    [10/19] PASS  varlen [256, 256]  (0.00s)
    [11/19] PASS  varlen [128, 256]  (0.00s)
    [12/19] PASS  varlen [384, 128]  (0.00s)
    [13/19] PASS  varlen [128, 128, 128]  (0.00s)
    [14/19] PASS  varlen [256, 128, 384]  (0.00s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.00s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.01s)
    [17/19] PASS  varlen rand 3seq T=896  (0.00s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.01s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.01s)

  H=32 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.00s)
    [ 2/19] PASS  fixed T=256  (0.00s)
    [ 3/19] PASS  fixed T=385  (0.00s)
    [ 4/19] PASS  fixed T=512  (0.00s)
    [ 5/19] PASS  fixed T=1024  (0.00s)
    [ 6/19] PASS  varlen [128]  (0.00s)
    [ 7/19] PASS  varlen [256]  (0.00s)
    [ 8/19] PASS  varlen [384]  (0.00s)
    [ 9/19] PASS  varlen [512]  (0.00s)
    [10/19] PASS  varlen [256, 256]  (0.00s)
    [11/19] PASS  varlen [128, 256]  (0.00s)
    [12/19] PASS  varlen [384, 128]  (0.00s)
    [13/19] PASS  varlen [128, 128, 128]  (0.00s)
    [14/19] PASS  varlen [256, 128, 384]  (0.00s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.00s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.01s)
    [17/19] PASS  varlen rand 3seq T=896  (0.00s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.01s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.01s)

  H=48 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.00s)
    [ 2/19] PASS  fixed T=256  (0.00s)
    [ 3/19] PASS  fixed T=385  (0.00s)
    [ 4/19] PASS  fixed T=512  (0.00s)
    [ 5/19] PASS  fixed T=1024  (0.01s)
    [ 6/19] PASS  varlen [128]  (0.00s)
    [ 7/19] PASS  varlen [256]  (0.00s)
    [ 8/19] PASS  varlen [384]  (0.00s)
    [ 9/19] PASS  varlen [512]  (0.00s)
    [10/19] PASS  varlen [256, 256]  (0.00s)
    [11/19] PASS  varlen [128, 256]  (0.00s)
    [12/19] PASS  varlen [384, 128]  (0.00s)
    [13/19] PASS  varlen [128, 128, 128]  (0.00s)
    [14/19] PASS  varlen [256, 128, 384]  (0.01s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.01s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.01s)
    [17/19] PASS  varlen rand 3seq T=896  (0.01s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.01s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.01s)

  H=64 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.00s)
    [ 2/19] PASS  fixed T=256  (0.00s)
    [ 3/19] PASS  fixed T=385  (0.00s)
    [ 4/19] PASS  fixed T=512  (0.00s)
    [ 5/19] PASS  fixed T=1024  (0.01s)
    [ 6/19] PASS  varlen [128]  (0.00s)
    [ 7/19] PASS  varlen [256]  (0.00s)
    [ 8/19] PASS  varlen [384]  (0.00s)
    [ 9/19] PASS  varlen [512]  (0.00s)
    [10/19] PASS  varlen [256, 256]  (0.00s)
    [11/19] PASS  varlen [128, 256]  (0.00s)
    [12/19] PASS  varlen [384, 128]  (0.00s)
    [13/19] PASS  varlen [128, 128, 128]  (0.00s)
    [14/19] PASS  varlen [256, 128, 384]  (0.01s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.01s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.01s)
    [17/19] PASS  varlen rand 3seq T=896  (0.01s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.01s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.01s)

============================================================
Stage: scaled_dot_kkt
============================================================

  H=16 (Hg=4)
    [ 1/19] PASS  fixed T=128  (2.71s)
    [ 2/19] PASS  fixed T=256  (0.07s)
    [ 3/19] PASS  fixed T=385  (0.09s)
    [ 4/19] PASS  fixed T=512  (0.10s)
    [ 5/19] PASS  fixed T=1024  (0.16s)
    [ 6/19] PASS  varlen [128]  (0.03s)
    [ 7/19] PASS  varlen [256]  (0.05s)
    [ 8/19] PASS  varlen [384]  (0.07s)
    [ 9/19] PASS  varlen [512]  (0.11s)
    [10/19] PASS  varlen [256, 256]  (0.11s)
    [11/19] PASS  varlen [128, 256]  (0.08s)
    [12/19] PASS  varlen [384, 128]  (0.11s)
    [13/19] PASS  varlen [128, 128, 128]  (0.08s)
    [14/19] PASS  varlen [256, 128, 384]  (0.17s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.23s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.27s)
    [17/19] PASS  varlen rand 3seq T=896  (0.18s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.37s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.53s)

  H=16 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.04s)
    [ 2/19] PASS  fixed T=256  (0.07s)
    [ 3/19] PASS  fixed T=385  (0.08s)
    [ 4/19] PASS  fixed T=512  (0.13s)
    [ 5/19] PASS  fixed T=1024  (0.24s)
    [ 6/19] PASS  varlen [128]  (0.04s)
    [ 7/19] PASS  varlen [256]  (0.07s)
    [ 8/19] PASS  varlen [384]  (0.10s)
    [ 9/19] PASS  varlen [512]  (0.13s)
    [10/19] PASS  varlen [256, 256]  (0.13s)
    [11/19] PASS  varlen [128, 256]  (0.10s)
    [12/19] PASS  varlen [384, 128]  (0.13s)
    [13/19] PASS  varlen [128, 128, 128]  (0.10s)
    [14/19] PASS  varlen [256, 128, 384]  (0.19s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.25s)
ERROR: large frobenius relative error: 0.004907002496266227. FTOL=0.001
    [16/19] FAIL  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.38s)
    [17/19] PASS  varlen rand 3seq T=896  (0.22s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.42s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.62s)

  H=24 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.05s)
    [ 2/19] PASS  fixed T=256  (0.09s)
    [ 3/19] PASS  fixed T=385  (0.14s)
    [ 4/19] PASS  fixed T=512  (0.17s)
    [ 5/19] PASS  fixed T=1024  (0.29s)
    [ 6/19] PASS  varlen [128]  (0.05s)
    [ 7/19] PASS  varlen [256]  (0.09s)
    [ 8/19] PASS  varlen [384]  (0.12s)
    [ 9/19] PASS  varlen [512]  (0.17s)
    [10/19] PASS  varlen [256, 256]  (0.17s)
    [11/19] PASS  varlen [128, 256]  (0.13s)
    [12/19] PASS  varlen [384, 128]  (0.12s)
    [13/19] PASS  varlen [128, 128, 128]  (0.13s)
    [14/19] PASS  varlen [256, 128, 384]  (0.23s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.34s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.48s)
    [17/19] PASS  varlen rand 3seq T=896  (0.29s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.58s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.80s)

  H=32 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.06s)
    [ 2/19] PASS  fixed T=256  (0.11s)
    [ 3/19] PASS  fixed T=385  (0.14s)
    [ 4/19] PASS  fixed T=512  (0.20s)
    [ 5/19] PASS  fixed T=1024  (0.35s)
    [ 6/19] PASS  varlen [128]  (0.04s)
    [ 7/19] PASS  varlen [256]  (0.10s)
    [ 8/19] PASS  varlen [384]  (0.17s)
    [ 9/19] PASS  varlen [512]  (0.14s)
    [10/19] PASS  varlen [256, 256]  (0.22s)
    [11/19] PASS  varlen [128, 256]  (0.15s)
    [12/19] PASS  varlen [384, 128]  (0.18s)
    [13/19] PASS  varlen [128, 128, 128]  (0.15s)
    [14/19] PASS  varlen [256, 128, 384]  (0.27s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.42s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.59s)
    [17/19] PASS  varlen rand 3seq T=896  (0.35s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.67s)
    [19/19] PASS  varlen rand 10seq T=2560  (1.03s)

  H=48 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.09s)
    [ 2/19] PASS  fixed T=256  (0.16s)
    [ 3/19] PASS  fixed T=385  (0.23s)
    [ 4/19] PASS  fixed T=512  (0.34s)
    [ 5/19] PASS  fixed T=1024  (0.55s)
    [ 6/19] PASS  varlen [128]  (0.09s)
    [ 7/19] PASS  varlen [256]  (0.17s)
    [ 8/19] PASS  varlen [384]  (0.18s)
    [ 9/19] PASS  varlen [512]  (0.32s)
    [10/19] PASS  varlen [256, 256]  (0.31s)
    [11/19] PASS  varlen [128, 256]  (0.25s)
    [12/19] PASS  varlen [384, 128]  (0.25s)
    [13/19] PASS  varlen [128, 128, 128]  (0.24s)
    [14/19] PASS  varlen [256, 128, 384]  (0.39s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.56s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.91s)
    [17/19] PASS  varlen rand 3seq T=896  (0.56s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.10s)
    [19/19] PASS  varlen rand 10seq T=2560  (1.50s)

  H=64 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.11s)
    [ 2/19] PASS  fixed T=256  (0.22s)
    [ 3/19] PASS  fixed T=385  (0.31s)
    [ 4/19] PASS  fixed T=512  (0.40s)
    [ 5/19] PASS  fixed T=1024  (0.73s)
    [ 6/19] PASS  varlen [128]  (0.09s)
    [ 7/19] PASS  varlen [256]  (0.22s)
    [ 8/19] PASS  varlen [384]  (0.31s)
    [ 9/19] PASS  varlen [512]  (0.43s)
    [10/19] PASS  varlen [256, 256]  (0.45s)
    [11/19] PASS  varlen [128, 256]  (0.33s)
    [12/19] PASS  varlen [384, 128]  (0.44s)
    [13/19] PASS  varlen [128, 128, 128]  (0.34s)
    [14/19] PASS  varlen [256, 128, 384]  (0.65s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.98s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (1.36s)
    [17/19] PASS  varlen rand 3seq T=896  (0.77s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.53s)
    [19/19] PASS  varlen rand 10seq T=2560  (2.16s)

============================================================
Stage: solve_tril
============================================================

  H=16 (Hg=4)
    [ 1/19] PASS  fixed T=128  (0.08s)
    [ 2/19] PASS  fixed T=256  (0.10s)
    [ 3/19] PASS  fixed T=385  (0.15s)
    [ 4/19] PASS  fixed T=512  (0.18s)
    [ 5/19] PASS  fixed T=1024  (0.33s)
    [ 6/19] PASS  varlen [128]  (0.06s)
    [ 7/19] PASS  varlen [256]  (0.11s)
    [ 8/19] PASS  varlen [384]  (0.15s)
    [ 9/19] PASS  varlen [512]  (0.18s)
    [10/19] PASS  varlen [256, 256]  (0.19s)
    [11/19] PASS  varlen [128, 256]  (0.15s)
    [12/19] PASS  varlen [384, 128]  (0.19s)
    [13/19] PASS  varlen [128, 128, 128]  (0.15s)
    [14/19] PASS  varlen [256, 128, 384]  (0.26s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.35s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.45s)
    [17/19] PASS  varlen rand 3seq T=896  (0.29s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.53s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.70s)

  H=16 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.07s)
    [ 2/19] PASS  fixed T=256  (0.11s)
    [ 3/19] PASS  fixed T=385  (0.16s)
    [ 4/19] PASS  fixed T=512  (0.19s)
    [ 5/19] PASS  fixed T=1024  (0.35s)
    [ 6/19] PASS  varlen [128]  (0.07s)
    [ 7/19] PASS  varlen [256]  (0.11s)
    [ 8/19] PASS  varlen [384]  (0.15s)
    [ 9/19] PASS  varlen [512]  (0.18s)
    [10/19] PASS  varlen [256, 256]  (0.18s)
    [11/19] PASS  varlen [128, 256]  (0.16s)
    [12/19] PASS  varlen [384, 128]  (0.20s)
    [13/19] PASS  varlen [128, 128, 128]  (0.16s)
    [14/19] PASS  varlen [256, 128, 384]  (0.23s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.32s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.48s)
    [17/19] PASS  varlen rand 3seq T=896  (0.29s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.53s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.81s)

  H=24 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.08s)
    [ 2/19] PASS  fixed T=256  (0.14s)
    [ 3/19] PASS  fixed T=385  (0.19s)
    [ 4/19] PASS  fixed T=512  (0.25s)
    [ 5/19] PASS  fixed T=1024  (0.35s)
    [ 6/19] PASS  varlen [128]  (0.08s)
    [ 7/19] PASS  varlen [256]  (0.14s)
    [ 8/19] PASS  varlen [384]  (0.20s)
    [ 9/19] PASS  varlen [512]  (0.25s)
    [10/19] PASS  varlen [256, 256]  (0.26s)
    [11/19] PASS  varlen [128, 256]  (0.20s)
    [12/19] PASS  varlen [384, 128]  (0.26s)
    [13/19] PASS  varlen [128, 128, 128]  (0.20s)
    [14/19] PASS  varlen [256, 128, 384]  (0.32s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.45s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.67s)
    [17/19] PASS  varlen rand 3seq T=896  (0.37s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.71s)
    [19/19] PASS  varlen rand 10seq T=2560  (1.09s)

  H=32 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.10s)
    [ 2/19] PASS  fixed T=256  (0.17s)
    [ 3/19] PASS  fixed T=385  (0.25s)
    [ 4/19] PASS  fixed T=512  (0.28s)
    [ 5/19] PASS  fixed T=1024  (0.50s)
    [ 6/19] PASS  varlen [128]  (0.10s)
    [ 7/19] PASS  varlen [256]  (0.18s)
    [ 8/19] PASS  varlen [384]  (0.23s)
    [ 9/19] PASS  varlen [512]  (0.32s)
    [10/19] PASS  varlen [256, 256]  (0.26s)
    [11/19] PASS  varlen [128, 256]  (0.24s)
    [12/19] PASS  varlen [384, 128]  (0.29s)
    [13/19] PASS  varlen [128, 128, 128]  (0.24s)
    [14/19] PASS  varlen [256, 128, 384]  (0.47s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.59s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.90s)
    [17/19] PASS  varlen rand 3seq T=896  (0.53s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.02s)
    [19/19] PASS  varlen rand 10seq T=2560  (1.31s)

  H=48 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.14s)
    [ 2/19] PASS  fixed T=256  (0.22s)
    [ 3/19] PASS  fixed T=385  (0.37s)
    [ 4/19] PASS  fixed T=512  (0.47s)
    [ 5/19] PASS  fixed T=1024  (0.85s)
    [ 6/19] PASS  varlen [128]  (0.14s)
    [ 7/19] PASS  varlen [256]  (0.25s)
    [ 8/19] PASS  varlen [384]  (0.36s)
    [ 9/19] PASS  varlen [512]  (0.41s)
    [10/19] PASS  varlen [256, 256]  (0.44s)
    [11/19] PASS  varlen [128, 256]  (0.36s)
    [12/19] PASS  varlen [384, 128]  (0.43s)
    [13/19] PASS  varlen [128, 128, 128]  (0.33s)
    [14/19] PASS  varlen [256, 128, 384]  (0.65s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.93s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (1.20s)
    [17/19] PASS  varlen rand 3seq T=896  (0.78s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.45s)
    [19/19] PASS  varlen rand 10seq T=2560  (2.01s)





  H=64 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.17s)
    [ 2/19] PASS  fixed T=256  (0.29s)
    [ 3/19] PASS  fixed T=385  (0.39s)
    [ 4/19] PASS  fixed T=512  (0.55s)
    [ 5/19] PASS  fixed T=1024  (0.84s)
    [ 6/19] PASS  varlen [128]  (0.17s)
    [ 7/19] PASS  varlen [256]  (0.28s)
    [ 8/19] PASS  varlen [384]  (0.36s)
    [ 9/19] PASS  varlen [512]  (0.44s)
    [10/19] PASS  varlen [256, 256]  (0.57s)
    [11/19] PASS  varlen [128, 256]  (0.40s)
    [12/19] PASS  varlen [384, 128]  (0.57s)
    [13/19] PASS  varlen [128, 128, 128]  (0.46s)
    [14/19] PASS  varlen [256, 128, 384]  (0.81s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (1.18s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (1.57s)
    [17/19] PASS  varlen rand 3seq T=896  (1.05s)
    [18/19] PASS  varlen rand 7seq T=1792  (2.09s)
    [19/19] PASS  varlen rand 10seq T=2560  (2.74s)

============================================================
Stage: chunk_h
============================================================

  H=16 (Hg=4)
    [ 1/19] PASS  fixed T=128  (2.91s)
    [ 2/19] PASS  fixed T=256  (0.21s)
    [ 3/19] PASS  fixed T=385  (0.28s)
    [ 4/19] PASS  fixed T=512  (0.35s)
    [ 5/19] PASS  fixed T=1024  (0.66s)
    [ 6/19] PASS  varlen [128]  (0.14s)
    [ 7/19] PASS  varlen [256]  (0.21s)
    [ 8/19] PASS  varlen [384]  (0.30s)
    [ 9/19] PASS  varlen [512]  (0.36s)
    [10/19] PASS  varlen [256, 256]  (0.34s)
    [11/19] PASS  varlen [128, 256]  (0.28s)
    [12/19] PASS  varlen [384, 128]  (0.34s)
    [13/19] PASS  varlen [128, 128, 128]  (0.30s)
    [14/19] PASS  varlen [256, 128, 384]  (0.51s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.71s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (1.01s)
    [17/19] PASS  varlen rand 3seq T=896  (0.57s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.11s)
    [19/19] PASS  varlen rand 10seq T=2560  (1.54s)

  H=16 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.14s)
    [ 2/19] PASS  fixed T=256  (0.23s)
    [ 3/19] PASS  fixed T=385  (0.31s)
    [ 4/19] PASS  fixed T=512  (0.34s)
    [ 5/19] PASS  fixed T=1024  (0.67s)
    [ 6/19] PASS  varlen [128]  (0.14s)
    [ 7/19] PASS  varlen [256]  (0.23s)
    [ 8/19] PASS  varlen [384]  (0.29s)
    [ 9/19] PASS  varlen [512]  (0.36s)
    [10/19] PASS  varlen [256, 256]  (0.37s)
    [11/19] PASS  varlen [128, 256]  (0.28s)
    [12/19] PASS  varlen [384, 128]  (0.36s)
    [13/19] PASS  varlen [128, 128, 128]  (0.29s)
    [14/19] PASS  varlen [256, 128, 384]  (0.52s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.80s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (1.00s)
    [17/19] PASS  varlen rand 3seq T=896  (0.60s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.22s)
    [19/19] PASS  varlen rand 10seq T=2560  (1.83s)

  H=24 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.18s)
    [ 2/19] PASS  fixed T=256  (0.30s)
    [ 3/19] PASS  fixed T=385  (0.44s)
    [ 4/19] PASS  fixed T=512  (0.54s)
    [ 5/19] PASS  fixed T=1024  (1.05s)
    [ 6/19] PASS  varlen [128]  (0.18s)
    [ 7/19] PASS  varlen [256]  (0.31s)
    [ 8/19] PASS  varlen [384]  (0.45s)
    [ 9/19] PASS  varlen [512]  (0.58s)
    [10/19] PASS  varlen [256, 256]  (0.59s)
    [11/19] PASS  varlen [128, 256]  (0.44s)
    [12/19] PASS  varlen [384, 128]  (0.56s)
    [13/19] PASS  varlen [128, 128, 128]  (0.43s)
    [14/19] PASS  varlen [256, 128, 384]  (0.84s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (1.20s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (1.74s)
    [17/19] PASS  varlen rand 3seq T=896  (0.94s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.80s)
    [19/19] PASS  varlen rand 10seq T=2560  (2.28s)

  H=32 (Hg=8)
    [ 1/19] PASS  fixed T=128  (0.23s)
    [ 2/19] PASS  fixed T=256  (0.39s)
    [ 3/19] PASS  fixed T=385  (0.54s)
    [ 4/19] PASS  fixed T=512  (0.62s)
    [ 5/19] PASS  fixed T=1024  (1.04s)
    [ 6/19] PASS  varlen [128]  (0.22s)
    [ 7/19] PASS  varlen [256]  (0.37s)
    [ 8/19] PASS  varlen [384]  (0.46s)
    [ 9/19] PASS  varlen [512]  (0.63s)
    [10/19] PASS  varlen [256, 256]  (0.65s)
    [11/19] PASS  varlen [128, 256]  (0.47s)
    [12/19] PASS  varlen [384, 128]  (0.69s)
    [13/19] PASS  varlen [128, 128, 128]  (0.53s)
    [14/19] PASS  varlen [256, 128, 384]  (0.99s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (1.40s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (2.09s)
    [17/19] PASS  varlen rand 3seq T=896  (1.03s)
    [18/19] PASS  varlen rand 7seq T=1792  (1.92s)
    [19/19] PASS  varlen rand 10seq T=2560  (3.20s)

  H=48 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.31s)
    [ 2/19] PASS  fixed T=256  (0.48s)
    [ 3/19] PASS  fixed T=385  (0.75s)
    [ 4/19] PASS  fixed T=512  (0.90s)
    [ 5/19] PASS  fixed T=1024  (1.74s)
    [ 6/19] PASS  varlen [128]  (0.29s)
    [ 7/19] PASS  varlen [256]  (0.46s)
    [ 8/19] PASS  varlen [384]  (0.67s)
    [ 9/19] PASS  varlen [512]  (0.93s)
    [10/19] PASS  varlen [256, 256]  (0.92s)
    [11/19] PASS  varlen [128, 256]  (0.81s)
    [12/19] PASS  varlen [384, 128]  (0.83s)
    [13/19] PASS  varlen [128, 128, 128]  (0.74s)
    [14/19] PASS  varlen [256, 128, 384]  (1.34s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (1.90s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (2.95s)
    [17/19] PASS  varlen rand 3seq T=896  (1.56s)
    [18/19] PASS  varlen rand 7seq T=1792  (2.80s)
    [19/19] PASS  varlen rand 10seq T=2560  (3.88s)

  H=64 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.38s)
    [ 2/19] PASS  fixed T=256  (0.65s)
    [ 3/19] PASS  fixed T=385  (1.05s)
    [ 4/19] PASS  fixed T=512  (1.38s)
    [ 5/19] PASS  fixed T=1024  (2.69s)
    [ 6/19] PASS  varlen [128]  (0.38s)
    [ 7/19] PASS  varlen [256]  (0.73s)
    [ 8/19] PASS  varlen [384]  (1.06s)
    [ 9/19] PASS  varlen [512]  (1.37s)
    [10/19] PASS  varlen [256, 256]  (1.38s)
    [11/19] PASS  varlen [128, 256]  (1.04s)
    [12/19] PASS  varlen [384, 128]  (1.38s)
    [13/19] PASS  varlen [128, 128, 128]  (1.08s)
    [14/19] PASS  varlen [256, 128, 384]  (2.03s)
    [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (2.92s)
    [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (3.91s)
    [17/19] PASS  varlen rand 3seq T=896  (1.69s)
    [18/19] PASS  varlen rand 7seq T=1792  (3.87s)
    [19/19] PASS  varlen rand 10seq T=2560  (5.58s)

============================================================
Stage: wy_fast
============================================================

  H=16 (Hg=4)
    [ 1/19] PASS  fixed T=128  (2.85s)
    [ 2/19] PASS  fixed T=256  (0.15s)
    [ 3/19] PASS  fixed T=385  (0.22s)
    [ 4/19] PASS  fixed T=512  (0.27s)
    [ 5/19] PASS  fixed T=1024  (0.45s)
    [ 6/19] PASS  varlen [128]  (0.09s)
    [ 7/19] PASS  varlen [256]  (0.16s)
    [ 8/19] PASS  varlen [384]  (0.20s)
    [ 9/19] PASS  varlen [512]  (0.28s)
    [10/19] PASS  varlen [256, 256]  (0.27s)
    [11/19] PASS  varlen [128, 256]  (0.21s)
    [12/19] PASS  varlen [384, 128]  (0.27s)
    [13/19] PASS  varlen [128, 128, 128]  (0.22s)
    [14/19] PASS  varlen [256, 128, 384]  (0.39s)
ERROR: large frobenius relative error: 0.012925724178695702. FTOL=0.001
    [15/19] FAIL  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.52s)
ERROR: large frobenius relative error: 0.03185979563319676. FTOL=0.001
    [16/19] FAIL  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.77s)
    [17/19] PASS  varlen rand 3seq T=896  (0.46s)
    [18/19] PASS  varlen rand 7seq T=1792  (0.84s)
    [19/19] PASS  varlen rand 10seq T=2560  (0.96s)

  H=16 (Hg=16)
    [ 1/19] PASS  fixed T=128  (0.09s)
    [ 2/19] PASS  fixed T=256  (0.17s)
ERROR: large frobenius relative error: 0.052853597945602945. FTOL=0.001
    [ 3/19] FAIL  fixed T=385  (0.20s)
    [ 4/19] PASS  fixed T=512  (0.29s)
    [ 5/19] PASS  fixed T=1024  (0.49s)
    [ 6/19] PASS  varlen [128]  (0.10s)
    [ 7/19] PASS  varlen [256]  (0.17s)




^C
已发送终止请求: task_20260810_230023_2521863，等待确认...
任务已终止

```

### KDA

```
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python tests/test_kda_single_kernels.py"
任务已提交: task_20260810_225223_2506353 (断开后可用 task-submit --wait task_20260810_225223_2506353 重连)
等待任务执行: task_20260810_225223_2506353 (Ctrl+C 终止任务)
[npu-lock] 获取设备 1 的锁 (无超时)...
[npu-lock] 已获取设备 1 的锁 (pid=2517982)
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/_path_manager.py:66: UserWarning: Permission mismatch: The owner of /home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/lib/libop_plugin_atb.so does not match.
  warnings.warn(f"Permission mismatch: The owner of {path} does not match.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/megagdn_pto/fast_inverse.py:177: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at ../torch_npu/csrc/aten/common/TensorFactories.cpp:340.)
  tensor_out = torch.zeros_like(A_fp16, dtype=torch.float32)
device=npu:0  H=4  K=128  V=128  CHUNK=128  cases=19

============================================================
Stage: Gate cumsum
============================================================
  [ 1/19] PASS  fixed T=128  (2.37s)
  [ 2/19] PASS  fixed T=256  (0.03s)
  [ 3/19] PASS  fixed T=385  (0.03s)
  [ 4/19] PASS  fixed T=512  (0.03s)
  [ 5/19] PASS  fixed T=1024  (0.05s)
  [ 6/19] PASS  varlen [128]  (0.02s)
  [ 7/19] PASS  varlen [256]  (0.02s)
  [ 8/19] PASS  varlen [384]  (0.03s)
  [ 9/19] PASS  varlen [512]  (0.03s)
  [10/19] PASS  varlen [256, 256]  (0.03s)
  [11/19] PASS  varlen [128, 256]  (0.03s)
  [12/19] PASS  varlen [384, 128]  (0.03s)
  [13/19] PASS  varlen [128, 128, 128]  (0.03s)
  [14/19] PASS  varlen [256, 128, 384]  (0.04s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.05s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.06s)
  [17/19] PASS  varlen rand 3seq T=896  (0.04s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.07s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.09s)

============================================================
Stage: KKT NPU kernel
============================================================
  [ 1/19] PASS  fixed T=128  (2.62s)
  [ 2/19] PASS  fixed T=256  (0.05s)
  [ 3/19] PASS  fixed T=385  (0.07s)
  [ 4/19] PASS  fixed T=512  (0.09s)
  [ 5/19] PASS  fixed T=1024  (0.14s)
  [ 6/19] PASS  varlen [128]  (0.03s)
  [ 7/19] PASS  varlen [256]  (0.05s)
  [ 8/19] PASS  varlen [384]  (0.04s)
  [ 9/19] PASS  varlen [512]  (0.05s)
  [10/19] PASS  varlen [256, 256]  (0.06s)
  [11/19] PASS  varlen [128, 256]  (0.04s)
  [12/19] PASS  varlen [384, 128]  (0.05s)
  [13/19] PASS  varlen [128, 128, 128]  (0.06s)
  [14/19] PASS  varlen [256, 128, 384]  (0.07s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.11s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.17s)
  [17/19] PASS  varlen rand 3seq T=896  (0.07s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.15s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.31s)

============================================================
Stage: Linalg (I+L)^{-1}
============================================================
  [ 1/19] PASS  fixed T=128  (0.05s)
  [ 2/19] PASS  fixed T=256  (0.06s)
  [ 3/19] PASS  fixed T=385  (0.08s)
  [ 4/19] PASS  fixed T=512  (0.10s)
  [ 5/19] PASS  fixed T=1024  (0.17s)
  [ 6/19] PASS  varlen [128]  (0.04s)
  [ 7/19] PASS  varlen [256]  (0.06s)
  [ 8/19] PASS  varlen [384]  (0.08s)
  [ 9/19] PASS  varlen [512]  (0.10s)
  [10/19] PASS  varlen [256, 256]  (0.10s)
  [11/19] PASS  varlen [128, 256]  (0.08s)
  [12/19] PASS  varlen [384, 128]  (0.10s)
  [13/19] PASS  varlen [128, 128, 128]  (0.08s)
  [14/19] PASS  varlen [256, 128, 384]  (0.14s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.19s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.26s)
  [17/19] PASS  varlen rand 3seq T=896  (0.16s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.29s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.41s)

============================================================
Stage: WY transform (u, w)
============================================================
  [ 1/19] PASS  fixed T=128  (2.78s)
  [ 2/19] PASS  fixed T=256  (0.09s)
  [ 3/19] PASS  fixed T=385  (0.12s)
  [ 4/19] PASS  fixed T=512  (0.15s)
  [ 5/19] PASS  fixed T=1024  (0.27s)
  [ 6/19] PASS  varlen [128]  (0.06s)
  [ 7/19] PASS  varlen [256]  (0.09s)
  [ 8/19] PASS  varlen [384]  (0.12s)
  [ 9/19] PASS  varlen [512]  (0.15s)
  [10/19] PASS  varlen [256, 256]  (0.15s)
  [11/19] PASS  varlen [128, 256]  (0.12s)
  [12/19] PASS  varlen [384, 128]  (0.15s)
  [13/19] PASS  varlen [128, 128, 128]  (0.12s)
  [14/19] PASS  varlen [256, 128, 384]  (0.21s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.26s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.41s)
  [17/19] PASS  varlen rand 3seq T=896  (0.22s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.38s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.48s)

============================================================
Stage: chunk_h_kda (snapshots)
============================================================
  [ 1/19] PASS  fixed T=128  (2.83s)
  [ 2/19] PASS  fixed T=256  (0.11s)
  [ 3/19] PASS  fixed T=385  (0.15s)
  [ 4/19] PASS  fixed T=512  (0.18s)
  [ 5/19] PASS  fixed T=1024  (0.33s)
  [ 6/19] PASS  varlen [128]  (0.07s)
  [ 7/19] PASS  varlen [256]  (0.11s)
  [ 8/19] PASS  varlen [384]  (0.15s)
  [ 9/19] PASS  varlen [512]  (0.18s)
  [10/19] PASS  varlen [256, 256]  (0.18s)
  [11/19] PASS  varlen [128, 256]  (0.13s)
  [12/19] PASS  varlen [384, 128]  (0.19s)
  [13/19] PASS  varlen [128, 128, 128]  (0.15s)
  [14/19] PASS  varlen [256, 128, 384]  (0.25s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.35s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.50s)
  [17/19] PASS  varlen rand 3seq T=896  (0.28s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.45s)
  [19/19] PASS  varlen rand 10seq T=2560  (0.70s)

============================================================
Stage: chunk_o_kda (output)
============================================================
  [ 1/19] PASS  fixed T=128  (2.85s)
  [ 2/19] PASS  fixed T=256  (0.13s)
  [ 3/19] PASS  fixed T=385  (0.20s)
  [ 4/19] PASS  fixed T=512  (0.23s)
  [ 5/19] PASS  fixed T=1024  (0.44s)
  [ 6/19] PASS  varlen [128]  (0.09s)
  [ 7/19] PASS  varlen [256]  (0.15s)
  [ 8/19] PASS  varlen [384]  (0.19s)
  [ 9/19] PASS  varlen [512]  (0.24s)
  [10/19] PASS  varlen [256, 256]  (0.25s)
  [11/19] PASS  varlen [128, 256]  (0.18s)
  [12/19] PASS  varlen [384, 128]  (0.25s)
  [13/19] PASS  varlen [128, 128, 128]  (0.19s)
  [14/19] PASS  varlen [256, 128, 384]  (0.36s)
  [15/19] PASS  varlen [1, 63, 64, 65, 127, 128, 129, 447]  (0.44s)
  [16/19] PASS  varlen [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367]  (0.72s)
  [17/19] PASS  varlen rand 3seq T=896  (0.32s)
  [18/19] PASS  varlen rand 7seq T=1792  (0.62s)
  [19/19] PASS  varlen rand 10seq T=2560  (1.00s)

ALL PASS
[npu-lock] 已释放设备 1 的锁
=== 任务完成 (exit=0) ===
(venv) [zouzias@localhost megagdn-pto]$ git log -1
commit 5be80f3632d7446c22fa44d364eb785598ba9fc0 (HEAD -> 50-enable-a5-compilation-on-all-kernels, origin/50-enable-a5-compilation-on-all-kernels)
Author: anastasios <anastasios.zouzias@huawei.com>
Date:   Mon Aug 10 14:47:39 2026 +0000

    fix tri_inv
(venv) [zouzias@localhost megagdn-pto]$ git rev-parse  HEAD
5be80f3632d7446c22fa44d364eb785598ba9fc0

```