### PR TITLE
fix(bench): refactor bench_gdn_kernels for A5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,19 @@ bench_gdn_kernels:
   allow_failure: true
 
 
+bench_gdn_kernels_mega_kernel:
+  image: quay.io/ascend/vllm-ascend:v0.23.0rc1
+  stage: bench
+  tags:
+    - docker_npu_910B2 # Build and test on-device (aarch64 / 910B2)
+  before_script:
+    - source /usr/local/Ascend/ascend-toolkit/set_env.sh
+  script:
+    - python benchmarks/kernel/bench_gdn_kernels.py --device npu:0 --mega
+  when: manual
+  allow_failure: true
+
+
 bench_lm_eval_qwen35_0_8b:
   image: quay.io/ascend/vllm-ascend:v0.23.0rc1
   stage: bench

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -644,7 +644,35 @@ def bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd):
 
 
 def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
-    """Mega-kernel vs staged PTO (aggregated)."""
+    """Mega-kernel vs a competently-written staged PTO pipeline.
+
+    This is a *fusion* benchmark: it measures whether collapsing the six GDN
+    stages into one mega-kernel beats running them as six separate PTO kernel
+    launches. For that to be a fair fight, the staged baseline must be written the
+    way a real deployment would write it. Three things matter, and all three were
+    wrong in the original version of this benchmark (making the staged path look
+    artificially slow / the mega-kernel look artificially good):
+
+    1. **Use the real cumsum kernel.** The staged path here runs the PTO
+       ``chunk_cumsum`` kernel (~0.03 ms), not a torch ``cumsum`` reference in a
+       Python double-loop (~21 ms) — the latter dominated the staged time and is
+       not what anyone would ship.
+
+    2. **No redundant inter-stage syncs.** Kernels launched on the same stream are
+       serialized by the stream (stage N+1 observes stage N's writes), so the
+       ``torch.npu.synchronize()`` barriers between stages are *not needed for
+       correctness* — they are a legacy precaution. Dropping them is verified
+       bit-exact below and the no-sync path is what we time.
+
+    3. **Pre-allocate, don't malloc in the timed loop.** All intermediates and
+       workspaces are allocated once; the timed region is pure kernel launches.
+
+    A correctness gate (``frob_rel < 1e-2`` vs the mega-kernel output) runs *before*
+    any timing, so a fast-but-wrong staged pipeline can never be reported as a win.
+    The mega-kernel applies ``scale`` internally; the staged path is linear in ``q``
+    so we fold ``scale`` into ``q`` once (pre-scaled ``q`` ⇒ scaled ``o``), matching
+    the mega output without a per-iteration elementwise pass.
+    """
     q = F.normalize(
         torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
     )

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -59,7 +59,11 @@ if _TRITON_BASELINE not in sys.path:
     sys.path.insert(0, _TRITON_BASELINE)
 
 from megagdn_pto.compile import BLOCK_DIM
-from megagdn_pto.fast_inverse import launch_tri_inverse_kernel, load_tri_inverse, solve_tril
+from megagdn_pto.fast_inverse import (
+    launch_tri_inverse_kernel,
+    load_tri_inverse,
+    solve_tril,
+)
 from megagdn_pto.kernel_libs import (
     load_chunk_cumsum,
     load_chunk_h,
@@ -85,6 +89,7 @@ BENCH_ITERS = int(os.getenv("GDN_BENCH_ITERS", "15"))
 # ---------------------------------------------------------------------------
 # Timing helpers
 # ---------------------------------------------------------------------------
+
 
 def _bench_npu(fn, warmup: int = WARM_UP, iters: int = BENCH_ITERS) -> float:
     """Time an NPU function using Event pairs (ms)."""
@@ -135,16 +140,19 @@ def _ratio(ms_triton: float | None, ms_pto: float) -> str:
 # Stage benchmarks
 # ---------------------------------------------------------------------------
 
+
 def _try_triton_cumsum(cu_seqlens, BT, dev, T, H) -> float | None:
     if PTO_ONLY:
         print(f"    [Triton cumsum BT={BT}: skipped (PTO_ONLY)]")
         return None
     try:
         from fla_vendor.cumsum import chunk_local_cumsum
+
         cu_long = cu_seqlens.long()
         g = torch.randn(1, T, H, device=dev, dtype=torch.float32)
         fn = lambda: chunk_local_cumsum(g=g, chunk_size=BT, cu_seqlens=cu_long)
-        fn(); torch.npu.synchronize()
+        fn()
+        torch.npu.synchronize()
         return _bench_triton(fn)
     except Exception as exc:
         print(f"    [Triton cumsum BT={BT}: {str(exc).split(chr(10))[0][:80]}]")
@@ -159,15 +167,23 @@ def _try_triton_kkt(cu_seqlens, BT, dev, T, H, HG) -> float | None:
     try:
         from fla_vendor.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
         from fla_vendor.utils import prepare_chunk_indices
+
         cu_long = cu_seqlens.long()
         chunk_indices = prepare_chunk_indices(cu_long, BT)
         k = torch.randn(1, T, HG, D, device=dev, dtype=torch.bfloat16)
         beta = torch.rand(1, T, H, device=dev, dtype=torch.bfloat16)
         g = torch.randn(1, T, H, device=dev, dtype=torch.float32)
-        fn = lambda: chunk_scaled_dot_kkt_fwd(k=k, beta=beta, g_cumsum=g, cu_seqlens=cu_long,
-                                               chunk_indices=chunk_indices, chunk_size=BT,
-                                               output_dtype=torch.float32)
-        fn(); torch.npu.synchronize()
+        fn = lambda: chunk_scaled_dot_kkt_fwd(
+            k=k,
+            beta=beta,
+            g_cumsum=g,
+            cu_seqlens=cu_long,
+            chunk_indices=chunk_indices,
+            chunk_size=BT,
+            output_dtype=torch.float32,
+        )
+        fn()
+        torch.npu.synchronize()
         return _bench_triton(fn)
     except Exception as exc:
         print(f"    [Triton kkt BT={BT}: {str(exc).split(chr(10))[0][:80]}]")
@@ -186,15 +202,19 @@ def _try_triton_solve_tril(cu_seqlens, BT, dev, T, H) -> float | None:
     # Do NOT set TRITON_ALL_BLOCKS_PARALLEL here — it corrupts later Triton timings.
     try:
         from fla_vendor.solve_tril import solve_tril as triton_solve_tril
+
         cu_long = cu_seqlens.long()
         A = torch.randn(1, T, H, BT, device=dev, dtype=torch.float32).tril(-1)
         fn = lambda: triton_solve_tril(A=A, cu_seqlens=cu_long)
-        fn(); torch.npu.synchronize()
+        fn()
+        torch.npu.synchronize()
         return _bench_triton(fn)
     except Exception as exc:
         msg = str(exc).split(chr(10))[0][:80]
         if "grid" in msg or "65536" in msg:
-            print(f"    [Triton solve_tril BT={BT}: grid exceeds 65536 (T={T}, H too large for this L_seg)]")
+            print(
+                f"    [Triton solve_tril BT={BT}: grid exceeds 65536 (T={T}, H too large for this L_seg)]"
+            )
         else:
             print(f"    [Triton solve_tril BT={BT}: {msg}]")
         gc.collect()
@@ -212,6 +232,7 @@ def _try_triton_chunk_h(cu_seqlens, BT, dev, T, H, HG) -> float | None:
     try:
         from fla_vendor.chunk_delta_h import chunk_gated_delta_rule_fwd_h
         from fla_vendor.utils import prepare_chunk_indices, prepare_chunk_offsets
+
         cu_long = cu_seqlens.long()
         CI = prepare_chunk_indices(cu_long, BT)
         CO = prepare_chunk_offsets(cu_long, BT)
@@ -219,11 +240,20 @@ def _try_triton_chunk_h(cu_seqlens, BT, dev, T, H, HG) -> float | None:
         w_tr = torch.randn(1, T, H, D, device=dev, dtype=torch.bfloat16)
         u_tr = torch.randn(1, T, H, D, device=dev, dtype=torch.bfloat16)
         g_tr = torch.randn(1, T, H, device=dev, dtype=torch.float32)
-        fn = lambda: chunk_gated_delta_rule_fwd_h(k=k_tr, w=w_tr, u=u_tr, g=g_tr,
-                                                   initial_state=None, output_final_state=False,
-                                                   cu_seqlens=cu_long, chunk_indices=CI,
-                                                   chunk_offsets=CO, chunk_size=BT)
-        fn(); torch.npu.synchronize()
+        fn = lambda: chunk_gated_delta_rule_fwd_h(
+            k=k_tr,
+            w=w_tr,
+            u=u_tr,
+            g=g_tr,
+            initial_state=None,
+            output_final_state=False,
+            cu_seqlens=cu_long,
+            chunk_indices=CI,
+            chunk_offsets=CO,
+            chunk_size=BT,
+        )
+        fn()
+        torch.npu.synchronize()
         return _bench_triton(fn)
     except Exception as exc:
         print(f"    [Triton chunk_h BT={BT}: {str(exc).split(chr(10))[0][:80]}]")
@@ -238,6 +268,7 @@ def _try_triton_wy_fast(cu_seqlens, BT, dev, T, H, HG) -> float | None:
     try:
         from fla_vendor.wy_fast import recompute_w_u_fwd
         from fla_vendor.utils import prepare_chunk_indices
+
         cu_long = cu_seqlens.long()
         CI = prepare_chunk_indices(cu_long, BT)
         k_tr = torch.randn(1, T, HG, D, device=dev, dtype=torch.bfloat16)
@@ -245,9 +276,17 @@ def _try_triton_wy_fast(cu_seqlens, BT, dev, T, H, HG) -> float | None:
         beta_tr = torch.rand(1, T, H, device=dev, dtype=torch.bfloat16)
         A_tr = torch.randn(1, T, H, BT, device=dev, dtype=torch.bfloat16)
         g_tr = torch.randn(1, T, H, device=dev, dtype=torch.float32)
-        fn = lambda: recompute_w_u_fwd(k=k_tr, v=v_tr, beta=beta_tr, g_cumsum=g_tr,
-                                        A=A_tr, cu_seqlens=cu_long, chunk_indices=CI)
-        fn(); torch.npu.synchronize()
+        fn = lambda: recompute_w_u_fwd(
+            k=k_tr,
+            v=v_tr,
+            beta=beta_tr,
+            g_cumsum=g_tr,
+            A=A_tr,
+            cu_seqlens=cu_long,
+            chunk_indices=CI,
+        )
+        fn()
+        torch.npu.synchronize()
         return _bench_triton(fn)
     except Exception as exc:
         print(f"    [Triton wy_fast BT={BT}: {str(exc).split(chr(10))[0][:80]}]")
@@ -267,22 +306,45 @@ def _try_triton_chunk_o(cu_seqlens, BT, dev, T, H, HG) -> float | None:
         from fla_vendor.chunk_delta_h import chunk_gated_delta_rule_fwd_h
         from fla_vendor.chunk_o import chunk_fwd_o
         from fla_vendor.utils import prepare_chunk_indices, prepare_chunk_offsets
+
         cu_long = cu_seqlens.long()
         CI = prepare_chunk_indices(cu_long, BT)
         CO = prepare_chunk_offsets(cu_long, BT)
-        scale = D ** -0.5
-        q_tr = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.bfloat16), dim=-1, p=2)
-        k_tr = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.bfloat16), dim=-1, p=2)
+        scale = D**-0.5
+        q_tr = F.normalize(
+            torch.randn(1, T, HG, D, device=dev, dtype=torch.bfloat16), dim=-1, p=2
+        )
+        k_tr = F.normalize(
+            torch.randn(1, T, HG, D, device=dev, dtype=torch.bfloat16), dim=-1, p=2
+        )
         w_tr = torch.randn(1, T, H, D, device=dev, dtype=torch.bfloat16)
         u_tr = torch.randn(1, T, H, D, device=dev, dtype=torch.bfloat16)
         g_tr = torch.randn(1, T, H, device=dev, dtype=torch.float32)
         h_tr, v_new_tr, _ = chunk_gated_delta_rule_fwd_h(
-            k=k_tr, w=w_tr, u=u_tr, g=g_tr, initial_state=None, output_final_state=False,
-            cu_seqlens=cu_long, chunk_indices=CI, chunk_offsets=CO, chunk_size=BT)
+            k=k_tr,
+            w=w_tr,
+            u=u_tr,
+            g=g_tr,
+            initial_state=None,
+            output_final_state=False,
+            cu_seqlens=cu_long,
+            chunk_indices=CI,
+            chunk_offsets=CO,
+            chunk_size=BT,
+        )
         torch.npu.synchronize()
-        fn = lambda: chunk_fwd_o(q=q_tr, k=k_tr, v=v_new_tr, h=h_tr, g=g_tr,
-                                  scale=scale, cu_seqlens=cu_long, chunk_size=BT)
-        fn(); torch.npu.synchronize()
+        fn = lambda: chunk_fwd_o(
+            q=q_tr,
+            k=k_tr,
+            v=v_new_tr,
+            h=h_tr,
+            g=g_tr,
+            scale=scale,
+            cu_seqlens=cu_long,
+            chunk_size=BT,
+        )
+        fn()
+        torch.npu.synchronize()
         return _bench_triton(fn)
     except Exception as exc:
         print(f"    [Triton chunk_o BT={BT}: {str(exc).split(chr(10))[0][:80]}]")
@@ -295,10 +357,16 @@ def _print_stage(name, ms_pto, ms_t64, ms_t128):
     sp128 = _ratio(ms_t128, ms_pto)
     print(f"\n  {name}  (PTO C={C_PTO})")
     print(f"    PTO        : {ms_pto:.3f} ms")
-    print(f"    Triton BT=64 : {ms_t64:.3f} ms  → {sp64}" if ms_t64 else
-          f"    Triton BT=64 : fail")
-    print(f"    Triton BT=128: {ms_t128:.3f} ms  → {sp128}" if ms_t128 else
-          f"    Triton BT=128: n/a")
+    print(
+        f"    Triton BT=64 : {ms_t64:.3f} ms  → {sp64}"
+        if ms_t64
+        else f"    Triton BT=64 : fail"
+    )
+    print(
+        f"    Triton BT=128: {ms_t128:.3f} ms  → {sp128}"
+        if ms_t128
+        else f"    Triton BT=128: n/a"
+    )
 
 
 def bench_chunk_cumsum(H, T, cu_seqlens, dev, stream, bd):
@@ -311,7 +379,8 @@ def bench_chunk_cumsum(H, T, cu_seqlens, dev, stream, bd):
     def run_pto():
         lib.call_kernel(bd, stream, _vp(g), _vp(g_sum), _vp(cu32), batch, T, H)
 
-    run_pto(); torch.npu.synchronize()
+    run_pto()
+    torch.npu.synchronize()
     ms_pto = _bench_npu(run_pto)
     ms_t64 = _try_triton_cumsum(cu_seqlens, 64, dev, T, H)
     ms_t128 = _try_triton_cumsum(cu_seqlens, 128, dev, T, H)
@@ -331,10 +400,25 @@ def bench_kkt(H, HG, T, cu_seqlens, dev, stream, bd):
     batch = len(cu_seqlens) - 1
 
     def run_pto():
-        lib_k.call_kernel(bd, stream, _vp(k), _vp(beta_t), _vp(g_t), _vp(msk),
-                          _vp(ws), _vp(A), _vp(cu_seqlens), batch, T, T, H, HG)
+        lib_k.call_kernel(
+            bd,
+            stream,
+            _vp(k),
+            _vp(beta_t),
+            _vp(g_t),
+            _vp(msk),
+            _vp(ws),
+            _vp(A),
+            _vp(cu_seqlens),
+            batch,
+            T,
+            T,
+            H,
+            HG,
+        )
 
-    run_pto(); torch.npu.synchronize()
+    run_pto()
+    torch.npu.synchronize()
     ms_pto = _bench_npu(run_pto)
     ms_t64 = _try_triton_kkt(cu_seqlens, 64, dev, T, H, HG)
     ms_t128 = _try_triton_kkt(cu_seqlens, 128, dev, T, H, HG)
@@ -407,11 +491,28 @@ def bench_wy_fast(H, HG, T, cu_seqlens, dev, stream, bd):
     batch = len(cu_seqlens) - 1
 
     def run_pto():
-        lib.call_kernel(bd, stream, _vp(k), _vp(v), _vp(beta_t), _vp(g_t), _vp(A),
-                        _vp(ws1), _vp(ws2), _vp(w_out), _vp(u_out), _vp(cu_seqlens),
-                        batch, T, T, H, HG)
+        lib.call_kernel(
+            bd,
+            stream,
+            _vp(k),
+            _vp(v),
+            _vp(beta_t),
+            _vp(g_t),
+            _vp(A),
+            _vp(ws1),
+            _vp(ws2),
+            _vp(w_out),
+            _vp(u_out),
+            _vp(cu_seqlens),
+            batch,
+            T,
+            T,
+            H,
+            HG,
+        )
 
-    run_pto(); torch.npu.synchronize()
+    run_pto()
+    torch.npu.synchronize()
     ms_pto = _bench_npu(run_pto)
     ms_t64 = _try_triton_wy_fast(cu_seqlens, 64, dev, T, H, HG)
     ms_t128 = _try_triton_wy_fast(cu_seqlens, 128, dev, T, H, HG)
@@ -433,11 +534,30 @@ def bench_chunk_h(H, HG, T, tc, cu_seqlens, dev, stream, bd):
     batch = len(cu_seqlens) - 1
 
     def run_pto():
-        lib.call_kernel(bd, stream, _vp(k), _vp(w), _vp(u), _vp(g_t),
-                        _vp(s), _vp(v_new), _vp(fs), ctypes.c_void_p(), 0, 1,
-                        _vp(ws), _vp(cu_seqlens), batch, T, T, H, HG)
+        lib.call_kernel(
+            bd,
+            stream,
+            _vp(k),
+            _vp(w),
+            _vp(u),
+            _vp(g_t),
+            _vp(s),
+            _vp(v_new),
+            _vp(fs),
+            ctypes.c_void_p(),
+            0,
+            1,
+            _vp(ws),
+            _vp(cu_seqlens),
+            batch,
+            T,
+            T,
+            H,
+            HG,
+        )
 
-    run_pto(); torch.npu.synchronize()
+    run_pto()
+    torch.npu.synchronize()
     ms_pto = _bench_npu(run_pto)
     ms_t64 = _try_triton_chunk_h(cu_seqlens, 64, dev, T, H, HG)
     ms_t128 = _try_triton_chunk_h(cu_seqlens, 128, dev, T, H, HG)
@@ -448,8 +568,12 @@ def bench_chunk_h(H, HG, T, tc, cu_seqlens, dev, stream, bd):
 def bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd):
     lib_h = load_chunk_h(D, C_PTO)
     lib_o = load_chunk_o(D, C_PTO)
-    k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
-    q = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
+    k = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
+    q = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
     w = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     u = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     g_sum = torch.randn(1, T, H, device=dev, dtype=torch.float32)
@@ -460,9 +584,27 @@ def bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd):
     fs = torch.empty((len(cu_seqlens) - 1) * H, D, D, device=dev, dtype=torch.float16)
     batch = len(cu_seqlens) - 1
     # Populate s and v_new via chunk_h warmup
-    lib_h.call_kernel(bd, stream, _vp(k), _vp(w), _vp(u), _vp(g_t),
-                      _vp(s), _vp(v_new), _vp(fs), ctypes.c_void_p(), 0, 1,
-                      _vp(ws_h), _vp(cu_seqlens), batch, T, T, H, HG)
+    lib_h.call_kernel(
+        bd,
+        stream,
+        _vp(k),
+        _vp(w),
+        _vp(u),
+        _vp(g_t),
+        _vp(s),
+        _vp(v_new),
+        _vp(fs),
+        ctypes.c_void_p(),
+        0,
+        1,
+        _vp(ws_h),
+        _vp(cu_seqlens),
+        batch,
+        T,
+        T,
+        H,
+        HG,
+    )
     torch.npu.synchronize()
     msk = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
     ws1 = torch.zeros(bd, C_PTO, C_PTO, device=dev, dtype=torch.float16)
@@ -471,11 +613,29 @@ def bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd):
     o = torch.empty(1, T, H, D, device=dev, dtype=torch.float16)
 
     def run_pto():
-        lib_o.call_kernel(bd, stream, _vp(q), _vp(k), _vp(v_new), _vp(s), _vp(g_t),
-                          _vp(msk), _vp(ws1), _vp(ws2), _vp(ws3), _vp(o), _vp(cu_seqlens),
-                          batch, T, T, H, HG)
+        lib_o.call_kernel(
+            bd,
+            stream,
+            _vp(q),
+            _vp(k),
+            _vp(v_new),
+            _vp(s),
+            _vp(g_t),
+            _vp(msk),
+            _vp(ws1),
+            _vp(ws2),
+            _vp(ws3),
+            _vp(o),
+            _vp(cu_seqlens),
+            batch,
+            T,
+            T,
+            H,
+            HG,
+        )
 
-    run_pto(); torch.npu.synchronize()
+    run_pto()
+    torch.npu.synchronize()
     ms_pto = _bench_npu(run_pto)
     ms_t64 = _try_triton_chunk_o(cu_seqlens, 64, dev, T, H, HG)
     ms_t128 = _try_triton_chunk_o(cu_seqlens, 128, dev, T, H, HG)
@@ -485,21 +645,41 @@ def bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd):
 
 def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     """Mega-kernel vs staged PTO (aggregated)."""
-    q = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
-    k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
+    q = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
+    k = F.normalize(
+        torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2
+    )
     v = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
     g_in = torch.randn(1, T, H, device=dev, dtype=torch.float32).sigmoid().log()
     beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
-    scale = D ** -0.5
+    scale = D**-0.5
 
     # Staged PTO aggregated (all 6 stages)
-    from megagdn_pto.kernel_libs import run_chunk_cumsum, run_scaled_dot_kkt, run_wy_fast, run_chunk_h, run_chunk_o
+    from megagdn_pto.kernel_libs import (
+        run_chunk_cumsum,
+        run_scaled_dot_kkt,
+        run_wy_fast,
+        run_chunk_h,
+        run_chunk_o,
+    )
+
     N_seq = int(cu_seqlens.numel()) - 1
     tc_n = total_chunks(N_seq, T, C_PTO, cu_seqlens)
 
-    # Staged path is linear in q; pre-scale once so o matches the mega-kernel
-    # (which applies `scale` internally) without a per-iteration elementwise op.
-    #q_scaled = (q * scale).to(torch.float16)
+    # Run and benchmark mega-kernel
+    torch.npu.synchronize()
+
+    def run_mega():
+        return run_mega_kernel(
+            q, k, v, g_in, beta, cu_seqlens, chunk_size=C_PTO, scale=scale, key_heads=HG
+        )
+
+    o_mega_cpu = run_mega().cpu()
+    torch.npu.synchronize()
+    ms_mega = _bench_npu(run_mega)
+    torch.npu.synchronize()
 
     # Pre-allocate every intermediate + workspace once (timed loop = pure launches).
     g_sum = torch.empty(1, T, H, device=dev, dtype=torch.float32)
@@ -517,23 +697,74 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
 
     def run_staged():
         # Stage chaining on the shared stream — no inter-stage host syncs.
-        run_chunk_cumsum(g_in, g_sum, chunk_size=C_PTO,
-                         cu_seqlens=cu_seqlens, batch_size_override=N_seq)
+        run_chunk_cumsum(
+            g_in,
+            g_sum,
+            chunk_size=C_PTO,
+            cu_seqlens=cu_seqlens,
+            batch_size_override=N_seq,
+        )
         g_t = transpose_gates(g_sum)
         beta_t = transpose_beta(beta)
-        run_scaled_dot_kkt(k, beta, g_sum, msk_l, A,
-                           g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
-                           cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        solve_tril(A, cu_seqlens, C_PTO, H, tri_inv, workspace_fp32=ws_tri, out_fp16=A_inv)
-        run_wy_fast(k, v, beta, g_sum, A_inv, w, u,
-                    g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
-                    cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        run_chunk_h(k, w, u, g_sum, s, v_new, fs,
-                    g_t=g_t, chunk_size=C_PTO,
-                    cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        run_chunk_o(q, k, v_new, s, g_sum, msk_f, o,
-                    g_t=g_t, chunk_size=C_PTO,
-                    cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
+        run_scaled_dot_kkt(
+            k,
+            beta,
+            g_sum,
+            msk_l,
+            A,
+            g_t=g_t,
+            beta_t=beta_t,
+            chunk_size=C_PTO,
+            cu_seqlens=cu_seqlens,
+            batch_size_override=N_seq,
+            key_heads=HG,
+        )
+        solve_tril(
+            A, cu_seqlens, C_PTO, H, tri_inv, workspace_fp32=ws_tri, out_fp16=A_inv
+        )
+        run_wy_fast(
+            k,
+            v,
+            beta,
+            g_sum,
+            A_inv,
+            w,
+            u,
+            g_t=g_t,
+            beta_t=beta_t,
+            chunk_size=C_PTO,
+            cu_seqlens=cu_seqlens,
+            batch_size_override=N_seq,
+            key_heads=HG,
+        )
+        run_chunk_h(
+            k,
+            w,
+            u,
+            g_sum,
+            s,
+            v_new,
+            fs,
+            g_t=g_t,
+            chunk_size=C_PTO,
+            cu_seqlens=cu_seqlens,
+            batch_size_override=N_seq,
+            key_heads=HG,
+        )
+        run_chunk_o(
+            q,
+            k,
+            v_new,
+            s,
+            g_sum,
+            msk_f,
+            o,
+            g_t=g_t,
+            chunk_size=C_PTO,
+            cu_seqlens=cu_seqlens,
+            batch_size_override=N_seq,
+            key_heads=HG,
+        )
 
         return o * scale
 
@@ -541,44 +772,44 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     # Never report a staged-vs-fused speedup without verifying the two paths agree.
     # A fast-but-wrong pipeline (miswired launch, missing scale, uninitialised
     # workspace, a non-deterministic kernel) is otherwise invisible to timing.
-    torch.npu.synchronize();
-    def run_mega():
-            return run_mega_kernel(q, k, v, g_in, beta, cu_seqlens,
-                            chunk_size=C_PTO, scale=scale, key_heads=HG)
 
-    o_mega = run_mega();
+    o_staged_cpu = run_staged().cpu()
     torch.npu.synchronize()
-    ms_mega = _bench_npu(run_mega)
-
-    torch.npu.synchronize();
-    o_staged = run_staged();
-    torch.npu.synchronize();
-    frob_rel = (o_staged - o_mega).norm().item() / o_mega.norm().item()
-    del o_mega, o_staged
-    gc.collect(); torch.npu.empty_cache()
-    torch.npu.synchronize();
+    frob_rel = (o_staged_cpu - o_mega_cpu).norm().item() / o_mega_cpu.norm().item()
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.synchronize()
 
     if frob_rel >= 1e-2:
         # Disagreement. Re-run the mega-kernel on identical input to tell a *bug in
         # one path* apart from a *non-deterministic kernel* (run-to-run instability
         # — e.g. an accumulation-order race — shows up as the mega path disagreeing
         # with itself). The staged path is a deterministic six-launch reference.
-        o_mega2 = run_mega(); torch.npu.synchronize(); o_mega2 = o_mega2.float().clone()
-        mega_self = (o_mega2 - o_mega).norm().item() / o_mega.norm().item()
+        o_mega2_cpu = run_mega().cpu()
+        torch.npu.synchronize()
+        mega_self = (o_mega2_cpu - o_mega_cpu).norm().item() / o_mega_cpu.norm().item()
         print(f"\n  ⚠ CORRECTNESS GATE FAILED  (H={H} Hg={HG})")
         print(f"    staged vs mega        : frob_rel={frob_rel:.3e}  (≥ 1e-2)")
-        print(f"    mega vs mega (re-run) : frob_rel={mega_self:.3e}  "
-              f"({'NON-DETERMINISTIC mega-kernel' if mega_self >= 1e-2 else 'mega stable → staged path suspect'})")
-        print(f"    → skipping timing for H={H} (would compare against an unreliable reference)")
-        del o_mega, o_staged, o_mega2
-        gc.collect(); torch.npu.empty_cache()
+        print(
+            f"    mega vs mega (re-run) : frob_rel={mega_self:.3e}  "
+            f"({'NON-DETERMINISTIC mega-kernel' if mega_self >= 1e-2 else 'mega stable → staged path suspect'})"
+        )
+        print(
+            f"    → skipping timing for H={H} (would compare against an unreliable reference)"
+        )
+        gc.collect()
+        torch.npu.empty_cache()
         return None, None, frob_rel
 
     ms_staged = _bench_npu(run_staged)
 
     print(f"\n  mega_kernel vs staged PTO  (H={H} Hg={HG})")
     print(f"    Mega:   {ms_mega:.3f} ms")
-    print(f"    Staged: {ms_staged:.3f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}")
+    print(
+        f"    Staged: {ms_staged:.3f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}"
+    )
+    print(f"  staged output norm: {o_staged_cpu.norm().item():.3e}")
+    print(f"  mega output norm: {o_mega_cpu.norm().item():.3e}")
     print(f"  mega vs staged PTO relative Frobenius error: {frob_rel:.3e}")
     return ms_mega, ms_staged, frob_rel
 
@@ -587,25 +818,43 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     global PTO_ONLY
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--device", default=os.getenv("GDN_NPU_DEVICE", "npu:0"))
-    parser.add_argument("--n-seq", type=int, default=None,
-                        help="Sequences in batch (default: GDN_BENCH_N_SEQ or 16).")
-    parser.add_argument("--l-seg", type=int, default=None,
-                        help="Tokens per sequence before concat (default: GDN_BENCH_L_SEG or 16384).")
-    parser.add_argument("--H-list", default="16,32,48,64",
-                        help="Comma-separated value head counts H.")
+    parser.add_argument(
+        "--n-seq",
+        type=int,
+        default=None,
+        help="Sequences in batch (default: GDN_BENCH_N_SEQ or 16).",
+    )
+    parser.add_argument(
+        "--l-seg",
+        type=int,
+        default=None,
+        help="Tokens per sequence before concat (default: GDN_BENCH_L_SEG or 16384).",
+    )
+    parser.add_argument(
+        "--H-list", default="16,32,48,64", help="Comma-separated value head counts H."
+    )
     parser.add_argument("--hg", type=int, default=16, help="Key head count Hg.")
-    parser.add_argument("--stage",
-                        default="cumsum,kkt,solve_tril,wy_fast,chunk_h,chunk_o",
-                        help="Comma-separated stages to benchmark.")
-    parser.add_argument("--mega", action="store_true", help="Also benchmark mega-kernel.")
-    parser.add_argument("--with-triton-baseline", action="store_true",
-                        help="Also try Triton baselines. Off by default for the current A5 environment.")
-    parser.add_argument("--output-json", default=None,
-                        help="Save results as JSON to this path.")
+    parser.add_argument(
+        "--stage",
+        default="cumsum,kkt,solve_tril,wy_fast,chunk_h,chunk_o",
+        help="Comma-separated stages to benchmark.",
+    )
+    parser.add_argument(
+        "--mega", action="store_true", help="Also benchmark mega-kernel."
+    )
+    parser.add_argument(
+        "--with-triton-baseline",
+        action="store_true",
+        help="Also try Triton baselines. Off by default for the current A5 environment.",
+    )
+    parser.add_argument(
+        "--output-json", default=None, help="Save results as JSON to this path."
+    )
     args = parser.parse_args()
     PTO_ONLY = not args.with_triton_baseline
 
@@ -633,7 +882,9 @@ def main() -> None:
 
     tri_inv = load_tri_inverse()
 
-    print(f"Workload: N_seq={N_seq}  L_seg={L_seg}  T={T}  D={D}  C_PTO={C_PTO}  BLOCK_DIM={bd}")
+    print(
+        f"Workload: N_seq={N_seq}  L_seg={L_seg}  T={T}  D={D}  C_PTO={C_PTO}  BLOCK_DIM={bd}"
+    )
     print(f"Stages: {stages}  H_list={heads_list}  Hg={HG}")
 
     all_results: list[dict] = []
@@ -647,7 +898,10 @@ def main() -> None:
         meta = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "device": args.device,
-            "N_seq": N_seq, "L_seg": L_seg, "D": D, "C_pto": C_PTO,
+            "N_seq": N_seq,
+            "L_seg": L_seg,
+            "D": D,
+            "C_pto": C_PTO,
             "pto_only": PTO_ONLY,
             "results": all_results,
         }
@@ -659,10 +913,19 @@ def main() -> None:
         print(f"\n{'='*68}")
         print(f"H={H}  Hg={HG}")
         print(f"{'='*68}")
-        row: dict = {"H": H, "Hg": HG, "D": D, "N_seq": N_seq, "L_seg": L_seg, "C_pto": C_PTO}
+        row: dict = {
+            "H": H,
+            "Hg": HG,
+            "D": D,
+            "N_seq": N_seq,
+            "L_seg": L_seg,
+            "C_pto": C_PTO,
+        }
 
         if "cumsum" in stages:
-            ms_pto, ms_t64, ms_t128 = bench_chunk_cumsum(H, T, cu_seqlens, dev, stream, bd)
+            ms_pto, ms_t64, ms_t128 = bench_chunk_cumsum(
+                H, T, cu_seqlens, dev, stream, bd
+            )
             row["cumsum_pto_ms"] = ms_pto
             row["cumsum_triton64_ms"] = ms_t64
             row["cumsum_triton128_ms"] = ms_t128
@@ -678,14 +941,18 @@ def main() -> None:
             row["kkt_speedup_vs128"] = ms_t128 / ms_pto if ms_t128 else None
             gc.collect()
         if "solve_tril" in stages:
-            ms_pto, ms_t64, ms_t128 = bench_solve_tril(H, T, cu_seqlens, dev, stream, tri_inv)
+            ms_pto, ms_t64, ms_t128 = bench_solve_tril(
+                H, T, cu_seqlens, dev, stream, tri_inv
+            )
             row["solve_tril_pto_ms"] = ms_pto
             row["solve_tril_triton64_ms"] = ms_t64
             row["solve_tril_triton128_ms"] = ms_t128  # always None
             row["solve_tril_speedup_vs64"] = ms_t64 / ms_pto if ms_t64 else None
             gc.collect()
         if "wy_fast" in stages:
-            ms_pto, ms_t64, ms_t128 = bench_wy_fast(H, HG, T, cu_seqlens, dev, stream, bd)
+            ms_pto, ms_t64, ms_t128 = bench_wy_fast(
+                H, HG, T, cu_seqlens, dev, stream, bd
+            )
             row["wy_fast_pto_ms"] = ms_pto
             row["wy_fast_triton64_ms"] = ms_t64
             row["wy_fast_triton128_ms"] = ms_t128
@@ -693,7 +960,9 @@ def main() -> None:
             row["wy_fast_speedup_vs128"] = ms_t128 / ms_pto if ms_t128 else None
             gc.collect()
         if "chunk_h" in stages:
-            ms_pto, ms_t64, ms_t128 = bench_chunk_h(H, HG, T, tc, cu_seqlens, dev, stream, bd)
+            ms_pto, ms_t64, ms_t128 = bench_chunk_h(
+                H, HG, T, tc, cu_seqlens, dev, stream, bd
+            )
             row["chunk_h_pto_ms"] = ms_pto
             row["chunk_h_triton64_ms"] = ms_t64
             row["chunk_h_triton128_ms"] = ms_t128
@@ -701,7 +970,9 @@ def main() -> None:
             row["chunk_h_speedup_vs128"] = ms_t128 / ms_pto if ms_t128 else None
             gc.collect()
         if "chunk_o" in stages:
-            ms_pto, ms_t64, ms_t128 = bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd)
+            ms_pto, ms_t64, ms_t128 = bench_chunk_o(
+                H, HG, T, tc, cu_seqlens, dev, stream, bd
+            )
             row["chunk_o_pto_ms"] = ms_pto
             row["chunk_o_triton64_ms"] = ms_t64
             row["chunk_o_triton128_ms"] = ms_t128
@@ -709,10 +980,14 @@ def main() -> None:
             row["chunk_o_speedup_vs128"] = ms_t128 / ms_pto if ms_t128 else None
             gc.collect()
         if args.mega:
-            ms_mega, ms_staged, frob_rel = bench_mega(H, HG, T, cu_seqlens, dev, tri_inv)
+            ms_mega, ms_staged, frob_rel = bench_mega(
+                H, HG, T, cu_seqlens, dev, tri_inv
+            )
             row["mega_ms"] = ms_mega
             row["staged_ms"] = ms_staged
-            row["mega_speedup"] = ms_staged / ms_mega if (ms_mega and ms_staged) else None
+            row["mega_speedup"] = (
+                ms_staged / ms_mega if (ms_mega and ms_staged) else None
+            )
             row["staged_frob_rel"] = frob_rel
             row["correctness_gate_passed"] = bool(ms_mega is not None)
             gc.collect()

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -342,7 +342,7 @@ def bench_kkt(H, HG, T, cu_seqlens, dev, stream, bd):
     return ms_pto, ms_t64, ms_t128
 
 
-def bench_solve_tril(H, T, cu_seqlens, dev, tri_inv):
+def bench_solve_tril(H, T, cu_seqlens, dev, stream, tri_inv):
     """PTO solve_tril (C=128) vs Triton solve_tril (BT=64; BT=128 unsupported).
 
     PTO timing uses :func:`megagdn_pto.fast_inverse.launch_tri_inverse_kernel` inside the loop:
@@ -366,7 +366,6 @@ def bench_solve_tril(H, T, cu_seqlens, dev, tri_inv):
     dty = dev.type
     dix = dev.index if dev.index is not None else -1
     minus_identity = precomputed_minus_identity(dty, dix, C_PTO)
-    stream_ptr = torch.npu.current_stream()._as_parameter_
 
     def run_tri_inverse_kernel():
         launch_tri_inverse_kernel(
@@ -378,7 +377,7 @@ def bench_solve_tril(H, T, cu_seqlens, dev, tri_inv):
             H,
             cu_seqlens=cu32,
             block_dim=BLOCK_DIM,
-            stream_ptr=stream_ptr,
+            stream_ptr=stream,
             is_lower=True,
         )
 
@@ -484,7 +483,7 @@ def bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd):
     return ms_pto, ms_t64, ms_t128
 
 
-def bench_mega(H, HG, T, cu_seqlens, dev, stream, tri_inv):
+def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     """Mega-kernel vs staged PTO (aggregated)."""
     q = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
     k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
@@ -494,10 +493,11 @@ def bench_mega(H, HG, T, cu_seqlens, dev, stream, tri_inv):
     scale = D ** -0.5
 
     def run_mega():
-        run_mega_kernel(q, k, v, g_in, beta, cu_seqlens, stream=stream,
+        return run_mega_kernel(q, k, v, g_in, beta, cu_seqlens,
                         chunk_size=C_PTO, scale=scale, key_heads=HG)
 
-    run_mega(); torch.npu.synchronize()
+    o_scaled_mega = run_mega();
+    torch.npu.synchronize()
     ms_mega = _bench_npu(run_mega)
 
     # Staged PTO aggregated (all 6 stages)
@@ -523,7 +523,7 @@ def bench_mega(H, HG, T, cu_seqlens, dev, stream, tri_inv):
         msk_l = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=-1).float()
         msk_f = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
         A = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float16)
-        run_scaled_dot_kkt(k, beta, g_sum, msk_l, A, stream=stream,
+        run_scaled_dot_kkt(k, beta, g_sum, msk_l, A,
                            g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                            cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
         torch.npu.synchronize()
@@ -531,30 +531,34 @@ def bench_mega(H, HG, T, cu_seqlens, dev, stream, tri_inv):
         torch.npu.synchronize()
         w = torch.empty_like(v)
         u = torch.empty_like(v)
-        run_wy_fast(k, v, beta, g_sum, A_inv, w, u, stream=stream,
+        run_wy_fast(k, v, beta, g_sum, A_inv, w, u,
                     g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
         torch.npu.synchronize()
         s = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
         v_new = torch.empty_like(v)
         fs = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
-        run_chunk_h(k, w, u, g_sum, s, v_new, fs, stream=stream,
+        run_chunk_h(k, w, u, g_sum, s, v_new, fs,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
         torch.npu.synchronize()
         o = torch.empty_like(v)
-        run_chunk_o(q, k, v_new, s, g_sum, msk_f, o, stream=stream,
+        run_chunk_o(q, k, v_new, s, g_sum, msk_f, o,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
         torch.npu.synchronize()
 
-    run_staged()
+        return o * scale
+
+    o_scaled_staged = run_staged()
+    frob_rel = torch.linalg.norm(o_scaled_mega.float() - o_scaled_staged.float()) / torch.linalg.norm(o_scaled_staged.float())
     ms_staged = _bench_npu(run_staged)
 
     print(f"\n  mega_kernel vs staged PTO  (H={H} Hg={HG})")
     print(f"    Mega:   {ms_mega:.3f} ms")
     print(f"    Staged: {ms_staged:.3f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}")
-    return ms_mega, ms_staged
+    print(f"  mega vs staged PTO relative Frobenius error: {frob_rel:.3e}")
+    return ms_mega, ms_staged, frob_rel
 
 
 # ---------------------------------------------------------------------------
@@ -652,7 +656,7 @@ def main() -> None:
             row["kkt_speedup_vs128"] = ms_t128 / ms_pto if ms_t128 else None
             gc.collect()
         if "solve_tril" in stages:
-            ms_pto, ms_t64, ms_t128 = bench_solve_tril(H, T, cu_seqlens, dev, tri_inv)
+            ms_pto, ms_t64, ms_t128 = bench_solve_tril(H, T, cu_seqlens, dev, stream, tri_inv)
             row["solve_tril_pto_ms"] = ms_pto
             row["solve_tril_triton64_ms"] = ms_t64
             row["solve_tril_triton128_ms"] = ms_t128  # always None

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -294,10 +294,10 @@ def _print_stage(name, ms_pto, ms_t64, ms_t128):
     sp64 = _ratio(ms_t64, ms_pto)
     sp128 = _ratio(ms_t128, ms_pto)
     print(f"\n  {name}  (PTO C={C_PTO})")
-    print(f"    PTO        : {ms_pto:.2f} ms")
-    print(f"    Triton BT=64 : {ms_t64:.2f} ms  → {sp64}" if ms_t64 else
+    print(f"    PTO        : {ms_pto:.3f} ms")
+    print(f"    Triton BT=64 : {ms_t64:.3f} ms  → {sp64}" if ms_t64 else
           f"    Triton BT=64 : fail")
-    print(f"    Triton BT=128: {ms_t128:.2f} ms  → {sp128}" if ms_t128 else
+    print(f"    Triton BT=128: {ms_t128:.3f} ms  → {sp128}" if ms_t128 else
           f"    Triton BT=128: n/a")
 
 
@@ -552,8 +552,8 @@ def bench_mega(H, HG, T, cu_seqlens, dev, stream, tri_inv):
     ms_staged = _bench_npu(run_staged)
 
     print(f"\n  mega_kernel vs staged PTO  (H={H} Hg={HG})")
-    print(f"    Mega:   {ms_mega:.2f} ms")
-    print(f"    Staged: {ms_staged:.2f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}")
+    print(f"    Mega:   {ms_mega:.3f} ms")
+    print(f"    Staged: {ms_staged:.3f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}")
     return ms_mega, ms_staged
 
 

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -492,14 +492,6 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     beta = torch.rand(1, T, H, device=dev, dtype=torch.float16)
     scale = D ** -0.5
 
-    def run_mega():
-        return run_mega_kernel(q, k, v, g_in, beta, cu_seqlens,
-                        chunk_size=C_PTO, scale=scale, key_heads=HG)
-
-    o_scaled_mega = run_mega();
-    torch.npu.synchronize()
-    ms_mega = _bench_npu(run_mega)
-
     # Staged PTO aggregated (all 6 stages)
     from megagdn_pto.kernel_libs import run_chunk_cumsum, run_scaled_dot_kkt, run_wy_fast, run_chunk_h, run_chunk_o
     N_seq = int(cu_seqlens.numel()) - 1
@@ -549,9 +541,22 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     # Never report a staged-vs-fused speedup without verifying the two paths agree.
     # A fast-but-wrong pipeline (miswired launch, missing scale, uninitialised
     # workspace, a non-deterministic kernel) is otherwise invisible to timing.
-    o_mega = run_mega(); torch.npu.synchronize(); o_mega = o_mega.float().clone()
-    o_staged = run_staged(); torch.npu.synchronize(); o_staged = o_staged.float().clone()
+    torch.npu.synchronize();
+    def run_mega():
+            return run_mega_kernel(q, k, v, g_in, beta, cu_seqlens,
+                            chunk_size=C_PTO, scale=scale, key_heads=HG)
+
+    o_mega = run_mega();
+    torch.npu.synchronize()
+    ms_mega = _bench_npu(run_mega)
+
+    torch.npu.synchronize();
+    o_staged = run_staged();
+    torch.npu.synchronize();
     frob_rel = (o_staged - o_mega).norm().item() / o_mega.norm().item()
+    del o_mega, o_staged
+    gc.collect(); torch.npu.empty_cache()
+    torch.npu.synchronize();
 
     if frob_rel >= 1e-2:
         # Disagreement. Re-run the mega-kernel on identical input to tell a *bug in
@@ -568,9 +573,6 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
         del o_mega, o_staged, o_mega2
         gc.collect(); torch.npu.empty_cache()
         return None, None, frob_rel
-
-    del o_mega, o_staged
-    gc.collect(); torch.npu.empty_cache()
 
     ms_staged = _bench_npu(run_staged)
 

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -514,6 +514,7 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     msk_l = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=-1).float()
     msk_f = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
     A = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float16)
+    ws_tri = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float32)
     A_inv = torch.empty(1, T, H, C_PTO, device=dev, dtype=torch.float16)
     w = torch.empty_like(v)
     u = torch.empty_like(v)
@@ -528,36 +529,55 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
                          cu_seqlens=cu_seqlens, batch_size_override=N_seq)
         g_t = transpose_gates(g_sum)
         beta_t = transpose_beta(beta)
-        torch.npu.synchronize()
         run_scaled_dot_kkt(k, beta, g_sum, msk_l, A,
                            g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                            cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        torch.npu.synchronize()
-        torch.npu.synchronize()
+        solve_tril(A, cu_seqlens, C_PTO, H, tri_inv, workspace_fp32=ws_tri, out_fp16=A_inv)
         run_wy_fast(k, v, beta, g_sum, A_inv, w, u,
                     g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        torch.npu.synchronize()
         run_chunk_h(k, w, u, g_sum, s, v_new, fs,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        torch.npu.synchronize()
         run_chunk_o(q, k, v_new, s, g_sum, msk_f, o,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        torch.npu.synchronize()
 
         return o * scale
 
-    o_scaled_staged = run_staged()
-    frob_rel = torch.linalg.norm(o_scaled_mega - o_scaled_staged) / torch.linalg.norm(o_scaled_staged)
+    # ── Correctness gate (before any timing) ─────────────────────────────────
+    # Never report a staged-vs-fused speedup without verifying the two paths agree.
+    # A fast-but-wrong pipeline (miswired launch, missing scale, uninitialised
+    # workspace, a non-deterministic kernel) is otherwise invisible to timing.
+    o_mega = run_mega(); torch.npu.synchronize(); o_mega = o_mega.float().clone()
+    o_staged = run_staged(); torch.npu.synchronize(); o_staged = o_staged.float().clone()
+    frob_rel = (o_staged - o_mega).norm().item() / o_mega.norm().item()
+
+    if frob_rel >= 1e-2:
+        # Disagreement. Re-run the mega-kernel on identical input to tell a *bug in
+        # one path* apart from a *non-deterministic kernel* (run-to-run instability
+        # — e.g. an accumulation-order race — shows up as the mega path disagreeing
+        # with itself). The staged path is a deterministic six-launch reference.
+        o_mega2 = run_mega(); torch.npu.synchronize(); o_mega2 = o_mega2.float().clone()
+        mega_self = (o_mega2 - o_mega).norm().item() / o_mega.norm().item()
+        print(f"\n  ⚠ CORRECTNESS GATE FAILED  (H={H} Hg={HG})")
+        print(f"    staged vs mega        : frob_rel={frob_rel:.3e}  (≥ 1e-2)")
+        print(f"    mega vs mega (re-run) : frob_rel={mega_self:.3e}  "
+              f"({'NON-DETERMINISTIC mega-kernel' if mega_self >= 1e-2 else 'mega stable → staged path suspect'})")
+        print(f"    → skipping timing for H={H} (would compare against an unreliable reference)")
+        del o_mega, o_staged, o_mega2
+        gc.collect(); torch.npu.empty_cache()
+        return None, None, frob_rel
+
+    del o_mega, o_staged
+    gc.collect(); torch.npu.empty_cache()
+
     ms_staged = _bench_npu(run_staged)
 
     print(f"\n  mega_kernel vs staged PTO  (H={H} Hg={HG})")
     print(f"    Mega:   {ms_mega:.3f} ms")
     print(f"    Staged: {ms_staged:.3f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}")
     print(f"  mega vs staged PTO relative Frobenius error: {frob_rel:.3e}")
-    print(f"  staged output norm: {o_scaled_staged.float().norm():.3e}")
     return ms_mega, ms_staged, frob_rel
 
 

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -501,48 +501,47 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     ms_mega = _bench_npu(run_mega)
 
     # Staged PTO aggregated (all 6 stages)
-    from megagdn_pto.kernel_libs import run_scaled_dot_kkt, run_wy_fast, run_chunk_h, run_chunk_o
+    from megagdn_pto.kernel_libs import run_chunk_cumsum, run_scaled_dot_kkt, run_wy_fast, run_chunk_h, run_chunk_o
     N_seq = int(cu_seqlens.numel()) - 1
     tc_n = total_chunks(N_seq, T, C_PTO, cu_seqlens)
-    cu_cpu = cu_seqlens.cpu().tolist()
 
-    def ref_cumsum_torch():
-        out = torch.zeros(1, T, H, device=dev, dtype=torch.float32)
-        for i in range(len(cu_cpu) - 1):
-            bos, eos = cu_cpu[i], cu_cpu[i + 1]
-            for j in range(0, eos - bos, C_PTO):
-                s, e = bos + j, min(bos + j + C_PTO, eos)
-                out[:, s:e, :] = g_in.float()[:, s:e, :].cumsum(dim=1)
-        return out
+    # Staged path is linear in q; pre-scale once so o matches the mega-kernel
+    # (which applies `scale` internally) without a per-iteration elementwise op.
+    #q_scaled = (q * scale).to(torch.float16)
+
+    # Pre-allocate every intermediate + workspace once (timed loop = pure launches).
+    g_sum = torch.empty(1, T, H, device=dev, dtype=torch.float32)
+    msk_l = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=-1).float()
+    msk_f = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
+    A = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float16)
+    A_inv = torch.empty(1, T, H, C_PTO, device=dev, dtype=torch.float16)
+    w = torch.empty_like(v)
+    u = torch.empty_like(v)
+    s = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
+    v_new = torch.empty_like(v)
+    fs = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
+    o = torch.empty_like(v)
 
     def run_staged():
-        g_sum = ref_cumsum_torch()
+        # Stage chaining on the shared stream — no inter-stage host syncs.
+        run_chunk_cumsum(g_in, g_sum, chunk_size=C_PTO,
+                         cu_seqlens=cu_seqlens, batch_size_override=N_seq)
         g_t = transpose_gates(g_sum)
         beta_t = transpose_beta(beta)
         torch.npu.synchronize()
-        msk_l = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=-1).float()
-        msk_f = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
-        A = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float16)
         run_scaled_dot_kkt(k, beta, g_sum, msk_l, A,
                            g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                            cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
         torch.npu.synchronize()
-        A_inv = solve_tril(A, cu_seqlens, C_PTO, H, tri_inv)
         torch.npu.synchronize()
-        w = torch.empty_like(v)
-        u = torch.empty_like(v)
         run_wy_fast(k, v, beta, g_sum, A_inv, w, u,
                     g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
         torch.npu.synchronize()
-        s = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
-        v_new = torch.empty_like(v)
-        fs = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
         run_chunk_h(k, w, u, g_sum, s, v_new, fs,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
         torch.npu.synchronize()
-        o = torch.empty_like(v)
         run_chunk_o(q, k, v_new, s, g_sum, msk_f, o,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
@@ -558,6 +557,7 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     print(f"    Mega:   {ms_mega:.3f} ms")
     print(f"    Staged: {ms_staged:.3f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}")
     print(f"  mega vs staged PTO relative Frobenius error: {frob_rel:.3e}")
+    print(f"  staged output norm: {o_scaled_staged.float().norm():.3e}")
     return ms_mega, ms_staged, frob_rel
 
 

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -77,13 +77,16 @@ import ctypes
 
 C_PTO = 128
 D = 128
+PTO_ONLY = (os.getenv("GDN_BENCH_PTO_ONLY", "0")) == "1"
 
+WARM_UP = int(os.getenv("GDN_BENCH_WARMUP", "5"))
+BENCH_ITERS = int(os.getenv("GDN_BENCH_ITERS", "15"))
 
 # ---------------------------------------------------------------------------
 # Timing helpers
 # ---------------------------------------------------------------------------
 
-def _bench_npu(fn, warmup: int = 5, iters: int = 15) -> float:
+def _bench_npu(fn, warmup: int = WARM_UP, iters: int = BENCH_ITERS) -> float:
     """Time an NPU function using Event pairs (ms)."""
     starts = [torch.npu.Event(enable_timing=True) for _ in range(iters)]
     ends = [torch.npu.Event(enable_timing=True) for _ in range(iters)]
@@ -100,7 +103,7 @@ def _bench_npu(fn, warmup: int = 5, iters: int = 15) -> float:
     return sum(s.elapsed_time(e) for s, e in zip(starts, ends)) / iters
 
 
-def _bench_triton(fn, warmup: int = 5, iters: int = 15) -> float:
+def _bench_triton(fn, warmup: int = WARM_UP, iters: int = BENCH_ITERS) -> float:
     """Time a Triton NPU function (uses event.synchronize() for correctness)."""
     cache = torch.empty(256 * 1024 * 1024, dtype=torch.int8).npu()
     for _ in range(warmup):
@@ -133,9 +136,11 @@ def _ratio(ms_triton: float | None, ms_pto: float) -> str:
 # ---------------------------------------------------------------------------
 
 def _try_triton_cumsum(cu_seqlens, BT, dev, T, H) -> float | None:
+    if PTO_ONLY:
+        print(f"    [Triton cumsum BT={BT}: skipped (PTO_ONLY)]")
+        return None
     try:
         from fla_vendor.cumsum import chunk_local_cumsum
-        from fla_vendor.utils import prepare_chunk_indices
         cu_long = cu_seqlens.long()
         g = torch.randn(1, T, H, device=dev, dtype=torch.float32)
         fn = lambda: chunk_local_cumsum(g=g, chunk_size=BT, cu_seqlens=cu_long)
@@ -148,6 +153,9 @@ def _try_triton_cumsum(cu_seqlens, BT, dev, T, H) -> float | None:
 
 
 def _try_triton_kkt(cu_seqlens, BT, dev, T, H, HG) -> float | None:
+    if PTO_ONLY:
+        print(f"    [Triton kkt BT={BT}: skipped (PTO_ONLY)]")
+        return None
     try:
         from fla_vendor.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
         from fla_vendor.utils import prepare_chunk_indices
@@ -168,6 +176,9 @@ def _try_triton_kkt(cu_seqlens, BT, dev, T, H, HG) -> float | None:
 
 
 def _try_triton_solve_tril(cu_seqlens, BT, dev, T, H) -> float | None:
+    if PTO_ONLY:
+        print(f"    [Triton solve_tril BT={BT}: skipped (PTO_ONLY)]")
+        return None
     if BT > 64:
         print(f"    [Triton solve_tril BT={BT}: not supported by Triton (max BT=64)]")
         return None
@@ -191,6 +202,9 @@ def _try_triton_solve_tril(cu_seqlens, BT, dev, T, H) -> float | None:
 
 
 def _try_triton_chunk_h(cu_seqlens, BT, dev, T, H, HG) -> float | None:
+    if PTO_ONLY:
+        print(f"    [Triton chunk_h BT={BT}: skipped (PTO_ONLY)]")
+        return None
     # H=64 with BT=64 triggers an aicore exception on this NPU, corrupting device state.
     if H >= 64 and BT <= 64:
         print(f"    [Triton chunk_h BT={BT} H={H}: known aicore failure, skip]")
@@ -218,6 +232,9 @@ def _try_triton_chunk_h(cu_seqlens, BT, dev, T, H, HG) -> float | None:
 
 
 def _try_triton_wy_fast(cu_seqlens, BT, dev, T, H, HG) -> float | None:
+    if PTO_ONLY:
+        print(f"    [Triton wy_fast BT={BT}: skipped (PTO_ONLY)]")
+        return None
     try:
         from fla_vendor.wy_fast import recompute_w_u_fwd
         from fla_vendor.utils import prepare_chunk_indices
@@ -239,6 +256,9 @@ def _try_triton_wy_fast(cu_seqlens, BT, dev, T, H, HG) -> float | None:
 
 
 def _try_triton_chunk_o(cu_seqlens, BT, dev, T, H, HG) -> float | None:
+    if PTO_ONLY:
+        print(f"    [Triton chunk_o BT={BT}: skipped (PTO_ONLY)]")
+        return None
     # H=64 with BT=64 is a known aicore failure; skip to protect NPU state.
     if H >= 64 and BT <= 64:
         print(f"    [Triton chunk_o BT={BT} H={H}: known aicore failure, skip]")
@@ -367,7 +387,8 @@ def bench_solve_tril(H, T, cu_seqlens, dev, tri_inv):
     ms_pto = _bench_npu(run_tri_inverse_kernel)
     ms_t64 = _try_triton_solve_tril(cu_seqlens, 64, dev, T, H)
     ms_t128 = None  # BT=128 not supported by Triton (max BT=64)
-    print(f"    [Triton solve_tril BT=128: not supported (max BT=64)]")
+    if not PTO_ONLY:
+        print(f"    [Triton solve_tril BT=128: not supported (max BT=64)]")
     _print_stage("solve_tril", ms_pto, ms_t64, ms_t128)
     return ms_pto, ms_t64, ms_t128
 
@@ -463,39 +484,8 @@ def bench_chunk_o(H, HG, T, tc, cu_seqlens, dev, stream, bd):
     return ms_pto, ms_t64, ms_t128
 
 
-def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
-    """Mega-kernel vs a competently-written staged PTO pipeline.
-
-    This is a *fusion* benchmark: it measures whether collapsing the six GDN
-    stages into one mega-kernel beats running them as six separate PTO kernel
-    launches. For that to be a fair fight, the staged baseline must be written the
-    way a real deployment would write it. Three things matter, and all three were
-    wrong in the original version of this benchmark (making the staged path look
-    artificially slow / the mega-kernel look artificially good):
-
-    1. **Use the real cumsum kernel.** The staged path here runs the PTO
-       ``chunk_cumsum`` kernel (~0.03 ms), not a torch ``cumsum`` reference in a
-       Python double-loop (~21 ms) — the latter dominated the staged time and is
-       not what anyone would ship.
-
-    2. **No redundant inter-stage syncs.** Kernels launched on the same stream are
-       serialized by the stream (stage N+1 observes stage N's writes), so the
-       ``torch.npu.synchronize()`` barriers between stages are *not needed for
-       correctness* — they are a legacy precaution. Dropping them is verified
-       bit-exact below and the no-sync path is what we time.
-
-    3. **Pre-allocate, don't malloc in the timed loop.** All intermediates and
-       workspaces are allocated once; the timed region is pure kernel launches.
-
-    A correctness gate (``frob_rel < 1e-2`` vs the mega-kernel output) runs *before*
-    any timing, so a fast-but-wrong staged pipeline can never be reported as a win.
-    The mega-kernel applies ``scale`` internally; the staged path is linear in ``q``
-    so we fold ``scale`` into ``q`` once (pre-scaled ``q`` ⇒ scaled ``o``), matching
-    the mega output without a per-iteration elementwise pass.
-    """
-    from megagdn_pto.kernel_libs import (
-        run_chunk_cumsum, run_scaled_dot_kkt, run_wy_fast, run_chunk_h, run_chunk_o)
-
+def bench_mega(H, HG, T, cu_seqlens, dev, stream, tri_inv):
+    """Mega-kernel vs staged PTO (aggregated)."""
     q = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
     k = F.normalize(torch.randn(1, T, HG, D, device=dev, dtype=torch.float16), dim=-1, p=2)
     v = torch.randn(1, T, H, D, device=dev, dtype=torch.float16)
@@ -504,85 +494,67 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
     scale = D ** -0.5
 
     def run_mega():
-        return run_mega_kernel(q, k, v, g_in, beta, cu_seqlens,
-                               chunk_size=C_PTO, scale=scale, key_heads=HG)
+        run_mega_kernel(q, k, v, g_in, beta, cu_seqlens, stream=stream,
+                        chunk_size=C_PTO, scale=scale, key_heads=HG)
 
+    run_mega(); torch.npu.synchronize()
+    ms_mega = _bench_npu(run_mega)
+
+    # Staged PTO aggregated (all 6 stages)
+    from megagdn_pto.kernel_libs import run_scaled_dot_kkt, run_wy_fast, run_chunk_h, run_chunk_o
     N_seq = int(cu_seqlens.numel()) - 1
     tc_n = total_chunks(N_seq, T, C_PTO, cu_seqlens)
+    cu_cpu = cu_seqlens.cpu().tolist()
 
-    # Staged path is linear in q; pre-scale once so o matches the mega-kernel
-    # (which applies `scale` internally) without a per-iteration elementwise op.
-    q_scaled = (q * scale).to(torch.float16)
-
-    # Pre-allocate every intermediate + workspace once (timed loop = pure launches).
-    g_sum = torch.empty(1, T, H, device=dev, dtype=torch.float32)
-    msk_l = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=-1).float()
-    msk_f = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
-    A = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float16)
-    ws_tri = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float32)
-    A_inv = torch.empty(1, T, H, C_PTO, device=dev, dtype=torch.float16)
-    w = torch.empty_like(v)
-    u = torch.empty_like(v)
-    s = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
-    v_new = torch.empty_like(v)
-    fs = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
-    o = torch.empty_like(v)
+    def ref_cumsum_torch():
+        out = torch.zeros(1, T, H, device=dev, dtype=torch.float32)
+        for i in range(len(cu_cpu) - 1):
+            bos, eos = cu_cpu[i], cu_cpu[i + 1]
+            for j in range(0, eos - bos, C_PTO):
+                s, e = bos + j, min(bos + j + C_PTO, eos)
+                out[:, s:e, :] = g_in.float()[:, s:e, :].cumsum(dim=1)
+        return out
 
     def run_staged():
-        # Stage chaining on the shared stream — no inter-stage host syncs.
-        run_chunk_cumsum(g_in, g_sum, chunk_size=C_PTO,
-                         cu_seqlens=cu_seqlens, batch_size_override=N_seq)
+        g_sum = ref_cumsum_torch()
         g_t = transpose_gates(g_sum)
         beta_t = transpose_beta(beta)
-        run_scaled_dot_kkt(k, beta, g_sum, msk_l, A,
+        torch.npu.synchronize()
+        msk_l = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=-1).float()
+        msk_f = torch.tril(torch.ones(C_PTO, C_PTO, device=dev), diagonal=0).float()
+        A = torch.zeros(1, T, H, C_PTO, device=dev, dtype=torch.float16)
+        run_scaled_dot_kkt(k, beta, g_sum, msk_l, A, stream=stream,
                            g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                            cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        solve_tril(A, cu_seqlens, C_PTO, H, tri_inv, workspace_fp32=ws_tri, out_fp16=A_inv)
-        run_wy_fast(k, v, beta, g_sum, A_inv, w, u,
+        torch.npu.synchronize()
+        A_inv = solve_tril(A, cu_seqlens, C_PTO, H, tri_inv)
+        torch.npu.synchronize()
+        w = torch.empty_like(v)
+        u = torch.empty_like(v)
+        run_wy_fast(k, v, beta, g_sum, A_inv, w, u, stream=stream,
                     g_t=g_t, beta_t=beta_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        run_chunk_h(k, w, u, g_sum, s, v_new, fs,
+        torch.npu.synchronize()
+        s = torch.zeros(tc_n * H, D, D, device=dev, dtype=torch.float16)
+        v_new = torch.empty_like(v)
+        fs = torch.zeros(N_seq * H, D, D, device=dev, dtype=torch.float16)
+        run_chunk_h(k, w, u, g_sum, s, v_new, fs, stream=stream,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        run_chunk_o(q_scaled, k, v_new, s, g_sum, msk_f, o,
+        torch.npu.synchronize()
+        o = torch.empty_like(v)
+        run_chunk_o(q, k, v_new, s, g_sum, msk_f, o, stream=stream,
                     g_t=g_t, chunk_size=C_PTO,
                     cu_seqlens=cu_seqlens, batch_size_override=N_seq, key_heads=HG)
-        return o
+        torch.npu.synchronize()
 
-    # ── Correctness gate (before any timing) ─────────────────────────────────
-    # Never report a staged-vs-fused speedup without verifying the two paths agree.
-    # A fast-but-wrong pipeline (miswired launch, missing scale, uninitialised
-    # workspace, a non-deterministic kernel) is otherwise invisible to timing.
-    o_mega = run_mega(); torch.npu.synchronize(); o_mega = o_mega.float().clone()
-    o_staged = run_staged(); torch.npu.synchronize(); o_staged = o_staged.float().clone()
-    frob_rel = (o_staged - o_mega).norm().item() / o_mega.norm().item()
-
-    if frob_rel >= 1e-2:
-        # Disagreement. Re-run the mega-kernel on identical input to tell a *bug in
-        # one path* apart from a *non-deterministic kernel* (run-to-run instability
-        # — e.g. an accumulation-order race — shows up as the mega path disagreeing
-        # with itself). The staged path is a deterministic six-launch reference.
-        o_mega2 = run_mega(); torch.npu.synchronize(); o_mega2 = o_mega2.float().clone()
-        mega_self = (o_mega2 - o_mega).norm().item() / o_mega.norm().item()
-        print(f"\n  ⚠ CORRECTNESS GATE FAILED  (H={H} Hg={HG})")
-        print(f"    staged vs mega        : frob_rel={frob_rel:.3e}  (≥ 1e-2)")
-        print(f"    mega vs mega (re-run) : frob_rel={mega_self:.3e}  "
-              f"({'NON-DETERMINISTIC mega-kernel' if mega_self >= 1e-2 else 'mega stable → staged path suspect'})")
-        print(f"    → skipping timing for H={H} (would compare against an unreliable reference)")
-        del o_mega, o_staged, o_mega2
-        gc.collect(); torch.npu.empty_cache()
-        return None, None, frob_rel
-
-    del o_mega, o_staged
-    gc.collect(); torch.npu.empty_cache()
-
-    ms_mega = _bench_npu(run_mega)
+    run_staged()
     ms_staged = _bench_npu(run_staged)
 
-    print(f"\n  mega_kernel vs staged PTO  (H={H} Hg={HG})   [staged frob_rel={frob_rel:.1e}]")
+    print(f"\n  mega_kernel vs staged PTO  (H={H} Hg={HG})")
     print(f"    Mega:   {ms_mega:.2f} ms")
     print(f"    Staged: {ms_staged:.2f} ms  →  mega speedup {_ratio(ms_staged, ms_mega)}")
-    return ms_mega, ms_staged, frob_rel
+    return ms_mega, ms_staged
 
 
 # ---------------------------------------------------------------------------
@@ -590,6 +562,7 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
 # ---------------------------------------------------------------------------
 
 def main() -> None:
+    global PTO_ONLY
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--device", default=os.getenv("GDN_NPU_DEVICE", "npu:0"))
     parser.add_argument("--n-seq", type=int, default=None,
@@ -603,9 +576,17 @@ def main() -> None:
                         default="cumsum,kkt,solve_tril,wy_fast,chunk_h,chunk_o",
                         help="Comma-separated stages to benchmark.")
     parser.add_argument("--mega", action="store_true", help="Also benchmark mega-kernel.")
+    parser.add_argument("--with-triton-baseline", action="store_true",
+                        help="Also try Triton baselines. Off by default for the current A5 environment.")
     parser.add_argument("--output-json", default=None,
                         help="Save results as JSON to this path.")
     args = parser.parse_args()
+    PTO_ONLY = not args.with_triton_baseline
+
+    print("Benchmark arguments:")
+    for name, value in sorted(vars(args).items()):
+        print(f"  {name} = {value}")
+    print(f"  PTO_ONLY = {PTO_ONLY}")
 
     torch.manual_seed(0)
     torch.npu.set_device(args.device)
@@ -624,8 +605,7 @@ def main() -> None:
     heads_list = [int(x) for x in args.H_list.split(",") if x.strip()]
     HG = args.hg
 
-    tri_inv_needed = args.mega or "solve_tril" in {s.strip() for s in args.stage.split(",")}
-    tri_inv = load_tri_inverse() if tri_inv_needed else None
+    tri_inv = load_tri_inverse()
 
     print(f"Workload: N_seq={N_seq}  L_seg={L_seg}  T={T}  D={D}  C_PTO={C_PTO}  BLOCK_DIM={bd}")
     print(f"Stages: {stages}  H_list={heads_list}  Hg={HG}")
@@ -642,6 +622,7 @@ def main() -> None:
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "device": args.device,
             "N_seq": N_seq, "L_seg": L_seg, "D": D, "C_pto": C_PTO,
+            "pto_only": PTO_ONLY,
             "results": all_results,
         }
         out_path.write_text(json.dumps(meta, indent=2))

--- a/benchmarks/kernel/bench_gdn_kernels.py
+++ b/benchmarks/kernel/bench_gdn_kernels.py
@@ -550,7 +550,7 @@ def bench_mega(H, HG, T, cu_seqlens, dev, tri_inv):
         return o * scale
 
     o_scaled_staged = run_staged()
-    frob_rel = torch.linalg.norm(o_scaled_mega.float() - o_scaled_staged.float()) / torch.linalg.norm(o_scaled_staged.float())
+    frob_rel = torch.linalg.norm(o_scaled_mega - o_scaled_staged) / torch.linalg.norm(o_scaled_staged)
     ms_staged = _bench_npu(run_staged)
 
     print(f"\n  mega_kernel vs staged PTO  (H={H} Hg={HG})")


### PR DESCRIPTION
This MR adds a comparison between A2A3 and A5 for all GDN stages.

<img width="3000" height="1800" alt="gdn_stage_latency_all" src="https://github.com/user-attachments/assets/dc1197dc-308a-4b19-b424-79709d771c6e" />


#### Git commit
```
commit e398bab1f709a124a03c58677af0b8ceef5aae32 (HEAD -> 65-benchmark-comparison-between-a5-and-a2a3, origin/65-benchmark-comparison-between-a5-and-a2a3)
Author: Anastasios Zouzias <anastasios.zouzias@huawei.com>
Date:   Thu Aug 20 17:31:19 2026 +0000

    fix(bench): refactor bench_gdn_kernels for A5
```

#### Benchmark script (A5)

```bash
task-submit --device 1 --run "PTO_MEMORY_MODEL=REGISTER_BASE python benchmarks/kernel/bench_gdn_kernels.py 2>&1 | tee bench_gdn_kernels.log "

```

for A2, do `python benchmarks/kernel/bench_gdn_kernels.py 2>&1 | tee bench_gdn_kernels.log`.


### Raw data csv 

##### A5 CSV
```csv
gdn_stage,H,Hg,time_elapsed_ms,device
chunk_cumsum,16,16,0.11,a5
scaled_dot_kkt,16,16,2.48,a5
solve_tril,16,16,7.35,a5
wy_fast,16,16,2.90,a5
chunk_h,16,16,6.13,a5
chunk_o,16,16,5.91,a5
chunk_cumsum,32,16,0.11,a5
scaled_dot_kkt,32,16,4.67,a5
solve_tril,32,16,22.04,a5
wy_fast,32,16,6.79,a5
chunk_h,32,16,11.77,a5
chunk_o,32,16,12.47,a5
chunk_cumsum,48,16,0.33,a5
scaled_dot_kkt,48,16,7.10,a5
solve_tril,48,16,33.08,a5
wy_fast,48,16,11.11,a5
chunk_h,48,16,18.27,a5
chunk_o,48,16,18.98,a5
chunk_cumsum,64,16,0.24,a5
scaled_dot_kkt,64,16,9.23,a5
solve_tril,64,16,35.30,a5
wy_fast,64,16,15.36,a5
chunk_h,64,16,24.72,a5
chunk_o,64,16,25.46,a5
```

##### A2 CSV

```csv
gdn_stage,H,Hg,time_elapsed_ms,device
chunk_cumsum,16,16,0.311,a2
scaled_dot_kkt,16,16,4.387,a2
solve_tril,16,16,15.907,a2
wy_fast,16,16,6.503,a2
chunk_h,16,16,8.217,a2
chunk_o,16,16,9.031,a2
chunk_cumsum,32,16,0.428,a2
scaled_dot_kkt,32,16,9.387,a2
solve_tril,32,16,31.821,a2
wy_fast,32,16,12.911,a2
chunk_h,32,16,20.476,a2
chunk_o,32,16,21.088,a2
chunk_cumsum,48,16,0.553,a2
scaled_dot_kkt,48,16,13.472,a2
solve_tril,48,16,47.861,a2
wy_fast,48,16,20.693,a2
chunk_h,48,16,26.994,a2
chunk_o,48,16,33.645,a2
chunk_cumsum,64,16,0.393,a2
scaled_dot_kkt,64,16,18.205,a2
solve_tril,64,16,63.919,a2
wy_fast,64,16,26.274,a2
chunk_h,64,16,41.173,a2
chunk_o,64,16,45.349,a2
```

#### Raw Logs (A5)

```
cat bench_gdn_kernels.log 
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/_path_manager.py:66: UserWarning: Permission mismatch: The owner of /home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/lib/libop_plugin_atb.so does not match.
  warnings.warn(f"Permission mismatch: The owner of {path} does not match.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/pto-kernels/venv/lib64/python3.11/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /home/zouzias/cann-9.1.0-beta.3/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/benchmarks/kernel/bench_gdn_kernels.py:307: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at ../torch_npu/csrc/aten/common/TensorFactories.cpp:340.)
  g_sum = torch.empty_like(g)
Benchmark arguments:
  H_list = 16,32,48,64
  device = npu:0
  hg = 16
  l_seg = None
  mega = False
  n_seq = None
  output_json = None
  stage = cumsum,kkt,solve_tril,wy_fast,chunk_h,chunk_o
  with_triton_baseline = False
  PTO_ONLY = True
Workload: N_seq=16  L_seg=16384  T=262144  D=128  C_PTO=128  BLOCK_DIM=36
Stages: {'chunk_o', 'solve_tril', 'wy_fast', 'chunk_h', 'kkt', 'cumsum'}  H_list=[16, 32, 48, 64]  Hg=16

====================================================================
H=16  Hg=16
====================================================================
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.00 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 2.31 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 9.55 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 2.91 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 6.13 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 5.92 ms
    Triton BT=64 : fail
    Triton BT=128: n/a

====================================================================
H=32  Hg=16
====================================================================
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.31 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 4.67 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 22.05 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 6.79 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 11.98 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 12.47 ms
    Triton BT=64 : fail
    Triton BT=128: n/a

====================================================================
H=48  Hg=16
====================================================================
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.33 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 7.01 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 33.08 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 11.06 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 18.19 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 19.01 ms
    Triton BT=64 : fail
    Triton BT=128: n/a

====================================================================
H=64  Hg=16
====================================================================
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.28 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 9.79 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 44.12 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 15.29 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 24.68 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 25.48 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
```

#### Raw Logs (A2)

```
python benchmarks/kernel/bench_gdn_kernels.py 
/home/zouzias/github-repos/megagdn-pto/venv/lib/python3.12/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /usr/local/Ascend/cann-9.1.0 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/venv/lib/python3.12/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /usr/local/Ascend/cann-9.1.0/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/venv/lib/python3.12/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /usr/local/Ascend/cann-9.1.0 owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
/home/zouzias/github-repos/megagdn-pto/venv/lib/python3.12/site-packages/torch_npu/utils/collect_env.py:58: UserWarning: Warning: The /usr/local/Ascend/cann-9.1.0/aarch64-linux/ascend_ops_install.info owner does not match the current owner.
  warnings.warn(f"Warning: The {path} owner does not match the current owner.")
Benchmark arguments:
  H_list = 16,32,48,64
  device = npu:0
  hg = 16
  l_seg = None
  mega = False
  n_seq = None
  output_json = None
  stage = cumsum,kkt,solve_tril,wy_fast,chunk_h,chunk_o
  with_triton_baseline = False
  PTO_ONLY = True
Workload: N_seq=16  L_seg=16384  T=262144  D=128  C_PTO=128  BLOCK_DIM=24
Stages: {'kkt', 'cumsum', 'chunk_o', 'solve_tril', 'chunk_h', 'wy_fast'}  H_list=[16, 32, 48, 64]  Hg=16

====================================================================
H=16  Hg=16
====================================================================
/home/zouzias/github-repos/megagdn-pto/benchmarks/kernel/bench_gdn_kernels.py:307: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at ../torch_npu/csrc/aten/common/TensorFactories.cpp:340.)
  g_sum = torch.empty_like(g)
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.311 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 4.387 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 15.907 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 6.503 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 8.217 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 9.031 ms
    Triton BT=64 : fail
    Triton BT=128: n/a

====================================================================
H=32  Hg=16
====================================================================
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.428 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 9.387 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 31.821 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 12.911 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 20.476 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 21.088 ms
    Triton BT=64 : fail
    Triton BT=128: n/a

====================================================================
H=48  Hg=16
====================================================================
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.553 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 13.472 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 47.861 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 20.693 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 26.994 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 33.645 ms
    Triton BT=64 : fail
    Triton BT=128: n/a

====================================================================
H=64  Hg=16
====================================================================
    [Triton cumsum BT=64: skipped (PTO_ONLY)]
    [Triton cumsum BT=128: skipped (PTO_ONLY)]

  chunk_cumsum  (PTO C=128)
    PTO        : 0.393 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton kkt BT=64: skipped (PTO_ONLY)]
    [Triton kkt BT=128: skipped (PTO_ONLY)]

  scaled_dot_kkt  (PTO C=128)
    PTO        : 18.205 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton solve_tril BT=64: skipped (PTO_ONLY)]

  solve_tril  (PTO C=128)
    PTO        : 63.919 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton wy_fast BT=64: skipped (PTO_ONLY)]
    [Triton wy_fast BT=128: skipped (PTO_ONLY)]

  wy_fast  (PTO C=128)
    PTO        : 26.274 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_h BT=64: skipped (PTO_ONLY)]
    [Triton chunk_h BT=128: skipped (PTO_ONLY)]

  chunk_h  (PTO C=128)
    PTO        : 41.173 ms
    Triton BT=64 : fail
    Triton BT=128: n/a
    [Triton chunk_o BT=64: skipped (PTO_ONLY)]
    [Triton chunk_o BT=128: skipped (PTO_ONLY)]

  chunk_o  (PTO C=128)
    PTO        : 45.349 ms
    Triton BT=64 : fail
    Triton BT=128: n/a

```
