### PR TITLE
fix(ci): add sglang E2E accuracy eval

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,57 @@ bench_gdn_kernels_mega_kernel:
   allow_failure: true
 
 
+bench_sglang_mmlu_qwen35_0_8b:
+  image: quay.io/ascend/vllm-ascend:v0.23.0rc1
+  stage: bench
+  tags:
+    - docker_npu_910B2 # Build and test on-device (aarch64 / 910B2)
+  variables:
+    GDN_USE_MEGA_GDN: "1" # Set to 0 to run the triton kernels instead
+    SGLANG_PORT: "30000"
+    SGLANG_MODEL: Qwen/Qwen3.5-0.8B
+    SGLANG_BENCH_VERSION: v0.5.18
+  before_script:
+    - source /usr/local/Ascend/ascend-toolkit/set_env.sh
+    - curl -fsSL -o bench_sglang.py
+      "https://raw.githubusercontent.com/sgl-project/sglang/refs/tags/${SGLANG_BENCH_VERSION}/benchmark/mmlu/bench_sglang.py"
+  script:
+    # Launch the server in the background and keep its logs as an artifact
+    - mkdir -p outputs/logs/
+    - python -m sglang.launch_server --model-path "$SGLANG_MODEL" --port "$SGLANG_PORT"
+      > outputs/logs/sglang_server.log 2>&1 &
+    - echo $! > sglang_server.pid
+    # Wait for the server to be up (fail fast if it dies or never becomes healthy)
+    - |
+      for i in $(seq 1 120); do
+        if ! kill -0 "$(cat sglang_server.pid)" 2>/dev/null; then
+          echo "sglang server exited before becoming healthy"
+          tail -n 100 outputs/logs/sglang_server.log
+          exit 1
+        fi
+        if curl -fsS "http://127.0.0.1:${SGLANG_PORT}/health_generate" >/dev/null 2>&1; then
+          echo "sglang server is up after ${i} attempt(s)"
+          break
+        fi
+        if [ "$i" -eq 120 ]; then
+          echo "timed out waiting for the sglang server on port ${SGLANG_PORT}"
+          tail -n 100 outputs/logs/sglang_server.log
+          exit 1
+        fi
+        sleep 5
+      done
+    # Test megaGDN-pto kernel
+    - python3 bench_sglang.py --nsub 10
+  after_script:
+    - if [ -f sglang_server.pid ]; then kill "$(cat sglang_server.pid)" 2>/dev/null || true; fi
+  when: manual
+  allow_failure: true
+  artifacts:
+    when: always
+    expire_in: 1 day
+    paths:
+      - outputs/logs/
+
 bench_lm_eval_qwen35_0_8b:
   image: quay.io/ascend/vllm-ascend:v0.23.0rc1
   stage: bench

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ bench_gdn_kernels_mega_kernel:
 
 
 bench_sglang_mmlu_qwen35_0_8b:
-  image: quay.io/ascend/vllm-ascend:v0.23.0rc1
+  image: quay.io/ascend/sglang:v0.5.18-cann9.0.0-910b
   stage: bench
   tags:
     - docker_npu_910B2 # Build and test on-device (aarch64 / 910B2)

--- a/docker/start_sglang_ascend.sh
+++ b/docker/start_sglang_ascend.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Start an interactive sglang-ascend container on all 8 NPUs of the host.
+#
+# The container is disposable (--rm) but the model weights are not: the host
+# directory /scratch/model_weights is mounted read-only at the same path inside
+# the container, so weights are never re-downloaded between runs.
+#
+# Mounts the host Ascend driver, firmware and queue-schedule paths so the
+# in-container CANN stack talks to the host NPUs. The container is named
+# sglang-ascend-$USER to avoid collisions between users on a shared host.
+#
+# Usage (run from the repo root):
+#   bash docker/start_sglang_ascend.sh [EXTRA_DOCKER_ARGS...]
+#   bash docker/start_sglang_ascend.sh -v "$PWD:/sources" -w /sources
+#
+# Extra arguments are passed to `docker run` (not to the shell in the
+# container), which lands you at a bash prompt inside the image.
+#
+# To use a different image, edit DOCKER_IMAGE_TAG below.
+
+DOCKER_IMAGE_TAG="quay.io/ascend/sglang:v0.5.18-cann9.0.0-910b"
+
+drun() {
+
+docker run -it --rm --privileged --network=host --ipc=host --shm-size=16g \
+    --device=/dev/davinci0 --device=/dev/davinci1 --device=/dev/davinci2 --device=/dev/davinci3 \
+    --device=/dev/davinci4 --device=/dev/davinci5 --device=/dev/davinci6 --device=/dev/davinci7 \
+    --device=/dev/davinci_manager --device=/dev/hisi_hdc \
+    --volume /usr/local/sbin:/usr/local/sbin --volume /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    --volume /usr/local/Ascend/firmware:/usr/local/Ascend/firmware \
+    --volume /etc/ascend_install.info:/etc/ascend_install.info \
+    --volume "/scratch/model_weights/:/scratch/model_weights/:ro" \
+    --name "sglang-ascend-${USER}" \
+    --volume /var/queue_schedule:/var/queue_schedule "$@"
+}
+
+drun "$@" ${DOCKER_IMAGE_TAG} /usr/bin/bash
+


### PR DESCRIPTION
This pull request introduces a new benchmarking job for the SGLang Qwen3.5-0.8B model on Ascend hardware and adds a utility script for launching an interactive SGLang container with appropriate NPU and model weight mounts. These changes improve our benchmarking coverage and developer experience when working with SGLang on Ascend NPUs.

**CI/CD Pipeline Enhancements:**

* Added a new manual benchmark job `bench_sglang_mmlu_qwen35_0_8b` to `.gitlab-ci.yml` for running the SGLang MMLU benchmark on the Qwen3.5-0.8B model using the Ascend 910B2 hardware and the `sglang` container image. This job handles server startup, health checks, and logs artifact collection.

**Developer Tooling:**

* Introduced `docker/start_sglang_ascend.sh`, a script to launch an interactive SGLang-Ascend container with all 8 NPUs, proper host mounts for drivers/firmware, and a persistent model weights directory, simplifying local development and testing.