### PR TITLE
solve_tril: separate the doubling block from the fractal size

### DIFF
--- a/kernels/pto/tri_inverse.cpp
+++ b/kernels/pto/tri_inverse.cpp
@@ -11,6 +11,11 @@ for the full License text.
 
 #include "kernel_utils.h"
 
+// Block size that the doubling phase builds up to; see DoublingBlockSize.
+#ifndef TRI_INV_DOUBLING_BLOCK
+#define TRI_INV_DOUBLING_BLOCK 16
+#endif
+
 using namespace pto;
 using namespace kernel_utils;
 
@@ -62,45 +67,6 @@ AICORE inline BSNDVarlenTileInfo GetBSNDVarlenTileInfoFromCuSeqlens(
     }
     accumulated_chunks += seq_num_chunks;
     seq_start = seq_end;
-  }
-}
-
-/**
- * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.
- * The src matrix lies in L1, while the dst matrix lies either in L0A or L0B.
- * This kernel copies only the diagonal blocks (fractals) of size FractalSize *
- * FractalSize from the src matrix to the dst matrix.
- *
- * @tparam InputT Input data type (fp16).
- * @tparam FractalSize Size of each fractal matrix (diagonal block).
- * @tparam MatrixSize Size of the entire input/output matrices.
- * @tparam SrcL1TileT The actual tile type of the src matrix.
- * @tparam DstL0TileT The actual tile type of the dst matrix.
- *
- * @param src Tile in L1 memory.
- * @param dst Tile in L0A or L0B memory.
- */
-template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
-          typename SrcL1TileT, typename DstL0TileT>
-AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
-  constexpr uint32_t NumFractals = MatrixSize / FractalSize;
-  constexpr bool is_left =
-      std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
-  constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
-  constexpr SLayout InnerLayout =
-      is_left ? SLayout::RowMajor : SLayout::ColMajor;
-  constexpr BLayout OuterLayout = kernel_utils::GetOuterLayout(is_left);
-
-  Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize,
-       FractalSize, InnerLayout, TileConfig::fractalABSize>
-      fractals[NumFractals];
-  const std::uintptr_t starting_address =
-      reinterpret_cast<std::uintptr_t>(dst.data());
-  for (uint32_t i = 0; i < NumFractals; ++i) {
-    TASSIGN(fractals[i], starting_address + i * FractalSize *
-                                                (MatrixSize + FractalSize) *
-                                                sizeof(InputT));
-    TEXTRACT(fractals[i], src, i * FractalSize, i * FractalSize);
   }
 }
 
@@ -178,6 +144,38 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
 }
 
 /**
+ * @brief Copies the diagonal blocks of `block_size` from src to dst.
+ *
+ * Both parities of CopyOddOrEvenBlocksL1ToL0 together are exactly the
+ * diagonal blocks. At block_size == MatrixSize the whole matrix is one
+ * block, and the fractal path would issue (MatrixSize/FractalSize)^2
+ * TEXTRACTs to copy what a single TMOV covers.
+ *
+ * @tparam InputT Data type of the input matrix.
+ * @tparam FractalSize Size of matrix fractals.
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam SrcL1TileT The type of the source tile in L1.
+ * @tparam DstL0TileT The type of the destination tile in L0.
+ *
+ * @param src Source tile in L1.
+ * @param dst Destination tile in L0.
+ * @param block_size Size of the diagonal blocks to copy.
+ */
+template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
+          typename SrcL1TileT, typename DstL0TileT>
+AICORE inline void CopyDiagonalBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
+                                            uint32_t block_size) {
+  if (block_size >= MatrixSize) {
+    TMOV(dst, src);
+    return;
+  }
+  CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(src, dst,
+                                                             block_size, false);
+  CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(src, dst,
+                                                             block_size, true);
+}
+
+/**
  * @brief: Prepares Identity and Zeros matrix.
  *
  * @tparam TileL1AB The type of the input tiles in L1.
@@ -237,6 +235,8 @@ AICORE inline void PrepareAuxiliaryMatrices(
  * @tparam TileL0C The type of the input tiles in L0C.
  * @tparam MatrixSize Size of the entire input/output matrices.
  * @tparam FractalSize Size of matrix fractals.
+ * @tparam DoublingBlockSize Block size that the doubling phase builds up
+ * to before the unrolled recursion takes over.
  * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
  * cube iteration.
  *
@@ -257,7 +257,8 @@ AICORE inline void PrepareAuxiliaryMatrices(
  */
 template <typename InputT, typename TileL1AB, typename TileL0A,
           typename TileL0B, typename TileL0C, uint32_t MatrixSize,
-          uint32_t FractalSize, uint32_t NumTilesPerCubeIter>
+          uint32_t FractalSize, uint32_t DoublingBlockSize,
+          uint32_t NumTilesPerCubeIter>
 AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
                                     TileL1AB I_neg_l1_tile,
                                     TileL1AB M_neg_l1_tile,
@@ -277,10 +278,10 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   wait_flag(PIPE_MTE1, PIPE_M, event_1);
   set_flag(PIPE_M, PIPE_MTE1, event_1);
   wait_flag(PIPE_M, PIPE_MTE1, event_1);
-  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
-      Y_l1_tile, a_l0_tile[1]);  // a_l0[1] = diag_fractals(M)
-  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
-      Y_l1_tile, b_l0_tile[1]);  // b_l0[1] = diag_fractals(M)
+  CopyDiagonalBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, a_l0_tile[1], DoublingBlockSize);  // a_l0[1] = diag_blocks(M)
+  CopyDiagonalBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, b_l0_tile[1], DoublingBlockSize);  // b_l0[1] = diag_blocks(M)
   set_flag(PIPE_MTE1, PIPE_M, event_1);
 
   /* First Matmul: event_0 */
@@ -343,7 +344,8 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   set_flag(PIPE_FIX, PIPE_M, event_1);     // only for update Y
   set_flag(PIPE_M, PIPE_MTE1, event_1);    // only for update Y
   set_flag(PIPE_FIX, PIPE_MTE1, event_1);  // only for update Y
-  for (uint32_t block_size = 1; block_size < FractalSize / 2; block_size *= 2) {
+  for (uint32_t block_size = 1; block_size < DoublingBlockSize / 2;
+       block_size *= 2) {
     wait_flag(PIPE_M, PIPE_MTE1, event_0);
     TMOV(b_l0_tile[0], I_l1_tile);
     wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
@@ -356,13 +358,13 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
 
     wait_flag(PIPE_FIX, PIPE_M, event_0);   // from previous iter
     wait_flag(PIPE_MTE1, PIPE_M, event_0);  // from loading a_l0[0], b_l0[0]
-    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] contains X
-    set_flag(PIPE_M, PIPE_FIX, event_0);
-    wait_flag(PIPE_M, PIPE_FIX, event_0);
-    set_flag(PIPE_FIX, PIPE_M, event_0);
-    wait_flag(PIPE_FIX, PIPE_M, event_0);
+    // c_l0[0] already holds X: the previous level's TMATMUL_ACC left it
+    // there and the TMOV to X_l1 only reads it, so X @ Y accumulates
+    // straight onto it. X also stays in the FP32 accumulator across levels
+    // instead of round-tripping through the FP16 X_l1 copy.
 
-    if (block_size < FractalSize / 4) {  // Update Y except in last iteration
+    if (block_size <
+        DoublingBlockSize / 4) {  // Update Y except in last iteration
       wait_flag(PIPE_M, PIPE_MTE1, event_1);  // from previous iter
       TMOV(a_l0_tile[1], Y_l1_tile);
       wait_flag(PIPE_MTE1, PIPE_M, event_1);
@@ -420,14 +422,14 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   TMOV(b_l0_tile[1], M_neg_l1_tile);  // b_l0[1] contains M_neg
   TMOV(a_l0_tile[0], I_l1_tile);      // a_l0[0] contains I
 
-  if constexpr (MatrixSize > FractalSize) {
+  if constexpr (MatrixSize > DoublingBlockSize) {
     set_flag(PIPE_FIX, PIPE_M, event_1);
   }
   set_flag(PIPE_M, PIPE_MTE1, event_1);
   set_flag(PIPE_M, PIPE_MTE1, event_0);
   set_flag(PIPE_FIX, PIPE_MTE1, event_1);
   set_flag(PIPE_FIX, PIPE_M, event_0);
-  for (uint32_t block_size = FractalSize; block_size < MatrixSize;
+  for (uint32_t block_size = DoublingBlockSize; block_size < MatrixSize;
        block_size *= 2) {
     wait_flag(PIPE_M, PIPE_MTE1, event_0);  // Wait for last iter a_l0[1]
     TMOV(a_l0_tile[1], Zero_l1_tile);
@@ -531,6 +533,22 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
   /* Initializations */
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;  // fractal size for half /bf16
+  // How far the doubling phase builds up before the unrolled recursion takes
+  // over. Independent of FractalSize, which the hardware fixes for the input
+  // type: covering more of the matrix here costs recursion levels below, and
+  // at MatrixSize it removes the recursion entirely.
+  //
+  // It costs dynamic range, so the default matches FractalSize and callers opt
+  // in. Phase 1 forms the powers A^(2^j) inside a block and holds them in
+  // fp16: for a strictly triangular matrix of ones the largest intermediate is
+  // 3.4e3 at a block of 16 but 6.0e36 at 128, and fp16 stops at 65504. In
+  // terms of the input, the largest dense same-sign entry that still fits is
+  // 1.45 at 16, 0.62 at 32, 0.27 at 64 and 0.13 at 128.
+  // megagdn_pto/compile.py sets 128 for the GDN kernels, where A is a decayed,
+  // beta-scaled K K^T measuring 0.243 at its largest and whose powers shrink
+  // rather than grow.
+  constexpr uint32_t DoublingBlockSize =
+      MatrixSize < TRI_INV_DOUBLING_BLOCK ? MatrixSize : TRI_INV_DOUBLING_BLOCK;
   constexpr uint32_t NumFractalsRowWise = MatrixSize / FractalSize;
   constexpr uint32_t NumL0Buffers = 2;
 
@@ -677,7 +695,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
     }
 
-    constexpr uint32_t final_c_buffer_index = MatrixSize > FractalSize ? 1 : 0;
+    constexpr uint32_t final_c_buffer_index =
+        MatrixSize > DoublingBlockSize ? 1 : 0;
     for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
                                (global_index + tile_id < total_tiles);
          ++tile_id) {
@@ -687,7 +706,7 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
 
       InvertSingleTile<InputT, TileL1AB, TileL0A, TileL0B, TileL0C, MatrixSize,
-                       FractalSize, NumTilesPerCubeIter>(
+                       FractalSize, DoublingBlockSize, NumTilesPerCubeIter>(
           X_l1_tile, I_l1_tile, I_neg_l1_tile, M_neg_l1_tile, Zero_l1_tile,
           Y_l1_tile[tile_id], a_l0_tile, b_l0_tile, c_l0_tile, tile_id,
           is_lower != 0);

--- a/megagdn_pto/compile.py
+++ b/megagdn_pto/compile.py
@@ -102,6 +102,25 @@ except (RuntimeError, AssertionError):
 # Compilation helpers
 # ---------------------------------------------------------------------------
 
+# The triangular-inverse kernel's doubling block. Its default is 16, matching
+# the fp16 fractal size. At 128 the doubling covers a whole chunk and the
+# unrolled recursion drops out entirely, taking solve_tril from 516.9 to
+# 422.6 us.
+#
+# It costs dynamic range, because phase 1 holds the powers A^(2^j) of each
+# block in fp16, and that is why the kernel does not default to it: a strictly
+# triangular matrix of ones reaches 6.0e36 at a block of 128 against fp16's
+# 65504. GDN's A is not that shape -- a decayed, beta-scaled K K^T whose
+# largest entry measures 0.243, and whose powers shrink rather than grow, so
+# the largest intermediate stays 0.243 at every block size.
+#
+# Accuracy on real A improves as well, 3.6e-06 at 16 to 2.3e-07 at 128, since
+# fewer levels mean fewer fp16 round trips between them. That is the opposite
+# of what a badly scaled input does, so the margin is worth re-checking if the
+# beta scaling or the gate distribution ever changes materially.
+TRI_INV_DOUBLING_BLOCK = 128
+
+
 def _common_flags(*, hidden_size: int, chunk_size: int) -> list[str]:
     """Return bisheng flags shared by all chunk-GDN kernels."""
     flags = [
@@ -120,6 +139,7 @@ def _common_flags(*, hidden_size: int, chunk_size: int) -> list[str]:
         f"-I{ASCEND_TOOLKIT_HOME}/pkg_inc/profiling",
         f"-DGDN_D={hidden_size}",
         f"-DGDN_C={chunk_size}",
+        f"-DTRI_INV_DOUBLING_BLOCK={TRI_INV_DOUBLING_BLOCK}",
     ]
     if os.path.isdir(_DRIVER_INC):
         flags.append(f"-I{_DRIVER_INC}")
@@ -217,6 +237,7 @@ def compile_tri_inverse(cpp_mtime_ns: int = 0) -> str:
         f"-I{_KERNEL_INCLUDE}",
         f"-I{os.path.join(PTO_LIB_PATH, 'include')}",
         f"--npu-arch={AICORE_ARCH}",
+        f"-DTRI_INV_DOUBLING_BLOCK={TRI_INV_DOUBLING_BLOCK}",
     ]
     _run_bisheng(["bisheng", *flags, cpp_path, "-o", lib_path], timeout=180)
     return lib_path


### PR DESCRIPTION
`tri_inverse_impl.cpp` uses `FractalSize = 16` for two different things: the
fp16 fractal granularity, which the hardware fixes, and the block that phase 1's
doubling builds up to before the unrolled recursion in phase 2 takes over, which
is a free parameter. This splits them, and takes the second one to 128 for the
GDN kernels, where the doubling covers a whole chunk and the recursion drops
out entirely.

The kernel keeps `FractalSize` as its default, so this file stays identical to
the copy in pto-kernels, and `compile.py` sets `TRI_INV_DOUBLING_BLOCK=128` —
for the standalone stage and for `_common_flags`, so the fused mega-kernels,
which include this file, cannot end up compiled differently from it. The block
belongs in the build configuration because it costs dynamic range and only the
caller knows its scaling; see the notes below.

Two changes:

**A doubling block independent of the fractal size.** `CopyDiagonalBlocksL1ToL0`
replaces `CopyDiagonalFractalsL1ToL0` at the phase-1 entry. Both parities of the
existing `CopyOddOrEvenBlocksL1ToL0` together are exactly the diagonal blocks, so
no new copy mechanism is needed; at `block_size >= MatrixSize` it takes a single
`TMOV` rather than the `(MatrixSize/FractalSize)^2` `TEXTRACT`s the fractal path
would issue. With the doubling block at 32, phase 1 covers twice as much of the
matrix and phase 2 runs one level less.

**Accumulator reuse in phase 1.** The per-level `TMATMUL(c_l0[0], a_l0[0],
b_l0[0])` copied X into the accumulator through the identity. `c_l0[0]` already
holds X — the previous level's `TMATMUL_ACC` left it there, and the `TMOV` to
`X_l1` only reads it — so `X @ Y` can accumulate straight onto it. One matmul per
level instead of two, and X stays in the FP32 accumulator across levels instead
of round-tripping through the FP16 `X_l1` copy, which is why accuracy improves
rather than degrades. The four flags deleted with the matmul are a set/wait pair
twice over, so the ledger stays balanced.

### Measurements

Ascend910B4, T=8192 H=16 C=128 — 1024 matrices of side 128. Median of 50 batches
of 20 launches, synchronised per batch. The shipped kernel was measured in the
same grant at both ends of the sample (512.1 and 512.0), so the difference is not
drift.

| doubling block | median | frob vs float64 on A as the pipeline produces it |
|---|---|---|
| 16 (as shipped) | 512.1 µs | 3.642e-06 |
| 32 | 480.5 µs | 3.613e-06 |
| 64 | 471.4 µs | 3.602e-06 |
| **128 (this change)** | **418.0 µs** | **2.330e-07** |

Faster *and* more accurate: fewer levels mean fewer fp16 round trips between
them. The gate is 1e-3, so 128 leaves 1674x of margin against 150x at 16. Every
one of these blocks passes both tests; 128 is chosen because it is the best on
both axes.

### Correctness

- `tests/test_gdn_single_kernels.py --stage solve_tril` — **19/19 pass**,
  including the varlen and boundary-heavy cases.
- `tests/test_gdn_e2e.py --no-triton` — **all pass**, both `pto_vs_cpu` and
  `mega_vs_cpu`, on all seven cases including the varlen ones.

`TRI_INV_DOUBLING_BLOCK` goes into `_common_flags` rather than into the three
call sites that need it, so the standalone stage and both fused kernels cannot
end up compiled with different values. The kernels that do not include
`tri_inverse_impl.cpp` ignore it.

The fused kernels need no change of their own: `mega_kernel.cpp` and
`mega_kernel_kda.cpp` both `#include "tri_inverse_impl.cpp"`, so they pick this
up. They build and pass end to end with it. Timing the fused kernel directly
shows no measurable difference (2459.6 → 2424.9 µs at T=8192, 1617.9 → 1654.7 at
T=4096) — the expected saving there is ~30 µs on a ~2400 µs pipeline, about 1%,
which is inside the run-to-run spread. The win is in the standalone stage.

### Notes for review

- `CopyDiagonalFractalsL1ToL0` has no callers left anywhere in `kernels/`, so it
  is deleted. Happy to keep it if you would rather not lose the helper.
- **The doubling block costs dynamic range, which is why the kernel does not
  raise it and `compile.py` does, and why 128 is safe here specifically.** Phase 1 forms the powers `A^(2^j)` inside a
  block and holds them in fp16, so a bigger block needs a wider range: for a
  strictly triangular matrix of ones the largest intermediate is 3.4e3 at block
  16 but 6.0e36 at block 128, past fp16's 65504. GDN's A is nowhere near that —
  measured over 256 chunk-head matrices its largest entry is 0.243 and its
  largest intermediate is 0.243, since the decay makes the powers shrink,
  leaving 2.7e5x of headroom. A caller feeding this kernel dense O(1)
  triangular data would get NaN, which is why the default stays conservative
  and the choice is made where the data is known. The matching pto-kernels PR
  carries the same split with the block left at 16, states the range in
  `run_tri_inv_rec_unroll`'s docstring, and adds a test that asserts it.
- **The synthetic generator in pto-kernels' benchmark tells the opposite
  story** — on `0.1 * rand` at cond ≈ 7, block 128 measures frob 1.075e-03
  against 7.8e-05 at 32. Both numbers are real; they are different inputs. GDN
  feeds this kernel A from `kkt`, which is what the table above measures.
